### PR TITLE
Hi good people of nodebox,

### DIFF
--- a/src-python/svg/__init__.py
+++ b/src-python/svg/__init__.py
@@ -43,20 +43,14 @@ _cache = cache()
 
 #### SVG PARSER ######################################################################################
 
-def parse(svg, cached=False, groupsonly=False, _copy=True):
+def parse(svg, cached=False, _copy=True):
     
     """ Returns cached copies unless otherwise specified.
     """
     
     if not cached:
         dom = parser.parseString(svg)
-        if groupsonly:
-            groups = []
-            for group in dom.getElementsByTagName('g'):
-                groups.append(parse_node(group,[]))
-            return groups
-        else:
-            paths = parse_node(dom, [])
+        paths = parse_node(dom, [])
     else:
         id = _cache.id(svg)
         if not _cache.has_key(id):
@@ -65,6 +59,17 @@ def parse(svg, cached=False, groupsonly=False, _copy=True):
         paths = _cache.load(id, _copy)
    
     return paths
+    
+def parse_groups(svg):
+    """ Returns top level groups
+    """
+
+    dom = parser.parseString(svg)
+    groups = []
+    for group in dom.getElementsByTagName('g'):
+        groups.append(parse_node(group,[]))
+
+    return groups
 
 def get_attribute(element, attribute, default=0):
     


### PR DESCRIPTION
I'm submitting to you the following changes to the SVG library:

> add ability to return array of groups when parsing compound paths if groupsonly argument is set for parse method
> 
> svg.parse accepts groupsonly argument and returns array of groups with
> containing paths.

have not gotten to making it play with caching, but I look forward to your feedback.
