### PR TITLE
Hi Frederik

### DIFF
--- a/src-python/svg/__init__.py
+++ b/src-python/svg/__init__.py
@@ -64,15 +64,16 @@ def parse_groups(svg):
     """ Returns groups dict
     """
 
-    id_count = 0
+    no_id_count = 0
     groups = {}
     dom = parser.parseString(svg)
 
     for group in dom.getElementsByTagName('g'):
         if group.hasAttribute('id'):
             groups[group.attributes['id'].value] = parse_node(group,[])
-        else
-            groups['group_'+str(id_count)] = parse_node(group,[])
+        else:
+            groups['no_id_'+str(no_id_count)] = parse_node(group,[])
+            no_id_count += 1
 
     return groups
     


### PR DESCRIPTION
After playing more with the ways in which Illustrator will export out to SVG, I find that getting group ids is pretty handy when trying to isolate them for rendering.

The following has been added:
- added `parse_groups_by_id` method that returns dictionary of groups with corresponding id as key

With that in mind, I'm submitting this latest change for review.
