### PR TITLE
Prevent null pointer exception when deleting the first node.

### DIFF
--- a/src/main/java/nodebox/client/NetworkView.java
+++ b/src/main/java/nodebox/client/NetworkView.java
@@ -743,7 +743,11 @@ public class NetworkView extends ZoomableView implements PaneView, Zoom {
     }
 
     public void deleteSelection() {
+        // Delete the nodes from the document
         document.removeNodes(getSelectedNodes());
+
+        // Remove the deleted nodes from the current selection
+        selectedNodes.clear();
     }
 
     private void moveSelectedNodes(int dx, int dy) {

--- a/src/main/java/nodebox/client/NodeBoxDocument.java
+++ b/src/main/java/nodebox/client/NodeBoxDocument.java
@@ -770,6 +770,9 @@ public class NodeBoxDocument extends JFrame implements WindowListener, HandleDel
     }
 
     public Object getValue(String portName) {
+        if (getActiveNode() == null) {
+            return null;
+        }
         Port port = checkValidPort(portName);
         return port.getValue();
     }

--- a/src/main/java/nodebox/handle/FourPointHandle.java
+++ b/src/main/java/nodebox/handle/FourPointHandle.java
@@ -35,6 +35,9 @@ public class FourPointHandle extends AbstractHandle {
 
     public void draw(GraphicsContext ctx) {
         Point cp = (Point) getValue(positionName);
+        if (cp == null) {
+            return;
+        }
         double cx = cp.x;
         double cy = cp.y;
         double width = (Double) getValue(widthName);


### PR DESCRIPTION
Previously when deleting the example rectangle node from a new document, there'd be a null pointer error.

```
[java] java.lang.NullPointerException
[java]  at nodebox.client.NodeBoxDocument.checkValidPort(Unknown Source)
[java]  at nodebox.client.NodeBoxDocument.getValue(Unknown Source)
[java]  at nodebox.handle.AbstractHandle.getValue(Unknown Source)
[java]  at nodebox.handle.FourPointHandle.draw(Unknown Source)
[java]  at nodebox.client.Viewer.paintHandle(Unknown Source)
[java]  at nodebox.client.Viewer.paintComponent(Unknown Source)
[java]  at javax.swing.JComponent.paint(JComponent.java:1045)
[java]  at javax.swing.JComponent.paintChildren(JComponent.java:878)
[java]  at javax.swing.JComponent.paint(JComponent.java:1054)
[java]  at javax.swing.JComponent.paintToOffscreen(JComponent.java:5210)
[java]  at javax.swing.BufferStrategyPaintManager.paint(BufferStrategyPaintManager.java:295)
[java]  at javax.swing.RepaintManager.paint(RepaintManager.java:1249)
[java]  at javax.swing.JComponent._paintImmediately(JComponent.java:5158)
[java]  at javax.swing.JComponent.paintImmediately(JComponent.java:4969)
[java]  at javax.swing.RepaintManager$3.run(RepaintManager.java:808)
[java]  at javax.swing.RepaintManager$3.run(RepaintManager.java:796)
[java]  at java.security.AccessController.doPrivileged(Native Method)
[java]  at java.security.ProtectionDomain$1.doIntersectionPrivilege(ProtectionDomain.java:76)
[java]  at javax.swing.RepaintManager.paintDirtyRegions(RepaintManager.java:796)
[java]  at javax.swing.RepaintManager.paintDirtyRegions(RepaintManager.java:769)
[java]  at javax.swing.RepaintManager.prePaintDirtyRegions(RepaintManager.java:718)
[java]  at javax.swing.RepaintManager.access$1100(RepaintManager.java:62)
[java]  at javax.swing.RepaintManager$ProcessingRunnable.run(RepaintManager.java:1677)
[java]  at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:312)
[java]  at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:733)
[java]  at java.awt.EventQueue.access$200(EventQueue.java:103)
[java]  at java.awt.EventQueue$3.run(EventQueue.java:694)
[java]  at java.awt.EventQueue$3.run(EventQueue.java:692)
[java]  at java.security.AccessController.doPrivileged(Native Method)
[java]  at java.security.ProtectionDomain$1.doIntersectionPrivilege(ProtectionDomain.java:76)
[java]  at java.awt.EventQueue.dispatchEvent(EventQueue.java:703)
[java]  at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:242)
[java]  at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:161)
[java]  at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:150)
[java]  at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:146)
[java]  at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:138)
[java]  at java.awt.EventDispatchThread.run(EventDispatchThread.java:91)
```

I've added some checks to prevent this, in what I think is the best place...
