### PR TITLE
multiple code improvements: squid:S00122, squid:S1118, squid:UnusedPrivateMethod, squid:S2293

### DIFF
--- a/src/main/java/nodebox/NodeBox.java
+++ b/src/main/java/nodebox/NodeBox.java
@@ -16,13 +16,10 @@ import java.util.List;
 
 public class NodeBox {
 
-    private static NodeLibrary systemLibrary(String systemLibraryDir, String name) {
-        String fileName = String.format("%s/%s/%s.ndbx", systemLibraryDir, name, name);
-        return NodeLibrary.load(new File(fileName), NodeRepository.of());
-    }
+    private NodeBox() {}
 
     public static NodeRepository getSystemRepository(String systemLibraryDir) {
-        List<NodeLibrary> libraries = new ArrayList<NodeLibrary>();
+        List<NodeLibrary> libraries = new ArrayList<>();
         libraries.add(NodeLibrary.loadSystemLibrary("math"));
         libraries.add(NodeLibrary.loadSystemLibrary("string"));
         libraries.add(NodeLibrary.loadSystemLibrary("color"));

--- a/src/main/java/nodebox/client/devicehandler/AudioInputDeviceHandler.java
+++ b/src/main/java/nodebox/client/devicehandler/AudioInputDeviceHandler.java
@@ -40,7 +40,9 @@ public class AudioInputDeviceHandler implements DeviceHandler {
 
     @Override
     public void start() {
-        if (frame != null) stop();
+        if (frame != null) {
+            stop();
+        }
         frame = new JFrame();
         applet = new MinimInputApplet();
         applet.init();
@@ -49,7 +51,9 @@ public class AudioInputDeviceHandler implements DeviceHandler {
 
     @Override
     public void resume() {
-        if (frame == null) start();
+        if (frame == null) {
+            start();
+        }
     }
 
     @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S00122 Statements should be on separate lines.
squid:S1118 Utility classes should not have public constructors.
squid:UnusedPrivateMethod Unused private method should be removed.
squid:S2293 The diamond operator ("<>") should be used.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS00122
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1118
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AUnusedPrivateMethod
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2293
Please let me know if you have any questions.
George Kankava