### PR TITLE
multiple code improvements: squid:S2325, squid:S1481, squid:S00122

### DIFF
--- a/src/main/java/nodebox/client/visualizer/CanvasVisualizer.java
+++ b/src/main/java/nodebox/client/visualizer/CanvasVisualizer.java
@@ -44,14 +44,14 @@ public class CanvasVisualizer implements Visualizer {
         GrobVisualizer.drawGrobs(g, (Iterable<Grob>) objects);
     }
 
-    private void drawCanvasBounds(Graphics2D g, Canvas canvas) {
+    private static void drawCanvasBounds(Graphics2D g, Canvas canvas) {
         Rectangle2D canvasBounds = canvas.getBounds().getRectangle2D();
         g.setColor(Color.DARK_GRAY);
         g.setStroke(new BasicStroke(1f));
         g.draw(canvasBounds);
     }
 
-    private Canvas getFirstCanvas(Iterable<?> objects) {
+    private static Canvas getFirstCanvas(Iterable<?> objects) {
         Canvas c = (Canvas) Iterables.getFirst(objects, null);
         return c != null ? c : new Canvas();
     }

--- a/src/main/java/nodebox/client/visualizer/ColorVisualizer.java
+++ b/src/main/java/nodebox/client/visualizer/ColorVisualizer.java
@@ -40,7 +40,6 @@ public final class ColorVisualizer implements Visualizer {
 
     @SuppressWarnings("unchecked")
     public void draw(Graphics2D g, Iterable<?> objects) {
-        AffineTransform t = g.getTransform();
         int x = 0;
         int y = 0;
 
@@ -55,7 +54,7 @@ public final class ColorVisualizer implements Visualizer {
         }
     }
 
-    private void drawColor(Graphics2D g, Color c, int x, int y) {
+    private static void drawColor(Graphics2D g, Color c, int x, int y) {
         g.setColor(java.awt.Color.WHITE);
         g.fillRoundRect(x, y, COLOR_SIZE + 6, COLOR_SIZE + 6, 3, 3);
         g.setColor(java.awt.Color.LIGHT_GRAY);

--- a/src/main/java/nodebox/client/visualizer/LastResortVisualizer.java
+++ b/src/main/java/nodebox/client/visualizer/LastResortVisualizer.java
@@ -34,7 +34,9 @@ public final class LastResortVisualizer implements Visualizer {
     }
 
     public void draw(Graphics2D g, Iterable<?> objects) {
-        if (objects == null) return;
+        if (objects == null) {
+            return;
+        }
         g.setColor(Theme.TEXT_NORMAL_COLOR);
         g.setFont(Theme.EDITOR_FONT);
         AffineTransform t = g.getTransform();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S2325 "private" methods that don't access instance data should be "static".
squid:S1481 Unused local variables should be removed.
squid:S00122 Statements should be on separate lines.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2325
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1481
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS00122
Please let me know if you have any questions.
George Kankava