### PR TITLE
Use unix linefeed as a line separator

### DIFF
--- a/src/main/java/nodebox/client/Application.java
+++ b/src/main/java/nodebox/client/Application.java
@@ -78,6 +78,8 @@ public class Application implements Host {
 
         initLastResortHandler();
         initLookAndFeel();
+
+        System.setProperty("line.separator", "\n");
     }
 
     //// Application Load ////


### PR DESCRIPTION
This makes .ndbx files saved in the same way on Linux
and Windows. Fixes issue #426