### PR TITLE
Add Linear-inspired design system and STYLE_GUIDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ Prereqs: Java JDK and Apache Ant are required; Maven is used for dependency reso
 
 The NodeBox GUI follows a Figma-inspired design philosophy:
 
-- **Angular & geometric** — square edges, minimal rounding (6px panels, 4px widgets)
+- **Angular & geometric** — square edges, minimal rounding (4px for all elements)
 - **Typography-driven** — use text size/color for hierarchy, not decoration
 - **Space over lines** — whitespace delineates sections, borders are structural only
 - **Subtle & functional** — no shadows, minimal hover effects, every element has purpose

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,65 +45,42 @@ Prereqs: Java JDK and Apache Ant are required; Maven is used for dependency reso
 
 ## UI Design System (Rust GUI)
 
-The NodeBox GUI uses a design token system inspired by Rerun. All design constants are centralized in `crates/nodebox-gui/src/theme.rs`.
+**IMPORTANT: When working on any GUI component, always consult `STYLE_GUIDE.md` first.**
 
-### Color Tokens
-Always use semantic color tokens from `theme.rs` instead of hardcoded hex values:
+The NodeBox GUI follows a Figma-inspired design philosophy:
 
-**Backgrounds:**
-- `PANEL_BG` - Main panel background (dark)
-- `TOP_BAR_BG` - Title bar background
-- `TAB_BAR_BG` - Tab bar background
-- `HOVER_BG` - Hover state background
-- `SELECTION_BG` - Selection highlight (blue)
+- **Angular & geometric** — square edges, minimal rounding (6px panels, 4px widgets)
+- **Typography-driven** — use text size/color for hierarchy, not decoration
+- **Space over lines** — whitespace delineates sections, borders are structural only
+- **Subtle & functional** — no shadows, minimal hover effects, every element has purpose
+- **High contrast dark theme** — comfortable for extended use
 
-**Text:**
-- `TEXT_STRONG` - Active/primary text (brightest)
-- `TEXT_DEFAULT` - Regular body text
-- `TEXT_SUBDUED` - Secondary/muted text
-- `TEXT_DISABLED` - Disabled text
+### Quick Reference
 
-**Widgets:**
-- `WIDGET_INACTIVE_BG` - Default widget background
-- `WIDGET_HOVERED_BG` - Hovered widget background
-- `WIDGET_ACTIVE_BG` - Active/pressed widget background
-- `BORDER_COLOR` - Standard border color
+All tokens are in `crates/nodebox-gui/src/theme.rs`. Key patterns:
 
-**Accents:**
-- `BLUE_400` / `BLUE_500` - Primary accent (selection, links)
-- `SUCCESS_GREEN`, `WARNING_ORANGE`, `ERROR_RED` - Status colors
+```rust
+use crate::theme::{
+    // Colors
+    PANEL_BG, HOVER_BG, SELECTION_BG,
+    TEXT_STRONG, TEXT_DEFAULT, TEXT_SUBDUED,
+    BLUE_500, BORDER_COLOR,
 
-### Spacing (4px Grid)
-All spacing should be multiples of 4px:
-- `PADDING_SMALL` = 4px
-- `PADDING` = 8px (standard)
-- `PADDING_LARGE` = 12px
-- `VIEW_PADDING` = 12px (panel margins)
-- `ITEM_SPACING` = 8px
-- `INDENT` = 12px (hierarchy indent)
+    // Spacing (8px grid)
+    PADDING, PADDING_SMALL, PADDING_LARGE,
 
-### Typography
-- `FONT_SIZE_BASE` = 12px (body text)
-- `FONT_SIZE_SMALL` = 11px
-- `FONT_SIZE_HEADING` = 16px
+    // Heights
+    ROW_HEIGHT, LIST_ITEM_HEIGHT, PANE_HEADER_HEIGHT,
+};
+```
 
-### Layout Heights
-- `TOP_BAR_HEIGHT` = 28px
-- `TITLE_BAR_HEIGHT` = 24px
-- `LIST_ITEM_HEIGHT` = 24px
-- `ROW_HEIGHT` = 22px
-
-### Corner Radii
-- `CORNER_RADIUS` = 6px (panels, windows)
-- `CORNER_RADIUS_SMALL` = 4px (buttons, widgets)
-
-### Best Practices
-1. **Use tokens, not literals** - Import from `crate::theme` and use named constants
-2. **Follow the 8px grid** - All margins and padding should align to the grid
-3. **Maintain text hierarchy** - Use `TEXT_STRONG` for emphasis, `TEXT_SUBDUED` for secondary info
-4. **Hover feedback** - Add 2px expansion + background color change on hover
-5. **Selection states** - Use `SELECTION_BG` with `BLUE_400` stroke (2px)
-6. **Call `theme::configure_style()`** - This is done in app startup; don't override global styles
+**See `STYLE_GUIDE.md` for complete documentation including:**
+- Full color palette and semantic tokens
+- Typography scale and text hierarchy
+- Spacing system and layout patterns
+- Component patterns (headers, buttons, lists, dialogs)
+- Interaction states and hover effects
+- Do's and Don'ts checklist
 
 ## API Design & Backwards Compatibility
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,13 +47,13 @@ Prereqs: Java JDK and Apache Ant are required; Maven is used for dependency reso
 
 **IMPORTANT: When working on any GUI component, always consult `STYLE_GUIDE.md` first.**
 
-The NodeBox GUI follows a Figma-inspired design philosophy:
+The NodeBox GUI follows a **Linear-inspired design philosophy**:
 
-- **Angular & geometric** — square edges, minimal rounding (4px for all elements)
-- **Typography-driven** — use text size/color for hierarchy, not decoration
-- **Space over lines** — whitespace delineates sections, borders are structural only
-- **Subtle & functional** — no shadows, minimal hover effects, every element has purpose
-- **High contrast dark theme** — comfortable for extended use
+- **Sharp & geometric** — 90° angles, straight lines, zero corner radius by default
+- **No borders** — use background color differentiation between panels
+- **Violet accent** — purple/violet for selections, links, and highlights
+- **Deep dark theme** — rich blacks with subtle cool undertones
+- **Subtle rounding only for selections** — 4px rounding on selected/hovered items
 
 ### Quick Reference
 
@@ -61,25 +61,25 @@ All tokens are in `crates/nodebox-gui/src/theme.rs`. Key patterns:
 
 ```rust
 use crate::theme::{
-    // Colors
-    PANEL_BG, HOVER_BG, SELECTION_BG,
-    TEXT_STRONG, TEXT_DEFAULT, TEXT_SUBDUED,
-    BLUE_500, BORDER_COLOR,
+    // Backgrounds (layered, darkest to lightest)
+    PANEL_BG, TAB_BAR_BG, SURFACE_ELEVATED, HOVER_BG, SELECTION_BG,
 
-    // Spacing (8px grid)
+    // Text (brightest to dimmest)
+    TEXT_STRONG, TEXT_DEFAULT, TEXT_SUBDUED, TEXT_DISABLED,
+
+    // Accents
+    VIOLET_400, VIOLET_500, VIOLET_900,
+
+    // Spacing (4px grid)
     PADDING, PADDING_SMALL, PADDING_LARGE,
-
-    // Heights
-    ROW_HEIGHT, LIST_ITEM_HEIGHT, PANE_HEADER_HEIGHT,
 };
 ```
 
 **See `STYLE_GUIDE.md` for complete documentation including:**
-- Full color palette and semantic tokens
-- Typography scale and text hierarchy
-- Spacing system and layout patterns
-- Component patterns (headers, buttons, lists, dialogs)
-- Interaction states and hover effects
+- Full Linear-inspired color palette
+- Sharp corners philosophy (0px default, 4px for selections)
+- No-border panel differentiation patterns
+- Component patterns with code examples
 - Do's and Don'ts checklist
 
 ## API Design & Backwards Compatibility

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1,0 +1,452 @@
+# NodeBox Design System
+
+This document defines the visual language and design principles for the NodeBox GUI. All UI development should follow these guidelines to ensure a consistent, professional, and usable interface.
+
+**Reference Implementation:** `crates/nodebox-gui/src/theme.rs`
+
+---
+
+## Design Philosophy
+
+NodeBox follows a **Figma-inspired design philosophy** with these core principles:
+
+### 1. Angular & Geometric
+- **Square edges preferred** over excessive rounding
+- Corner radii: `6px` for panels/windows, `4px` for small widgets
+- No decorative curves or ornamental shapes
+- Grid-aligned elements create visual harmony
+
+### 2. Typography-Driven Hierarchy
+- **Text is the primary visual element** — use size, weight, and color to create hierarchy
+- Let typography do the work instead of boxes, badges, or icons
+- Strong contrast between heading, body, and subdued text levels
+- Consistent font sizes across the entire application
+
+### 3. Space Over Lines
+- **Use whitespace to delineate sections** instead of borders and dividers
+- Reserve borders for structural elements (panels, inputs, selections)
+- Consistent 8px-based spacing grid creates visual rhythm
+- Generous padding makes content breathable
+
+### 4. Subtle & Functional
+- **No drop shadows** on panels or UI elements
+- Minimal hover effects (1px expansion, subtle background change)
+- State changes through color, not animation or decoration
+- Every visual element must serve a purpose
+
+### 5. High Contrast Dark Theme
+- **Optimized for extended use** with comfortable contrast ratios
+- White text on dark backgrounds for primary content
+- Subtle gray variations create depth without visual noise
+
+---
+
+## Color System
+
+### Gray Scale (21-stop, Dark Theme)
+
+The gray scale provides smooth transitions for backgrounds, borders, and text.
+
+| Token | RGB | Usage |
+|-------|-----|-------|
+| `GRAY_0` | `(0, 0, 0)` | Pure black (rarely used) |
+| `GRAY_100` | `(13, 16, 17)` | Main panel backgrounds |
+| `GRAY_150` | `(20, 24, 25)` | Bottom bars, recessed areas |
+| `GRAY_200` | `(28, 33, 35)` | Tab bars, input backgrounds |
+| `GRAY_250` | `(38, 43, 46)` | Borders, pane headers |
+| `GRAY_300` | `(49, 56, 59)` | Inactive widget backgrounds |
+| `GRAY_325` | `(55, 63, 66)` | Hover/active states |
+| `GRAY_400` | `(76, 86, 90)` | Disabled text, secondary borders |
+| `GRAY_550` | `(125, 140, 146)` | Subdued/muted text |
+| `GRAY_700` | `(174, 194, 202)` | Header text |
+| `GRAY_775` | `(202, 216, 222)` | Default body text |
+| `GRAY_800` | `(211, 222, 227)` | Bright text variant |
+| `GRAY_1000` | `(255, 255, 255)` | Strong/active text |
+
+### Primary Accent: Blue
+
+Blue is the primary accent color for selections, links, and interactive highlights.
+
+| Token | RGB | Usage |
+|-------|-----|-------|
+| `BLUE_350` | `(24, 73, 187)` | Selection backgrounds |
+| `BLUE_400` | `(51, 102, 255)` | Selection strokes |
+| `BLUE_500` | `(68, 138, 255)` | Links, value text, primary accent |
+
+### Status Colors
+
+Use sparingly for semantic feedback only.
+
+| Token | RGB | Usage |
+|-------|-----|-------|
+| `SUCCESS_GREEN` | `(0, 218, 126)` | Success states, valid input |
+| `WARNING_ORANGE` | `(255, 122, 12)` | Warnings, caution states |
+| `ERROR_RED` | `(171, 1, 22)` | Errors, destructive actions |
+
+### Semantic Color Mapping
+
+**Always use semantic tokens**, never raw gray values:
+
+```rust
+// Background colors
+PANEL_BG          // Main panel background
+TOP_BAR_BG        // Title/top bar
+TAB_BAR_BG        // Tab bar background
+BOTTOM_BAR_BG     // Footer/bottom bar
+TEXT_EDIT_BG      // Input field background
+HOVER_BG          // Hover state background
+SELECTION_BG      // Selection highlight
+
+// Text colors
+TEXT_STRONG       // Primary/active text (white)
+TEXT_DEFAULT      // Body text
+TEXT_SUBDUED      // Secondary/muted text
+TEXT_DISABLED     // Disabled/non-interactive
+
+// Widget colors
+WIDGET_INACTIVE_BG
+WIDGET_HOVERED_BG
+WIDGET_ACTIVE_BG
+WIDGET_NONINTERACTIVE_BG
+BORDER_COLOR
+BORDER_SECONDARY
+```
+
+---
+
+## Typography
+
+### Font Sizes
+
+| Token | Size | Usage |
+|-------|------|-------|
+| `FONT_SIZE_SMALL` | 11px | Labels, captions, metadata |
+| `FONT_SIZE_BASE` | 12px | Body text, buttons, inputs |
+| `FONT_SIZE_HEADING` | 16px | Section headings |
+
+### Text Hierarchy
+
+Use text color to establish hierarchy, not font weight:
+
+1. **Strong** (`TEXT_STRONG` / white) — Active, focused, or primary content
+2. **Default** (`TEXT_DEFAULT`) — Standard body text
+3. **Subdued** (`TEXT_SUBDUED`) — Secondary information, hints
+4. **Disabled** (`TEXT_DISABLED`) — Non-interactive elements
+
+```rust
+// Example: Parameter row
+ui.label(RichText::new("Width").color(TEXT_SUBDUED));      // Label
+ui.label(RichText::new("1920").color(BLUE_500));           // Value (interactive)
+```
+
+### Line Height
+
+Use `LINE_HEIGHT_RATIO = 1.333` for comfortable reading in dense UIs.
+
+---
+
+## Spacing System
+
+All spacing follows an **8px grid** for visual consistency.
+
+### Spacing Tokens
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| `PADDING_SMALL` | 4px | Tight spaces, icon margins |
+| `PADDING` | 8px | Standard padding, item spacing |
+| `PADDING_LARGE` | 12px | Button padding, panel margins |
+| `VIEW_PADDING` | 12px | Outer panel padding |
+| `ITEM_SPACING` | 8px | Space between list items |
+| `INDENT` | 14px | Hierarchical indentation |
+| `ICON_TEXT_PADDING` | 4px | Icon-to-text gap |
+
+### Layout Heights
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| `TOP_BAR_HEIGHT` | 28px | Address bar, toolbar |
+| `TITLE_BAR_HEIGHT` | 24px | Pane headers |
+| `LIST_ITEM_HEIGHT` | 24px | List items, tree nodes |
+| `ROW_HEIGHT` | 22px | Parameter rows, table rows |
+| `TABLE_HEADER_HEIGHT` | 32px | Table headers |
+
+### Spacing Principles
+
+1. **Use consistent spacing** — Same spacing between similar elements
+2. **Increase spacing to separate groups** — Use `PADDING_LARGE` between sections
+3. **Reduce spacing within groups** — Use `PADDING_SMALL` for related items
+4. **Align to the grid** — All dimensions should be multiples of 4px
+
+---
+
+## Component Patterns
+
+### Pane Headers
+
+Consistent styling across all panes:
+
+```rust
+let header_rect = ui.available_rect_before_wrap();
+let header_rect = header_rect.with_max_y(header_rect.min.y + PANE_HEADER_HEIGHT);
+
+// Background
+ui.painter().rect_filled(header_rect, 0.0, PANE_HEADER_BACKGROUND_COLOR);
+
+// Title text
+ui.label(
+    RichText::new("PARAMETERS")
+        .size(FONT_SIZE_SMALL)
+        .color(PANE_HEADER_FOREGROUND_COLOR)
+);
+```
+
+- Height: `24px` (`PANE_HEADER_HEIGHT`)
+- Background: `PANE_HEADER_BACKGROUND_COLOR` (GRAY_250)
+- Text: `PANE_HEADER_FOREGROUND_COLOR` (GRAY_700), 11px uppercase
+- No border on top, optional 1px border on bottom
+
+### Buttons
+
+```rust
+// Standard button
+let response = ui.button(RichText::new("Export").size(FONT_SIZE_BASE));
+
+// Icon button (no text)
+let response = ui.add(egui::Button::new("⚙").frame(false));
+```
+
+- Padding: `12px` horizontal, `8px` vertical
+- Corner radius: `4px`
+- Hover: Background → `WIDGET_HOVERED_BG`, 1px expansion
+- Active: Background → `WIDGET_ACTIVE_BG`
+
+### Input Fields
+
+```rust
+let response = ui.add(
+    egui::TextEdit::singleline(&mut value)
+        .desired_width(100.0)
+        .font(FontId::proportional(FONT_SIZE_BASE))
+);
+```
+
+- Background: `TEXT_EDIT_BG` (GRAY_200)
+- Text: `TEXT_DEFAULT`
+- Focused border: 1px `BLUE_400`
+- Corner radius: `4px`
+
+### Lists & Selections
+
+```rust
+let is_selected = current_item == item_id;
+let is_hovered = response.hovered();
+
+let bg_color = if is_selected {
+    SELECTION_BG
+} else if is_hovered {
+    HOVER_BG
+} else {
+    Color32::TRANSPARENT
+};
+
+ui.painter().rect_filled(item_rect, CORNER_RADIUS_SMALL, bg_color);
+```
+
+- Item height: `24px` (`LIST_ITEM_HEIGHT`)
+- Selected: `SELECTION_BG` with 1px `BLUE_400` stroke
+- Hovered: `HOVER_BG`
+- Corner radius: `4px`
+- Inner padding: `8px`
+
+### Dialogs / Modals
+
+```rust
+egui::Window::new("Add Node")
+    .fixed_size([500.0, 400.0])
+    .frame(egui::Frame::window(&ctx.style())
+        .fill(PANEL_BG)
+        .stroke(Stroke::new(1.0, BORDER_COLOR))
+        .rounding(CORNER_RADIUS))
+```
+
+- Fixed size (no resizing by default)
+- Background: `PANEL_BG`
+- Border: 1px `BORDER_COLOR`
+- Corner radius: `6px`
+- No drop shadow
+
+### Separators
+
+Use sparingly — prefer spacing over lines:
+
+```rust
+// Horizontal separator
+ui.add(egui::Separator::default().horizontal());
+
+// Or draw manually for control
+let line_rect = Rect::from_min_max(
+    pos2(rect.left() + PADDING, y),
+    pos2(rect.right() - PADDING, y + 1.0)
+);
+ui.painter().rect_filled(line_rect, 0.0, BORDER_COLOR);
+```
+
+- Color: `BORDER_COLOR` (GRAY_250)
+- Thickness: 1px
+- Inset from edges by `PADDING`
+
+---
+
+## Interaction States
+
+### State Progression
+
+| State | Background | Text | Border |
+|-------|------------|------|--------|
+| Noninteractive | `GRAY_150` | `TEXT_SUBDUED` | None |
+| Inactive | `GRAY_300` | `TEXT_DEFAULT` | None |
+| Hovered | `GRAY_325` | `TEXT_STRONG` | None |
+| Active/Pressed | `GRAY_325` | `TEXT_STRONG` | None |
+| Selected | `BLUE_350` | `TEXT_STRONG` | 1px `BLUE_400` |
+| Disabled | `GRAY_150` | `TEXT_DISABLED` | None |
+
+### Hover Effects
+
+- Background color change (subtle step up in gray scale)
+- 1px expansion on widgets
+- Cursor change to pointer for clickable elements
+- No shadows, glows, or animations
+
+### Focus States
+
+- Input fields: 1px `BLUE_400` border
+- Buttons: Same as hover state
+- List items: Selected state
+
+---
+
+## Layout Guidelines
+
+### Panel Structure
+
+```
+┌─────────────────────────────────────┐
+│ PANE HEADER (24px)                  │  ← PANE_HEADER_BACKGROUND_COLOR
+├─────────────────────────────────────┤
+│                                     │
+│  Content Area                       │  ← PANEL_BG
+│  (VIEW_PADDING on all sides)        │
+│                                     │
+└─────────────────────────────────────┘
+```
+
+### Parameter Panel Layout
+
+```
+┌─────────────────────────────────────┐
+│ PARAMETERS    separator   Node Name │  ← Header (24px)
+├─────────────────────────────────────┤
+│ Label          │ Value              │  ← Row (22px each)
+│ Label          │ Value              │
+│ Label          │ Value              │
+│ ...                                 │
+└─────────────────────────────────────┘
+```
+
+- Label width: `100px` fixed
+- Value: fills remaining space
+- Row height: `22px`
+- Horizontal spacing: `8px`
+- Vertical spacing: `2px` between rows (dense layout)
+
+### Grid Alignment
+
+The network view uses a 48px grid:
+
+```
+GRID_CELL_SIZE = 48px
+NODE_WIDTH = 132px (3 cells - margins)
+NODE_HEIGHT = 36px (1 cell - margins)
+NODE_MARGIN = 6px
+```
+
+---
+
+## Do's and Don'ts
+
+### Do
+
+- ✓ Use semantic color tokens from `theme.rs`
+- ✓ Follow the 8px spacing grid
+- ✓ Use typography hierarchy for emphasis
+- ✓ Keep borders thin (1px) and subtle
+- ✓ Provide hover feedback on interactive elements
+- ✓ Test with actual content to verify spacing
+
+### Don't
+
+- ✗ Hardcode hex color values
+- ✗ Add drop shadows to panels or dialogs
+- ✗ Use borders when spacing would suffice
+- ✗ Create custom fonts or sizes outside the system
+- ✗ Add decorative elements that don't serve function
+- ✗ Use animation for state changes (keep it snappy)
+
+---
+
+## Implementation Checklist
+
+When creating new UI components:
+
+1. [ ] Import tokens from `crate::theme`
+2. [ ] Use semantic color constants, not raw values
+3. [ ] Align dimensions to 4px/8px grid
+4. [ ] Use standard heights (`ROW_HEIGHT`, `LIST_ITEM_HEIGHT`, etc.)
+5. [ ] Implement hover states with `HOVER_BG`
+6. [ ] Test with both short and long content
+7. [ ] Verify text is readable (proper contrast)
+8. [ ] Check alignment with adjacent components
+
+---
+
+## Quick Reference
+
+```rust
+use crate::theme::{
+    // Backgrounds
+    PANEL_BG, HOVER_BG, SELECTION_BG, TEXT_EDIT_BG,
+
+    // Text
+    TEXT_STRONG, TEXT_DEFAULT, TEXT_SUBDUED, TEXT_DISABLED,
+
+    // Widgets
+    WIDGET_INACTIVE_BG, WIDGET_HOVERED_BG, WIDGET_ACTIVE_BG,
+
+    // Borders
+    BORDER_COLOR, CORNER_RADIUS, CORNER_RADIUS_SMALL,
+
+    // Spacing
+    PADDING, PADDING_SMALL, PADDING_LARGE, ITEM_SPACING,
+
+    // Typography
+    FONT_SIZE_BASE, FONT_SIZE_SMALL, FONT_SIZE_HEADING,
+
+    // Heights
+    ROW_HEIGHT, LIST_ITEM_HEIGHT, PANE_HEADER_HEIGHT,
+
+    // Accents
+    BLUE_400, BLUE_500, SUCCESS_GREEN, WARNING_ORANGE, ERROR_RED,
+};
+```
+
+---
+
+## Evolution
+
+This design system is living documentation. When adding new patterns:
+
+1. First check if existing tokens cover your use case
+2. If new tokens are needed, add them to `theme.rs` with semantic names
+3. Update this document with the new pattern
+4. Ensure consistency with existing components

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -12,7 +12,7 @@ NodeBox follows a **Figma-inspired design philosophy** with these core principle
 
 ### 1. Angular & Geometric
 - **Square edges preferred** over excessive rounding
-- Corner radii: `6px` for panels/windows, `4px` for small widgets
+- Corner radii: `4px` for all elements (panels, windows, widgets)
 - No decorative curves or ornamental shapes
 - Grid-aligned elements create visual harmony
 
@@ -158,7 +158,7 @@ All spacing follows an **8px grid** for visual consistency.
 | `PADDING_LARGE` | 12px | Button padding, panel margins |
 | `VIEW_PADDING` | 12px | Outer panel padding |
 | `ITEM_SPACING` | 8px | Space between list items |
-| `INDENT` | 14px | Hierarchical indentation |
+| `INDENT` | 16px | Hierarchical indentation |
 | `ICON_TEXT_PADDING` | 4px | Icon-to-text gap |
 
 ### Layout Heights
@@ -168,7 +168,7 @@ All spacing follows an **8px grid** for visual consistency.
 | `TOP_BAR_HEIGHT` | 28px | Address bar, toolbar |
 | `TITLE_BAR_HEIGHT` | 24px | Pane headers |
 | `LIST_ITEM_HEIGHT` | 24px | List items, tree nodes |
-| `ROW_HEIGHT` | 22px | Parameter rows, table rows |
+| `ROW_HEIGHT` | 24px | Parameter rows, table rows |
 | `TABLE_HEADER_HEIGHT` | 32px | Table headers |
 
 ### Spacing Principles
@@ -273,7 +273,7 @@ egui::Window::new("Add Node")
 - Fixed size (no resizing by default)
 - Background: `PANEL_BG`
 - Border: 1px `BORDER_COLOR`
-- Corner radius: `6px`
+- Corner radius: `4px`
 - No drop shadow
 
 ### Separators
@@ -347,7 +347,7 @@ ui.painter().rect_filled(line_rect, 0.0, BORDER_COLOR);
 ┌─────────────────────────────────────┐
 │ PARAMETERS    separator   Node Name │  ← Header (24px)
 ├─────────────────────────────────────┤
-│ Label          │ Value              │  ← Row (22px each)
+│ Label          │ Value              │  ← Row (24px each)
 │ Label          │ Value              │
 │ Label          │ Value              │
 │ ...                                 │
@@ -356,9 +356,9 @@ ui.painter().rect_filled(line_rect, 0.0, BORDER_COLOR);
 
 - Label width: `100px` fixed
 - Value: fills remaining space
-- Row height: `22px`
+- Row height: `24px`
 - Horizontal spacing: `8px`
-- Vertical spacing: `2px` between rows (dense layout)
+- Vertical spacing: `0px` between rows (dense layout)
 
 ### Grid Alignment
 
@@ -366,9 +366,11 @@ The network view uses a 48px grid:
 
 ```
 GRID_CELL_SIZE = 48px
-NODE_WIDTH = 132px (3 cells - margins)
-NODE_HEIGHT = 36px (1 cell - margins)
-NODE_MARGIN = 6px
+NODE_MARGIN = 8px
+NODE_WIDTH = 128px (48×3 - 8×2)
+NODE_HEIGHT = 32px (48×1 - 8×2)
+NODE_PADDING = 4px
+NODE_ICON_SIZE = 24px
 ```
 
 ---

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1,6 +1,6 @@
 # NodeBox Design System
 
-This document defines the visual language and design principles for the NodeBox GUI. All UI development should follow these guidelines to ensure a consistent, professional, and usable interface.
+This document defines the visual language and design principles for the NodeBox GUI. All UI development should follow these guidelines to ensure a consistent, professional, and modern interface.
 
 **Reference Implementation:** `crates/nodebox-gui/src/theme.rs`
 
@@ -8,108 +8,112 @@ This document defines the visual language and design principles for the NodeBox 
 
 ## Design Philosophy
 
-NodeBox follows a **Figma-inspired design philosophy** with these core principles:
+NodeBox follows a **Linear-inspired design philosophy** with these core principles:
 
-### 1. Angular & Geometric
-- **Square edges preferred** over excessive rounding
-- Corner radii: `4px` for all elements (panels, windows, widgets)
-- No decorative curves or ornamental shapes
-- Grid-aligned elements create visual harmony
+### 1. Sharp & Geometric
+- **Straight lines and 90° angles** for a clean, precise aesthetic
+- Most UI elements have **zero corner radius** — sharp rectangles
+- Subtle rounding (`4px`) only for specific highlighted elements:
+  - Selected items in lists/dialogs (e.g., node selection dialog)
+  - Focused input fields
+- Creates a professional, tool-like appearance
 
-### 2. Typography-Driven Hierarchy
-- **Text is the primary visual element** — use size, weight, and color to create hierarchy
-- Let typography do the work instead of boxes, badges, or icons
-- Strong contrast between heading, body, and subdued text levels
-- Consistent font sizes across the entire application
+### 2. No Borders, Use Backgrounds
+- **Eliminate borders wherever possible** — they add visual noise
+- Delineate sections through background color differentiation
+- Panels are distinguished by subtle background shade changes
+- Only use borders for:
+  - Window/dialog outer edges (1px, very subtle)
+  - Focus states on inputs
+  - Critical separation needs
 
-### 3. Space Over Lines
-- **Use whitespace to delineate sections** instead of borders and dividers
-- Reserve borders for structural elements (panels, inputs, selections)
-- Consistent 8px-based spacing grid creates visual rhythm
-- Generous padding makes content breathable
+### 3. Deep, Rich Dark Theme
+- **Near-black backgrounds** with subtle cool undertones
+- Multiple gray levels create depth through layering
+- Darker = further back, lighter = elevated/interactive
+- Comfortable for extended use, reduces eye strain
 
-### 4. Subtle & Functional
-- **No drop shadows** on panels or UI elements
-- Minimal hover effects (1px expansion, subtle background change)
-- State changes through color, not animation or decoration
-- Every visual element must serve a purpose
+### 4. Violet Accent
+- **Purple/violet as the primary accent color** — distinctive and modern
+- Used for: selections, links, active states, primary actions
+- Adds personality without overwhelming
+- Status colors: green (success), yellow (warning), red (error)
 
-### 5. High Contrast Dark Theme
-- **Optimized for extended use** with comfortable contrast ratios
-- White text on dark backgrounds for primary content
-- Subtle gray variations create depth without visual noise
+### 5. Generous Spacing
+- **Breathable, airy layouts** — don't crowd elements
+- Consistent 4px grid for all dimensions
+- Larger padding creates a premium feel
+- White space is a feature, not wasted space
 
 ---
 
 ## Color System
 
-### Gray Scale (21-stop, Dark Theme)
+### Gray Scale (Linear-inspired Dark Theme)
 
-The gray scale provides smooth transitions for backgrounds, borders, and text.
+Deep blacks with subtle cool undertones, creating a sophisticated dark interface.
 
-| Token | RGB | Usage |
-|-------|-----|-------|
-| `GRAY_0` | `(0, 0, 0)` | Pure black (rarely used) |
-| `GRAY_100` | `(13, 16, 17)` | Main panel backgrounds |
-| `GRAY_150` | `(20, 24, 25)` | Bottom bars, recessed areas |
-| `GRAY_200` | `(28, 33, 35)` | Tab bars, input backgrounds |
-| `GRAY_250` | `(38, 43, 46)` | Borders, pane headers |
-| `GRAY_300` | `(49, 56, 59)` | Inactive widget backgrounds |
-| `GRAY_325` | `(55, 63, 66)` | Hover/active states |
-| `GRAY_400` | `(76, 86, 90)` | Disabled text, secondary borders |
-| `GRAY_550` | `(125, 140, 146)` | Subdued/muted text |
-| `GRAY_700` | `(174, 194, 202)` | Header text |
-| `GRAY_775` | `(202, 216, 222)` | Default body text |
-| `GRAY_800` | `(211, 222, 227)` | Bright text variant |
-| `GRAY_1000` | `(255, 255, 255)` | Strong/active text |
+| Token | RGB | Hex | Usage |
+|-------|-----|-----|-------|
+| `GRAY_0` | `(0, 0, 0)` | #000000 | Pure black |
+| `GRAY_50` | `(9, 9, 11)` | #09090B | Deepest background |
+| `GRAY_100` | `(17, 17, 19)` | #111113 | Main panel background |
+| `GRAY_150` | `(23, 23, 26)` | #17171A | Secondary panels, sidebar |
+| `GRAY_200` | `(31, 31, 35)` | #1F1F23 | Elevated surfaces, inputs |
+| `GRAY_250` | `(39, 39, 43)` | #27272B | Subtle borders, hover bg |
+| `GRAY_300` | `(49, 49, 54)` | #313136 | Widget backgrounds |
+| `GRAY_350` | `(55, 55, 61)` | #37373D | Active/pressed states |
+| `GRAY_400` | `(75, 75, 82)` | #4B4B52 | Disabled elements |
+| `GRAY_500` | `(107, 107, 115)` | #6B6B73 | Muted text, icons |
+| `GRAY_600` | `(139, 139, 148)` | #8B8B94 | Secondary text |
+| `GRAY_700` | `(171, 171, 181)` | #ABABB5 | Body text |
+| `GRAY_800` | `(219, 219, 224)` | #DBDBE0 | Primary text |
+| `GRAY_900` | `(235, 235, 240)` | #EBEBF0 | Bright/emphasized text |
+| `GRAY_1000` | `(255, 255, 255)` | #FFFFFF | Pure white |
 
-### Primary Accent: Blue
+### Primary Accent: Violet
 
-Blue is the primary accent color for selections, links, and interactive highlights.
+Purple/violet creates a distinctive, modern identity.
 
-| Token | RGB | Usage |
-|-------|-----|-------|
-| `BLUE_350` | `(24, 73, 187)` | Selection backgrounds |
-| `BLUE_400` | `(51, 102, 255)` | Selection strokes |
-| `BLUE_500` | `(68, 138, 255)` | Links, value text, primary accent |
+| Token | RGB | Hex | Usage |
+|-------|-----|-----|-------|
+| `VIOLET_900` | `(45, 38, 64)` | #2D2640 | Selection background (subtle) |
+| `VIOLET_600` | `(124, 58, 237)` | #7C3AED | Pressed/darker accent |
+| `VIOLET_500` | `(139, 92, 246)` | #8B5CF6 | Primary accent |
+| `VIOLET_400` | `(167, 139, 250)` | #A78BFA | Hover/lighter accent |
 
 ### Status Colors
 
 Use sparingly for semantic feedback only.
 
-| Token | RGB | Usage |
-|-------|-----|-------|
-| `SUCCESS_GREEN` | `(0, 218, 126)` | Success states, valid input |
-| `WARNING_ORANGE` | `(255, 122, 12)` | Warnings, caution states |
-| `ERROR_RED` | `(171, 1, 22)` | Errors, destructive actions |
+| Token | RGB | Hex | Usage |
+|-------|-----|-----|-------|
+| `SUCCESS_GREEN` | `(34, 197, 94)` | #22C55E | Success, valid |
+| `WARNING_YELLOW` | `(234, 179, 8)` | #EAB308 | Warning, caution |
+| `ERROR_RED` | `(239, 68, 68)` | #EF4444 | Error, danger |
 
 ### Semantic Color Mapping
 
-**Always use semantic tokens**, never raw gray values:
+**Always use semantic tokens**, never raw values:
 
 ```rust
-// Background colors
-PANEL_BG          // Main panel background
-TOP_BAR_BG        // Title/top bar
-TAB_BAR_BG        // Tab bar background
-BOTTOM_BAR_BG     // Footer/bottom bar
-TEXT_EDIT_BG      // Input field background
-HOVER_BG          // Hover state background
-SELECTION_BG      // Selection highlight
+// Backgrounds (darkest to lightest)
+PANEL_BG           // Main panels (GRAY_100)
+TAB_BAR_BG         // Sidebars, secondary (GRAY_150)
+SURFACE_ELEVATED   // Cards, dialogs, inputs (GRAY_200)
+HOVER_BG           // Hover states (GRAY_250)
+SELECTION_BG       // Selected items (VIOLET_900)
 
-// Text colors
-TEXT_STRONG       // Primary/active text (white)
-TEXT_DEFAULT      // Body text
-TEXT_SUBDUED      // Secondary/muted text
-TEXT_DISABLED     // Disabled/non-interactive
+// Text (brightest to dimmest)
+TEXT_STRONG        // Emphasized, active (GRAY_900)
+TEXT_DEFAULT       // Body text (GRAY_700)
+TEXT_SUBDUED       // Secondary info (GRAY_500)
+TEXT_DISABLED      // Disabled (GRAY_400)
 
-// Widget colors
-WIDGET_INACTIVE_BG
-WIDGET_HOVERED_BG
-WIDGET_ACTIVE_BG
-WIDGET_NONINTERACTIVE_BG
-BORDER_COLOR
-BORDER_SECONDARY
+// Widgets
+WIDGET_INACTIVE_BG   // Button default (GRAY_250)
+WIDGET_HOVERED_BG    // Button hover (GRAY_300)
+WIDGET_ACTIVE_BG     // Button pressed (GRAY_350)
 ```
 
 ---
@@ -120,46 +124,42 @@ BORDER_SECONDARY
 
 | Token | Size | Usage |
 |-------|------|-------|
-| `FONT_SIZE_SMALL` | 11px | Labels, captions, metadata |
-| `FONT_SIZE_BASE` | 12px | Body text, buttons, inputs |
+| `FONT_SIZE_SMALL` | 11px | Labels, captions |
+| `FONT_SIZE_BASE` | 13px | Body text, buttons |
 | `FONT_SIZE_HEADING` | 16px | Section headings |
 
 ### Text Hierarchy
 
-Use text color to establish hierarchy, not font weight:
+Use text color (not weight) to establish hierarchy:
 
-1. **Strong** (`TEXT_STRONG` / white) — Active, focused, or primary content
-2. **Default** (`TEXT_DEFAULT`) — Standard body text
-3. **Subdued** (`TEXT_SUBDUED`) — Secondary information, hints
-4. **Disabled** (`TEXT_DISABLED`) — Non-interactive elements
+1. **Strong** (`TEXT_STRONG` / GRAY_900) — Active, focused, primary
+2. **Default** (`TEXT_DEFAULT` / GRAY_700) — Standard body text
+3. **Subdued** (`TEXT_SUBDUED` / GRAY_500) — Secondary, hints
+4. **Disabled** (`TEXT_DISABLED` / GRAY_400) — Non-interactive
 
 ```rust
-// Example: Parameter row
-ui.label(RichText::new("Width").color(TEXT_SUBDUED));      // Label
-ui.label(RichText::new("1920").color(BLUE_500));           // Value (interactive)
+// Example: List item
+ui.label(RichText::new("Primary text").color(TEXT_DEFAULT));
+ui.label(RichText::new("Secondary").color(TEXT_SUBDUED));
 ```
-
-### Line Height
-
-Use `LINE_HEIGHT_RATIO = 1.333` for comfortable reading in dense UIs.
 
 ---
 
 ## Spacing System
 
-All spacing follows an **8px grid** for visual consistency.
+All spacing follows a **4px grid** for visual consistency.
 
 ### Spacing Tokens
 
 | Token | Value | Usage |
 |-------|-------|-------|
-| `PADDING_SMALL` | 4px | Tight spaces, icon margins |
-| `PADDING` | 8px | Standard padding, item spacing |
-| `PADDING_LARGE` | 12px | Button padding, panel margins |
-| `VIEW_PADDING` | 12px | Outer panel padding |
-| `ITEM_SPACING` | 8px | Space between list items |
-| `INDENT` | 16px | Hierarchical indentation |
-| `ICON_TEXT_PADDING` | 4px | Icon-to-text gap |
+| `PADDING_SMALL` | 4px | Tight spaces, icon gaps |
+| `PADDING` | 8px | Standard padding |
+| `PADDING_LARGE` | 12px | Button padding, sections |
+| `PADDING_XL` | 16px | Large section gaps |
+| `VIEW_PADDING` | 12px | Panel content margins |
+| `ITEM_SPACING` | 8px | Between list items |
+| `INDENT` | 16px | Tree/hierarchy indent |
 
 ### Layout Heights
 
@@ -167,33 +167,56 @@ All spacing follows an **8px grid** for visual consistency.
 |-------|-------|-------|
 | `TOP_BAR_HEIGHT` | 28px | Address bar, toolbar |
 | `TITLE_BAR_HEIGHT` | 24px | Pane headers |
-| `LIST_ITEM_HEIGHT` | 24px | List items, tree nodes |
-| `ROW_HEIGHT` | 24px | Parameter rows, table rows |
+| `LIST_ITEM_HEIGHT` | 28px | List items (taller for touch) |
+| `ROW_HEIGHT` | 24px | Parameter rows |
 | `TABLE_HEADER_HEIGHT` | 32px | Table headers |
 
-### Spacing Principles
+---
 
-1. **Use consistent spacing** — Same spacing between similar elements
-2. **Increase spacing to separate groups** — Use `PADDING_LARGE` between sections
-3. **Reduce spacing within groups** — Use `PADDING_SMALL` for related items
-4. **Align to the grid** — All dimensions should be multiples of 4px
+## Corner Radii
+
+Sharp corners by default, with subtle rounding for interactive highlights.
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| `CORNER_RADIUS` | 0px | Panels, windows, dialogs — sharp edges |
+| `CORNER_RADIUS_SMALL` | 4px | Selected items, focused inputs only |
+
+**When to use `CORNER_RADIUS_SMALL` (4px):**
+- Selection highlight in node selection dialog
+- Hovered/selected list items
+- Focused text input fields
+
+**Everything else: sharp corners (0px)**
 
 ---
 
 ## Component Patterns
 
-### Pane Headers
+### Panels (No Borders)
 
-Consistent styling across all panes:
+Panels are distinguished by background color, not borders:
 
 ```rust
-let header_rect = ui.available_rect_before_wrap();
-let header_rect = header_rect.with_max_y(header_rect.min.y + PANE_HEADER_HEIGHT);
+// Main content area
+ui.painter().rect_filled(rect, 0.0, PANEL_BG);
 
-// Background
+// Sidebar or secondary panel
+ui.painter().rect_filled(rect, 0.0, TAB_BAR_BG);
+
+// Elevated card or section
+ui.painter().rect_filled(rect, CORNER_RADIUS, SURFACE_ELEVATED);
+```
+
+**Key principle:** Adjacent panels have different background shades. No borders needed.
+
+### Pane Headers
+
+Blend seamlessly with their panels:
+
+```rust
+// Header background matches panel, slightly lighter text
 ui.painter().rect_filled(header_rect, 0.0, PANE_HEADER_BACKGROUND_COLOR);
-
-// Title text
 ui.label(
     RichText::new("PARAMETERS")
         .size(FONT_SIZE_SMALL)
@@ -201,63 +224,68 @@ ui.label(
 );
 ```
 
-- Height: `24px` (`PANE_HEADER_HEIGHT`)
-- Background: `PANE_HEADER_BACKGROUND_COLOR` (GRAY_250)
-- Text: `PANE_HEADER_FOREGROUND_COLOR` (GRAY_700), 11px uppercase
-- No border on top, optional 1px border on bottom
+- Background: `GRAY_150` (matches sidebar tone)
+- Text: `GRAY_600` (subdued, not competing with content)
+- No bottom border — spacing separates header from content
 
 ### Buttons
 
-```rust
-// Standard button
-let response = ui.button(RichText::new("Export").size(FONT_SIZE_BASE));
+Sharp corners, no borders, background-based states:
 
-// Icon button (no text)
-let response = ui.add(egui::Button::new("⚙").frame(false));
+```rust
+let bg = if response.is_pointer_button_down_on() {
+    WIDGET_ACTIVE_BG
+} else if response.hovered() {
+    WIDGET_HOVERED_BG
+} else {
+    WIDGET_INACTIVE_BG
+};
+
+ui.painter().rect_filled(rect, 0.0, bg);  // Sharp corners
 ```
 
-- Padding: `12px` horizontal, `8px` vertical
-- Corner radius: `4px`
-- Hover: Background → `WIDGET_HOVERED_BG`, 1px expansion
-- Active: Background → `WIDGET_ACTIVE_BG`
+- Default: `GRAY_250`
+- Hover: `GRAY_300`
+- Active: `GRAY_350`
+- No border strokes, sharp 90° corners
 
 ### Input Fields
+
+Elevated background, sharp corners:
 
 ```rust
 let response = ui.add(
     egui::TextEdit::singleline(&mut value)
         .desired_width(100.0)
-        .font(FontId::proportional(FONT_SIZE_BASE))
 );
 ```
 
-- Background: `TEXT_EDIT_BG` (GRAY_200)
+- Background: `SURFACE_ELEVATED` (GRAY_200)
 - Text: `TEXT_DEFAULT`
-- Focused border: 1px `BLUE_400`
-- Corner radius: `4px`
+- No border by default, sharp corners
+- Focus: Subtle `VIOLET_500` border or 4px rounded highlight
 
-### Lists & Selections
+### Selections (Exception: Use Subtle Rounding)
+
+Selected items get subtle rounding to make them "pop":
 
 ```rust
-let is_selected = current_item == item_id;
-let is_hovered = response.hovered();
-
-let bg_color = if is_selected {
-    SELECTION_BG
+let bg = if is_selected {
+    SELECTION_BG  // Violet-tinted background
 } else if is_hovered {
     HOVER_BG
 } else {
     Color32::TRANSPARENT
 };
 
-ui.painter().rect_filled(item_rect, CORNER_RADIUS_SMALL, bg_color);
+// Use CORNER_RADIUS_SMALL (4px) for selections only
+ui.painter().rect_filled(item_rect, CORNER_RADIUS_SMALL, bg);
 ```
 
-- Item height: `24px` (`LIST_ITEM_HEIGHT`)
-- Selected: `SELECTION_BG` with 1px `BLUE_400` stroke
-- Hovered: `HOVER_BG`
-- Corner radius: `4px`
-- Inner padding: `8px`
+- Selected: `VIOLET_900` with 4px rounding
+- Hovered: `HOVER_BG` with 4px rounding
+- Default: transparent, no rounding
+- Text becomes `TEXT_STRONG` when selected
 
 ### Dialogs / Modals
 
@@ -265,64 +293,36 @@ ui.painter().rect_filled(item_rect, CORNER_RADIUS_SMALL, bg_color);
 egui::Window::new("Add Node")
     .fixed_size([500.0, 400.0])
     .frame(egui::Frame::window(&ctx.style())
-        .fill(PANEL_BG)
-        .stroke(Stroke::new(1.0, BORDER_COLOR))
-        .rounding(CORNER_RADIUS))
+        .fill(SURFACE_ELEVATED)
+        .stroke(Stroke::new(1.0, GRAY_250))
+        .rounding(0.0))  // Sharp corners
 ```
 
-- Fixed size (no resizing by default)
-- Background: `PANEL_BG`
-- Border: 1px `BORDER_COLOR`
-- Corner radius: `4px`
+- Background: `SURFACE_ELEVATED` (elevated from underlying content)
+- Border: 1px `GRAY_250` (only place we use a visible border)
+- Corner radius: `0px` (sharp)
 - No drop shadow
-
-### Separators
-
-Use sparingly — prefer spacing over lines:
-
-```rust
-// Horizontal separator
-ui.add(egui::Separator::default().horizontal());
-
-// Or draw manually for control
-let line_rect = Rect::from_min_max(
-    pos2(rect.left() + PADDING, y),
-    pos2(rect.right() - PADDING, y + 1.0)
-);
-ui.painter().rect_filled(line_rect, 0.0, BORDER_COLOR);
-```
-
-- Color: `BORDER_COLOR` (GRAY_250)
-- Thickness: 1px
-- Inset from edges by `PADDING`
 
 ---
 
 ## Interaction States
 
-### State Progression
+### State Progression (No Borders)
 
-| State | Background | Text | Border |
-|-------|------------|------|--------|
-| Noninteractive | `GRAY_150` | `TEXT_SUBDUED` | None |
-| Inactive | `GRAY_300` | `TEXT_DEFAULT` | None |
-| Hovered | `GRAY_325` | `TEXT_STRONG` | None |
-| Active/Pressed | `GRAY_325` | `TEXT_STRONG` | None |
-| Selected | `BLUE_350` | `TEXT_STRONG` | 1px `BLUE_400` |
-| Disabled | `GRAY_150` | `TEXT_DISABLED` | None |
+| State | Background | Text |
+|-------|------------|------|
+| Default | `GRAY_250` | `TEXT_DEFAULT` |
+| Hovered | `GRAY_300` | `TEXT_STRONG` |
+| Active/Pressed | `GRAY_350` | `TEXT_STRONG` |
+| Selected | `VIOLET_900` | `TEXT_STRONG` |
+| Disabled | `GRAY_150` | `TEXT_DISABLED` |
 
 ### Hover Effects
 
-- Background color change (subtle step up in gray scale)
-- 1px expansion on widgets
-- Cursor change to pointer for clickable elements
-- No shadows, glows, or animations
-
-### Focus States
-
-- Input fields: 1px `BLUE_400` border
-- Buttons: Same as hover state
-- List items: Selected state
+- Background color lightens one step
+- Text brightens to `TEXT_STRONG`
+- No expansion, no borders, no shadows
+- Cursor changes to pointer
 
 ---
 
@@ -332,37 +332,30 @@ ui.painter().rect_filled(line_rect, 0.0, BORDER_COLOR);
 
 ```
 ┌─────────────────────────────────────┐
-│ PANE HEADER (24px)                  │  ← PANE_HEADER_BACKGROUND_COLOR
-├─────────────────────────────────────┤
+│ PANE HEADER (24px)                  │  ← GRAY_150
 │                                     │
-│  Content Area                       │  ← PANEL_BG
+│  Content Area                       │  ← GRAY_100
 │  (VIEW_PADDING on all sides)        │
 │                                     │
 └─────────────────────────────────────┘
 ```
 
-### Parameter Panel Layout
+No borders between header and content — spacing creates separation.
+
+### Sidebar + Main Layout
 
 ```
-┌─────────────────────────────────────┐
-│ PARAMETERS    separator   Node Name │  ← Header (24px)
-├─────────────────────────────────────┤
-│ Label          │ Value              │  ← Row (24px each)
-│ Label          │ Value              │
-│ Label          │ Value              │
-│ ...                                 │
-└─────────────────────────────────────┘
+┌──────────┬──────────────────────────┐
+│          │                          │
+│ Sidebar  │  Main Content            │
+│ GRAY_150 │  GRAY_100                │
+│          │                          │
+└──────────┴──────────────────────────┘
 ```
 
-- Label width: `100px` fixed
-- Value: fills remaining space
-- Row height: `24px`
-- Horizontal spacing: `8px`
-- Vertical spacing: `0px` between rows (dense layout)
+Different background colors distinguish areas. No vertical border needed.
 
-### Grid Alignment
-
-The network view uses a 48px grid:
+### Network View Grid
 
 ```
 GRID_CELL_SIZE = 48px
@@ -379,21 +372,21 @@ NODE_ICON_SIZE = 24px
 
 ### Do
 
+- ✓ Use **sharp 90° corners** for most UI elements
+- ✓ Use background color to distinguish panels and sections
+- ✓ Apply subtle 4px rounding **only** for selected/hovered items
+- ✓ Use the violet accent for selections and links
+- ✓ Keep interfaces spacious with generous padding
 - ✓ Use semantic color tokens from `theme.rs`
-- ✓ Follow the 8px spacing grid
-- ✓ Use typography hierarchy for emphasis
-- ✓ Keep borders thin (1px) and subtle
-- ✓ Provide hover feedback on interactive elements
-- ✓ Test with actual content to verify spacing
 
 ### Don't
 
-- ✗ Hardcode hex color values
-- ✗ Add drop shadows to panels or dialogs
-- ✗ Use borders when spacing would suffice
-- ✗ Create custom fonts or sizes outside the system
-- ✗ Add decorative elements that don't serve function
-- ✗ Use animation for state changes (keep it snappy)
+- ✗ Round corners on panels, dialogs, or buttons — keep them sharp
+- ✗ Add borders to separate panels — use background colors instead
+- ✗ Use borders on buttons or list items
+- ✗ Add drop shadows (they add visual noise)
+- ✗ Hardcode color values — use tokens
+- ✗ Use expansion effects on hover — just change color
 
 ---
 
@@ -402,13 +395,13 @@ NODE_ICON_SIZE = 24px
 When creating new UI components:
 
 1. [ ] Import tokens from `crate::theme`
-2. [ ] Use semantic color constants, not raw values
-3. [ ] Align dimensions to 4px/8px grid
-4. [ ] Use standard heights (`ROW_HEIGHT`, `LIST_ITEM_HEIGHT`, etc.)
-5. [ ] Implement hover states with `HOVER_BG`
-6. [ ] Test with both short and long content
-7. [ ] Verify text is readable (proper contrast)
-8. [ ] Check alignment with adjacent components
+2. [ ] Use semantic colors, not raw values
+3. [ ] Use **sharp corners (0px)** by default
+4. [ ] Only use 4px rounding for selections/highlights
+5. [ ] **NO BORDERS** — use background differentiation
+6. [ ] Implement hover/active states via background color
+7. [ ] Use violet (`SELECTION_BG`) for selections
+8. [ ] Align to 4px grid
 
 ---
 
@@ -417,7 +410,7 @@ When creating new UI components:
 ```rust
 use crate::theme::{
     // Backgrounds
-    PANEL_BG, HOVER_BG, SELECTION_BG, TEXT_EDIT_BG,
+    PANEL_BG, TAB_BAR_BG, SURFACE_ELEVATED, HOVER_BG, SELECTION_BG,
 
     // Text
     TEXT_STRONG, TEXT_DEFAULT, TEXT_SUBDUED, TEXT_DISABLED,
@@ -425,20 +418,17 @@ use crate::theme::{
     // Widgets
     WIDGET_INACTIVE_BG, WIDGET_HOVERED_BG, WIDGET_ACTIVE_BG,
 
-    // Borders
-    BORDER_COLOR, CORNER_RADIUS, CORNER_RADIUS_SMALL,
+    // Accents
+    VIOLET_400, VIOLET_500, VIOLET_900,
+    SUCCESS_GREEN, WARNING_YELLOW, ERROR_RED,
 
-    // Spacing
-    PADDING, PADDING_SMALL, PADDING_LARGE, ITEM_SPACING,
+    // Layout
+    CORNER_RADIUS, CORNER_RADIUS_SMALL,
+    PADDING, PADDING_SMALL, PADDING_LARGE, PADDING_XL,
+    ROW_HEIGHT, LIST_ITEM_HEIGHT,
 
     // Typography
     FONT_SIZE_BASE, FONT_SIZE_SMALL, FONT_SIZE_HEADING,
-
-    // Heights
-    ROW_HEIGHT, LIST_ITEM_HEIGHT, PANE_HEADER_HEIGHT,
-
-    // Accents
-    BLUE_400, BLUE_500, SUCCESS_GREEN, WARNING_ORANGE, ERROR_RED,
 };
 ```
 
@@ -448,7 +438,7 @@ use crate::theme::{
 
 This design system is living documentation. When adding new patterns:
 
-1. First check if existing tokens cover your use case
-2. If new tokens are needed, add them to `theme.rs` with semantic names
+1. Check if existing tokens cover your use case
+2. Add new tokens to `theme.rs` with semantic names
 3. Update this document with the new pattern
-4. Ensure consistency with existing components
+4. **Remember: sharp corners, no borders, background differentiation**

--- a/crates/nodebox-gui/src/network_view.rs
+++ b/crates/nodebox-gui/src/network_view.rs
@@ -52,14 +52,14 @@ struct ConnectionDrag {
 
 /// Visual constants (matching NodeBox Java).
 const GRID_CELL_SIZE: f32 = 48.0;
-const NODE_MARGIN: f32 = 6.0;
-const NODE_WIDTH: f32 = 132.0; // 48*3 - 6*2
-const NODE_HEIGHT: f32 = 36.0; // 48 - 6*2
-const NODE_ICON_SIZE: f32 = 26.0;
-const NODE_PADDING: f32 = 5.0;
-const PORT_WIDTH: f32 = 10.0;
-const PORT_HEIGHT: f32 = 3.0;
-const PORT_SPACING: f32 = 10.0;
+const NODE_MARGIN: f32 = 8.0;
+const NODE_WIDTH: f32 = 128.0; // 48*3 - 8*2
+const NODE_HEIGHT: f32 = 32.0; // 48 - 8*2
+const NODE_ICON_SIZE: f32 = 24.0;
+const NODE_PADDING: f32 = 4.0;
+const PORT_WIDTH: f32 = 12.0;
+const PORT_HEIGHT: f32 = 4.0;
+const PORT_SPACING: f32 = 8.0;
 
 /// Colors matching NodeBox Java Theme.
 const NETWORK_BACKGROUND_COLOR: (u8, u8, u8) = (69, 69, 69);

--- a/crates/nodebox-gui/src/theme.rs
+++ b/crates/nodebox-gui/src/theme.rs
@@ -1,10 +1,11 @@
-//! Centralized theme constants inspired by Rerun's refined design system.
+//! Centralized theme constants inspired by Linear's refined dark design.
 //!
-//! Design tokens are organized by:
-//! - Gray scale (dark theme optimized)
-//! - Semantic colors (panel backgrounds, text, etc.)
-//! - Spacing and layout constants
-//! - Typography settings
+//! Design principles:
+//! - Deep, rich dark backgrounds with subtle cool undertones
+//! - Purple/violet accent color for selections and highlights
+//! - Rounded corners (8px large, 4px small) for a softer feel
+//! - Minimal borders - use background color differentiation instead
+//! - Generous spacing for a breathable, modern look
 //!
 //! Note: Not all tokens are used yet - they are defined for the complete design system.
 
@@ -13,37 +14,73 @@
 use eframe::egui::{self, Color32, FontId, Rounding, Stroke, Style, Visuals};
 
 // =============================================================================
-// GRAY SCALE (Dark Theme)
+// GRAY SCALE (Linear-inspired Dark Theme)
 // =============================================================================
-// 21-stop gray scale from pure black to pure white
+// Deep blacks with subtle cool undertones, smooth gradient from black to white
 
 pub const GRAY_0: Color32 = Color32::from_rgb(0, 0, 0);
-pub const GRAY_100: Color32 = Color32::from_rgb(13, 16, 17);
-pub const GRAY_150: Color32 = Color32::from_rgb(20, 24, 25);
-pub const GRAY_200: Color32 = Color32::from_rgb(28, 33, 35);
-pub const GRAY_250: Color32 = Color32::from_rgb(38, 43, 46);
-pub const GRAY_300: Color32 = Color32::from_rgb(49, 56, 59);
-pub const GRAY_325: Color32 = Color32::from_rgb(55, 63, 66);
-pub const GRAY_400: Color32 = Color32::from_rgb(76, 86, 90);
-pub const GRAY_550: Color32 = Color32::from_rgb(125, 140, 146);
-pub const GRAY_700: Color32 = Color32::from_rgb(174, 194, 202);
-pub const GRAY_775: Color32 = Color32::from_rgb(202, 216, 222);
-pub const GRAY_800: Color32 = Color32::from_rgb(211, 222, 227);
+/// Deepest background - for drop shadows or true black needs
+pub const GRAY_50: Color32 = Color32::from_rgb(9, 9, 11);
+/// Main panel/window background
+pub const GRAY_100: Color32 = Color32::from_rgb(17, 17, 19);
+/// Sidebar/secondary panel background
+pub const GRAY_150: Color32 = Color32::from_rgb(23, 23, 26);
+/// Elevated surfaces, cards, inputs
+pub const GRAY_200: Color32 = Color32::from_rgb(31, 31, 35);
+/// Subtle borders (use sparingly)
+pub const GRAY_250: Color32 = Color32::from_rgb(39, 39, 43);
+/// Stronger borders, dividers
+pub const GRAY_300: Color32 = Color32::from_rgb(49, 49, 54);
+/// Hover backgrounds
+pub const GRAY_350: Color32 = Color32::from_rgb(55, 55, 61);
+/// Disabled/tertiary elements
+pub const GRAY_400: Color32 = Color32::from_rgb(75, 75, 82);
+/// Muted text, icons
+pub const GRAY_500: Color32 = Color32::from_rgb(107, 107, 115);
+/// Secondary text
+pub const GRAY_600: Color32 = Color32::from_rgb(139, 139, 148);
+/// Body text
+pub const GRAY_700: Color32 = Color32::from_rgb(171, 171, 181);
+/// Primary text
+pub const GRAY_800: Color32 = Color32::from_rgb(219, 219, 224);
+/// Bright/emphasized text
+pub const GRAY_900: Color32 = Color32::from_rgb(235, 235, 240);
+/// Pure white
 pub const GRAY_1000: Color32 = Color32::from_rgb(255, 255, 255);
 
+// Legacy aliases for compatibility
+pub const GRAY_325: Color32 = GRAY_350;
+pub const GRAY_550: Color32 = GRAY_500;
+pub const GRAY_775: Color32 = GRAY_800;
+
 // =============================================================================
-// ACCENT COLORS
+// ACCENT COLORS (Purple/Violet - Linear-inspired)
 // =============================================================================
 
-// Selection blue (primary accent)
-pub const BLUE_350: Color32 = Color32::from_rgb(24, 73, 187);
-pub const BLUE_400: Color32 = Color32::from_rgb(51, 102, 255);
-pub const BLUE_500: Color32 = Color32::from_rgb(68, 138, 255);
+/// Selection background (subtle violet tint)
+pub const VIOLET_900: Color32 = Color32::from_rgb(45, 38, 64);
+/// Darker pressed state
+pub const VIOLET_600: Color32 = Color32::from_rgb(124, 58, 237);
+/// Primary accent color
+pub const VIOLET_500: Color32 = Color32::from_rgb(139, 92, 246);
+/// Hover/lighter accent
+pub const VIOLET_400: Color32 = Color32::from_rgb(167, 139, 250);
 
-// Status colors
-pub const SUCCESS_GREEN: Color32 = Color32::from_rgb(0, 218, 126);
-pub const WARNING_ORANGE: Color32 = Color32::from_rgb(255, 122, 12);
-pub const ERROR_RED: Color32 = Color32::from_rgb(171, 1, 22);
+// Legacy blue aliases (map to violet for backwards compat)
+pub const BLUE_350: Color32 = VIOLET_900;
+pub const BLUE_400: Color32 = VIOLET_500;
+pub const BLUE_500: Color32 = VIOLET_400;
+
+// =============================================================================
+// STATUS COLORS
+// =============================================================================
+
+pub const SUCCESS_GREEN: Color32 = Color32::from_rgb(34, 197, 94);
+pub const WARNING_YELLOW: Color32 = Color32::from_rgb(234, 179, 8);
+pub const ERROR_RED: Color32 = Color32::from_rgb(239, 68, 68);
+
+// Legacy alias
+pub const WARNING_ORANGE: Color32 = WARNING_YELLOW;
 
 // =============================================================================
 // SEMANTIC COLORS - Panel & Background
@@ -54,26 +91,28 @@ pub const PANEL_BG: Color32 = GRAY_100;
 /// Top bar / title bar background
 pub const TOP_BAR_BG: Color32 = GRAY_100;
 /// Tab bar background
-pub const TAB_BAR_BG: Color32 = GRAY_200;
+pub const TAB_BAR_BG: Color32 = GRAY_150;
 /// Bottom bar / footer background
-pub const BOTTOM_BAR_BG: Color32 = GRAY_150;
+pub const BOTTOM_BAR_BG: Color32 = GRAY_100;
+/// Elevated surface (cards, dialogs, popups)
+pub const SURFACE_ELEVATED: Color32 = GRAY_200;
 /// Text edit / input field background
 pub const TEXT_EDIT_BG: Color32 = GRAY_200;
 /// Hover state background
-pub const HOVER_BG: Color32 = GRAY_325;
-/// Selection background
-pub const SELECTION_BG: Color32 = BLUE_350;
+pub const HOVER_BG: Color32 = GRAY_250;
+/// Selection background (subtle violet)
+pub const SELECTION_BG: Color32 = VIOLET_900;
 
 // =============================================================================
 // SEMANTIC COLORS - Text
 // =============================================================================
 
 /// Strong/active text (brightest)
-pub const TEXT_STRONG: Color32 = GRAY_1000;
+pub const TEXT_STRONG: Color32 = GRAY_900;
 /// Default body text
-pub const TEXT_DEFAULT: Color32 = GRAY_775;
+pub const TEXT_DEFAULT: Color32 = GRAY_700;
 /// Secondary/muted text
-pub const TEXT_SUBDUED: Color32 = GRAY_550;
+pub const TEXT_SUBDUED: Color32 = GRAY_500;
 /// Disabled/non-interactive text
 pub const TEXT_DISABLED: Color32 = GRAY_400;
 
@@ -82,17 +121,17 @@ pub const TEXT_DISABLED: Color32 = GRAY_400;
 // =============================================================================
 
 /// Widget inactive background
-pub const WIDGET_INACTIVE_BG: Color32 = GRAY_300;
+pub const WIDGET_INACTIVE_BG: Color32 = GRAY_250;
 /// Widget hovered background
-pub const WIDGET_HOVERED_BG: Color32 = GRAY_325;
+pub const WIDGET_HOVERED_BG: Color32 = GRAY_300;
 /// Widget active/pressed background
-pub const WIDGET_ACTIVE_BG: Color32 = GRAY_325;
+pub const WIDGET_ACTIVE_BG: Color32 = GRAY_350;
 /// Non-interactive widget background
 pub const WIDGET_NONINTERACTIVE_BG: Color32 = GRAY_150;
-/// Border color
+/// Border color (use sparingly - prefer no borders)
 pub const BORDER_COLOR: Color32 = GRAY_250;
 /// Secondary border color
-pub const BORDER_SECONDARY: Color32 = GRAY_400;
+pub const BORDER_SECONDARY: Color32 = GRAY_300;
 
 // =============================================================================
 // LAYOUT CONSTANTS - Heights
@@ -103,7 +142,7 @@ pub const TOP_BAR_HEIGHT: f32 = 28.0;
 /// Standard title bar height
 pub const TITLE_BAR_HEIGHT: f32 = 24.0;
 /// List item height
-pub const LIST_ITEM_HEIGHT: f32 = 24.0;
+pub const LIST_ITEM_HEIGHT: f32 = 28.0;
 /// Table header height
 pub const TABLE_HEADER_HEIGHT: f32 = 32.0;
 /// Standard row height
@@ -119,15 +158,15 @@ pub const LABEL_WIDTH: f32 = 100.0;
 // PANE HEADER COLORS
 // =============================================================================
 
-/// Pane header background color (consistent across all panes)
-pub const PANE_HEADER_BACKGROUND_COLOR: Color32 = GRAY_250;
-/// Pane header foreground/text color (higher contrast for readability)
-pub const PANE_HEADER_FOREGROUND_COLOR: Color32 = GRAY_700;
+/// Pane header background color (same as panel for seamless look)
+pub const PANE_HEADER_BACKGROUND_COLOR: Color32 = GRAY_150;
+/// Pane header foreground/text color
+pub const PANE_HEADER_FOREGROUND_COLOR: Color32 = GRAY_600;
 pub const PARAMETER_PANEL_WIDTH: f32 = 280.0;
 pub const PARAMETER_ROW_HEIGHT: f32 = ROW_HEIGHT;
 
 // =============================================================================
-// LAYOUT CONSTANTS - Spacing (8px grid)
+// LAYOUT CONSTANTS - Spacing (4px grid)
 // =============================================================================
 
 /// Standard padding
@@ -136,29 +175,31 @@ pub const PADDING: f32 = 8.0;
 pub const PADDING_SMALL: f32 = 4.0;
 /// Large padding
 pub const PADDING_LARGE: f32 = 12.0;
+/// Extra large padding
+pub const PADDING_XL: f32 = 16.0;
 /// View/panel padding
 pub const VIEW_PADDING: f32 = 12.0;
 /// Item spacing
 pub const ITEM_SPACING: f32 = 8.0;
 /// Menu item spacing
-pub const MENU_SPACING: f32 = 1.0;
+pub const MENU_SPACING: f32 = 4.0;
 /// Indent for hierarchical items
 pub const INDENT: f32 = 16.0;
 /// Icon to text padding
-pub const ICON_TEXT_PADDING: f32 = 4.0;
+pub const ICON_TEXT_PADDING: f32 = 8.0;
 
 // =============================================================================
 // LAYOUT CONSTANTS - Sizing
 // =============================================================================
 
-/// Standard corner radius
-pub const CORNER_RADIUS: f32 = 4.0;
-/// Small corner radius (widgets)
+/// Standard corner radius (sharp/square for most UI)
+pub const CORNER_RADIUS: f32 = 0.0;
+/// Small corner radius (subtle rounding for selections, highlighted items)
 pub const CORNER_RADIUS_SMALL: f32 = 4.0;
 /// Large button size
 pub const BUTTON_SIZE_LARGE: f32 = 24.0;
 /// Button icon size
-pub const BUTTON_ICON_SIZE: f32 = 12.0;
+pub const BUTTON_ICON_SIZE: f32 = 16.0;
 /// Small icon size
 pub const ICON_SIZE_SMALL: f32 = 16.0;
 /// Scroll bar width
@@ -168,79 +209,79 @@ pub const SCROLL_BAR_WIDTH: f32 = 8.0;
 // TYPOGRAPHY
 // =============================================================================
 
-/// Base font size (12px is industry standard for dense UIs)
-pub const FONT_SIZE_BASE: f32 = 12.0;
+/// Base font size
+pub const FONT_SIZE_BASE: f32 = 13.0;
 /// Small font size
 pub const FONT_SIZE_SMALL: f32 = 11.0;
 /// Large/heading font size
 pub const FONT_SIZE_HEADING: f32 = 16.0;
 /// Line height ratio
-pub const LINE_HEIGHT_RATIO: f32 = 1.333;
+pub const LINE_HEIGHT_RATIO: f32 = 1.4;
 
 // =============================================================================
 // LEGACY CONSTANTS (for backward compatibility)
 // =============================================================================
 
-// Parameter panel value colors
-pub const VALUE_TEXT: Color32 = BLUE_500;
-pub const VALUE_TEXT_HOVER: Color32 = Color32::from_rgb(168, 200, 255);
+// Parameter panel value colors (now violet)
+pub const VALUE_TEXT: Color32 = VIOLET_400;
+pub const VALUE_TEXT_HOVER: Color32 = VIOLET_500;
 
 // Background colors
-pub const BACKGROUND_COLOR: Color32 = GRAY_200;
-pub const HEADER_BACKGROUND: Color32 = GRAY_250;
-pub const DARK_BACKGROUND: Color32 = GRAY_150;
+pub const BACKGROUND_COLOR: Color32 = GRAY_150;
+pub const HEADER_BACKGROUND: Color32 = GRAY_150;
+pub const DARK_BACKGROUND: Color32 = GRAY_100;
 
 // Text colors
 pub const TEXT_NORMAL: Color32 = TEXT_DEFAULT;
 pub const TEXT_BRIGHT: Color32 = TEXT_STRONG;
 
 // Port/parameter colors
-pub const PORT_LABEL_BACKGROUND: Color32 = GRAY_300;
-pub const PORT_VALUE_BACKGROUND: Color32 = GRAY_200;
+pub const PORT_LABEL_BACKGROUND: Color32 = GRAY_200;
+pub const PORT_VALUE_BACKGROUND: Color32 = GRAY_150;
 
 // Tab colors
-pub const SELECTED_TAB_BACKGROUND: Color32 = GRAY_150;
-pub const UNSELECTED_TAB_BACKGROUND: Color32 = GRAY_250;
+pub const SELECTED_TAB_BACKGROUND: Color32 = GRAY_200;
+pub const UNSELECTED_TAB_BACKGROUND: Color32 = GRAY_150;
 
 // Address bar colors
-pub const ADDRESS_BAR_BACKGROUND: Color32 = GRAY_200;
-pub const ADDRESS_SEGMENT_HOVER: Color32 = GRAY_325;
+pub const ADDRESS_BAR_BACKGROUND: Color32 = GRAY_150;
+pub const ADDRESS_SEGMENT_HOVER: Color32 = GRAY_250;
 pub const ADDRESS_SEPARATOR_COLOR: Color32 = GRAY_400;
 
 // Animation bar colors
-pub const ANIMATION_BAR_BACKGROUND: Color32 = GRAY_150;
+pub const ANIMATION_BAR_BACKGROUND: Color32 = GRAY_100;
 
 // Network view colors
-pub const NETWORK_BACKGROUND: Color32 = GRAY_200;
-pub const NETWORK_GRID: Color32 = GRAY_250;
+pub const NETWORK_BACKGROUND: Color32 = GRAY_100;
+pub const NETWORK_GRID: Color32 = GRAY_150;
 
 // Port type colors (semantic colors for data types)
-pub const PORT_COLOR_INT: Color32 = Color32::from_rgb(116, 119, 121);
-pub const PORT_COLOR_FLOAT: Color32 = Color32::from_rgb(116, 119, 121);
-pub const PORT_COLOR_STRING: Color32 = Color32::from_rgb(92, 90, 91);
-pub const PORT_COLOR_BOOLEAN: Color32 = Color32::from_rgb(92, 90, 91);
-pub const PORT_COLOR_POINT: Color32 = Color32::from_rgb(119, 154, 173);
-pub const PORT_COLOR_COLOR: Color32 = Color32::from_rgb(94, 85, 112);
-pub const PORT_COLOR_GEOMETRY: Color32 = Color32::from_rgb(20, 20, 20);
-pub const PORT_COLOR_LIST: Color32 = Color32::from_rgb(76, 137, 174);
-pub const PORT_COLOR_DATA: Color32 = Color32::from_rgb(52, 85, 129);
+pub const PORT_COLOR_INT: Color32 = Color32::from_rgb(99, 102, 241);    // Indigo
+pub const PORT_COLOR_FLOAT: Color32 = Color32::from_rgb(99, 102, 241);  // Indigo
+pub const PORT_COLOR_STRING: Color32 = Color32::from_rgb(34, 197, 94); // Green
+pub const PORT_COLOR_BOOLEAN: Color32 = Color32::from_rgb(234, 179, 8); // Yellow
+pub const PORT_COLOR_POINT: Color32 = Color32::from_rgb(56, 189, 248);  // Sky blue
+pub const PORT_COLOR_COLOR: Color32 = Color32::from_rgb(236, 72, 153);  // Pink
+pub const PORT_COLOR_GEOMETRY: Color32 = Color32::from_rgb(139, 92, 246); // Violet
+pub const PORT_COLOR_LIST: Color32 = Color32::from_rgb(20, 184, 166);   // Teal
+pub const PORT_COLOR_DATA: Color32 = Color32::from_rgb(249, 115, 22);   // Orange
 
 // Node selection dialog colors
-pub const DIALOG_BACKGROUND: Color32 = GRAY_200;
-pub const DIALOG_BORDER: Color32 = GRAY_100;
+pub const DIALOG_BACKGROUND: Color32 = GRAY_150;
+pub const DIALOG_BORDER: Color32 = GRAY_250;
 pub const SELECTED_ITEM: Color32 = SELECTION_BG;
-pub const HOVERED_ITEM: Color32 = GRAY_250;
+pub const HOVERED_ITEM: Color32 = GRAY_200;
 
 // Button colors
-pub const BUTTON_NORMAL: Color32 = WIDGET_INACTIVE_BG;
-pub const BUTTON_HOVER: Color32 = WIDGET_HOVERED_BG;
-pub const BUTTON_ACTIVE: Color32 = WIDGET_ACTIVE_BG;
+pub const BUTTON_NORMAL: Color32 = GRAY_250;
+pub const BUTTON_HOVER: Color32 = GRAY_300;
+pub const BUTTON_ACTIVE: Color32 = GRAY_350;
 
 // =============================================================================
 // STYLE CONFIGURATION
 // =============================================================================
 
-/// Configure egui's global style and visuals for NodeBox's dark theme.
+/// Configure egui's global style and visuals for NodeBox's Linear-inspired dark theme.
 pub fn configure_style(ctx: &egui::Context) {
     let mut style = Style::default();
     let mut visuals = Visuals::dark();
@@ -267,65 +308,65 @@ pub fn configure_style(ctx: &egui::Context) {
         FontId::monospace(FONT_SIZE_BASE),
     );
 
-    // Spacing
+    // Spacing - generous for a modern, breathable feel
     style.spacing.item_spacing = egui::vec2(ITEM_SPACING, ITEM_SPACING);
     style.spacing.button_padding = egui::vec2(PADDING_LARGE, PADDING);
     style.spacing.menu_margin = egui::Margin::same(MENU_SPACING);
     style.spacing.indent = INDENT;
     style.spacing.scroll = egui::style::ScrollStyle {
         bar_width: SCROLL_BAR_WIDTH,
-        bar_inner_margin: 2.0,
-        bar_outer_margin: 2.0,
+        bar_inner_margin: 4.0,
+        bar_outer_margin: 4.0,
         ..Default::default()
     };
 
-    // Visuals - Window (Figma-style: subtle borders)
-    visuals.window_fill = PANEL_BG;
-    visuals.window_stroke = Stroke::new(1.0, BORDER_COLOR);
-    visuals.window_rounding = Rounding::same(CORNER_RADIUS);
-    visuals.window_shadow = egui::Shadow::NONE; // Figma: no shadows on panels
+    // Visuals - Window (sharp corners, subtle border)
+    visuals.window_fill = SURFACE_ELEVATED;
+    visuals.window_stroke = Stroke::new(1.0, GRAY_250); // Very subtle border
+    visuals.window_rounding = Rounding::ZERO; // Sharp 90° corners
+    visuals.window_shadow = egui::Shadow::NONE;
 
-    // Visuals - Panel (clean, no extra borders)
+    // Visuals - Panel (no borders, use background differentiation)
     visuals.panel_fill = PANEL_BG;
     visuals.faint_bg_color = GRAY_150;
-    visuals.extreme_bg_color = GRAY_100;
+    visuals.extreme_bg_color = GRAY_50;
 
-    // Visuals - Widgets (subtle, Figma-like)
+    // Visuals - Widgets (sharp corners, minimal borders)
     visuals.widgets.noninteractive.bg_fill = WIDGET_NONINTERACTIVE_BG;
     visuals.widgets.noninteractive.fg_stroke = Stroke::new(1.0, TEXT_SUBDUED);
-    visuals.widgets.noninteractive.rounding = Rounding::same(CORNER_RADIUS_SMALL);
-    visuals.widgets.noninteractive.bg_stroke = Stroke::NONE; // Clean look
+    visuals.widgets.noninteractive.rounding = Rounding::ZERO;
+    visuals.widgets.noninteractive.bg_stroke = Stroke::NONE;
 
     visuals.widgets.inactive.bg_fill = WIDGET_INACTIVE_BG;
     visuals.widgets.inactive.fg_stroke = Stroke::new(1.0, TEXT_DEFAULT);
-    visuals.widgets.inactive.rounding = Rounding::same(CORNER_RADIUS_SMALL);
-    visuals.widgets.inactive.bg_stroke = Stroke::NONE; // Clean look
+    visuals.widgets.inactive.rounding = Rounding::ZERO;
+    visuals.widgets.inactive.bg_stroke = Stroke::NONE;
 
     visuals.widgets.hovered.bg_fill = WIDGET_HOVERED_BG;
     visuals.widgets.hovered.fg_stroke = Stroke::new(1.0, TEXT_STRONG);
-    visuals.widgets.hovered.rounding = Rounding::same(CORNER_RADIUS_SMALL);
-    visuals.widgets.hovered.expansion = 1.0; // Subtle hover expansion (Figma-like)
+    visuals.widgets.hovered.rounding = Rounding::ZERO;
+    visuals.widgets.hovered.expansion = 0.0; // No expansion, just color change
     visuals.widgets.hovered.bg_stroke = Stroke::NONE;
 
     visuals.widgets.active.bg_fill = WIDGET_ACTIVE_BG;
     visuals.widgets.active.fg_stroke = Stroke::new(1.0, TEXT_STRONG);
-    visuals.widgets.active.rounding = Rounding::same(CORNER_RADIUS_SMALL);
-    visuals.widgets.active.expansion = 1.0;
+    visuals.widgets.active.rounding = Rounding::ZERO;
+    visuals.widgets.active.expansion = 0.0;
     visuals.widgets.active.bg_stroke = Stroke::NONE;
 
     visuals.widgets.open.bg_fill = WIDGET_ACTIVE_BG;
     visuals.widgets.open.fg_stroke = Stroke::new(1.0, TEXT_STRONG);
-    visuals.widgets.open.rounding = Rounding::same(CORNER_RADIUS_SMALL);
+    visuals.widgets.open.rounding = Rounding::ZERO;
 
-    // Selection (Figma-style: clean selection highlight)
+    // Selection (violet tint, no stroke for cleaner look)
     visuals.selection.bg_fill = SELECTION_BG;
-    visuals.selection.stroke = Stroke::new(1.0, BLUE_400); // Thinner selection stroke
+    visuals.selection.stroke = Stroke::NONE;
 
-    // Separators - very subtle
-    visuals.widgets.noninteractive.bg_stroke = Stroke::new(1.0, GRAY_200);
+    // Separators - almost invisible
+    visuals.widgets.noninteractive.bg_stroke = Stroke::NONE;
 
-    // Hyperlinks
-    visuals.hyperlink_color = BLUE_500;
+    // Hyperlinks (violet accent)
+    visuals.hyperlink_color = VIOLET_400;
 
     // Apply styles
     style.visuals = visuals;

--- a/crates/nodebox-gui/src/theme.rs
+++ b/crates/nodebox-gui/src/theme.rs
@@ -107,11 +107,11 @@ pub const LIST_ITEM_HEIGHT: f32 = 24.0;
 /// Table header height
 pub const TABLE_HEADER_HEIGHT: f32 = 32.0;
 /// Standard row height
-pub const ROW_HEIGHT: f32 = 22.0;
+pub const ROW_HEIGHT: f32 = 24.0;
 
 // Legacy constants (for compatibility)
 pub const ADDRESS_BAR_HEIGHT: f32 = TOP_BAR_HEIGHT;
-pub const ANIMATION_BAR_HEIGHT: f32 = 27.0;
+pub const ANIMATION_BAR_HEIGHT: f32 = 28.0;
 pub const PANE_HEADER_HEIGHT: f32 = TITLE_BAR_HEIGHT;
 pub const LABEL_WIDTH: f32 = 100.0;
 
@@ -143,7 +143,7 @@ pub const ITEM_SPACING: f32 = 8.0;
 /// Menu item spacing
 pub const MENU_SPACING: f32 = 1.0;
 /// Indent for hierarchical items
-pub const INDENT: f32 = 14.0;
+pub const INDENT: f32 = 16.0;
 /// Icon to text padding
 pub const ICON_TEXT_PADDING: f32 = 4.0;
 
@@ -152,17 +152,17 @@ pub const ICON_TEXT_PADDING: f32 = 4.0;
 // =============================================================================
 
 /// Standard corner radius
-pub const CORNER_RADIUS: f32 = 6.0;
+pub const CORNER_RADIUS: f32 = 4.0;
 /// Small corner radius (widgets)
 pub const CORNER_RADIUS_SMALL: f32 = 4.0;
 /// Large button size
-pub const BUTTON_SIZE_LARGE: f32 = 22.0;
+pub const BUTTON_SIZE_LARGE: f32 = 24.0;
 /// Button icon size
 pub const BUTTON_ICON_SIZE: f32 = 12.0;
 /// Small icon size
-pub const ICON_SIZE_SMALL: f32 = 14.0;
+pub const ICON_SIZE_SMALL: f32 = 16.0;
 /// Scroll bar width
-pub const SCROLL_BAR_WIDTH: f32 = 6.0;
+pub const SCROLL_BAR_WIDTH: f32 = 8.0;
 
 // =============================================================================
 // TYPOGRAPHY


### PR DESCRIPTION
For the color palette we're taking inspiration from linear. NodeBox "house style" is a bit more boxy, with less rounded corners, only very subtle ones for selected nodes etc.

This PR adds a `STYLE_GUIDE.md` document, that is referenced in `AGENTS.md`, with a comprehensive style guide when doing GUI design.

<img width="1440" height="916" alt="image" src="https://github.com/user-attachments/assets/3a7810db-8633-453a-8780-e0265f936d99" />


