### PR TITLE
Fix animation bar to follow style guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,44 @@ pub fn new_for_testing() -> Self { ... }
 - `ui.allocate_ui_at_rect(rect, |ui| { ... })` is deprecated
 - Use `ui.allocate_new_ui(egui::UiBuilder::new().max_rect(rect), |ui| { ... })` instead
 
+### Fixed-size DragValue widgets
+DragValue shifts by a few pixels when entering text edit mode due to different padding between button and text edit states. To prevent this:
+
+```rust
+// Save original state
+let old_visuals = ui.visuals().clone();
+let old_spacing = ui.spacing().clone();
+
+// Set expansion=0 on all widget states to prevent size changes
+ui.visuals_mut().widgets.inactive.expansion = 0.0;
+ui.visuals_mut().widgets.hovered.expansion = 0.0;
+ui.visuals_mut().widgets.active.expansion = 0.0;
+ui.visuals_mut().widgets.noninteractive.expansion = 0.0;
+
+// Use consistent padding for button and text edit modes
+ui.spacing_mut().button_padding = egui::vec2(4.0, 2.0);
+
+// Allocate exact size first, then place widget inside
+let (rect, _) = ui.allocate_exact_size(
+    egui::vec2(width, height),
+    egui::Sense::hover(),
+);
+let response = ui.put(rect, egui::DragValue::new(value).range(range));
+
+// Restore original state
+*ui.visuals_mut() = old_visuals;
+*ui.spacing_mut() = old_spacing;
+```
+
+### Styling widgets to follow the style guide
+When styling egui widgets (DragValue, checkbox, etc.) to match the style guide:
+
+1. Override `bg_fill` AND `weak_bg_fill` - some widgets use one or the other
+2. Set `bg_stroke = Stroke::NONE` to remove borders
+3. Set `rounding = Rounding::ZERO` for sharp corners
+4. Override ALL states: `inactive`, `hovered`, `active`, `noninteractive`
+5. Save and restore both `visuals` and `spacing` to avoid affecting other widgets
+
 ## Build Commands
 
 ### Excluding problematic crates

--- a/crates/nodebox-gui/src/animation_bar.rs
+++ b/crates/nodebox-gui/src/animation_bar.rs
@@ -244,14 +244,14 @@ impl AnimationBar {
 
             ui.add_space(theme::PADDING);
 
-            // Frame counter
+            // Frame counter - width for 3+ digits
             ui.label(
                 egui::RichText::new("Frame")
                     .color(theme::TEXT_SUBDUED)
                     .size(theme::FONT_SIZE_SMALL),
             );
             let mut frame = self.frame as i32;
-            let frame_response = Self::styled_drag_value(ui, &mut frame, self.start_frame as i32..=self.end_frame as i32);
+            let frame_response = Self::styled_drag_value(ui, &mut frame, self.start_frame as i32..=self.end_frame as i32, 40.0);
             if frame_response.changed() {
                 self.frame = frame as u32;
                 event = AnimationEvent::FrameChanged(self.frame as f64);
@@ -265,14 +265,14 @@ impl AnimationBar {
 
             ui.add_space(theme::PADDING);
 
-            // FPS control
+            // FPS control - width for 3 digits
             ui.label(
                 egui::RichText::new("FPS")
                     .color(theme::TEXT_SUBDUED)
                     .size(theme::FONT_SIZE_SMALL),
             );
             let mut fps = self.fps as i32;
-            let fps_response = Self::styled_drag_value(ui, &mut fps, 1..=120);
+            let fps_response = Self::styled_drag_value(ui, &mut fps, 1..=120, 40.0);
             if fps_response.changed() {
                 self.fps = fps as u32;
                 event = AnimationEvent::FpsChanged(self.fps);
@@ -294,7 +294,7 @@ impl AnimationBar {
 
     /// Styled DragValue that follows the style guide.
     /// Uses SLATE_800 for subtle elevation against SLATE_900 bar background.
-    fn styled_drag_value(ui: &mut egui::Ui, value: &mut i32, range: std::ops::RangeInclusive<i32>) -> egui::Response {
+    fn styled_drag_value(ui: &mut egui::Ui, value: &mut i32, range: std::ops::RangeInclusive<i32>, width: f32) -> egui::Response {
         // Override visuals for this widget - use SLATE_800 for subtle elevation
         let old_visuals = ui.visuals().clone();
 
@@ -322,7 +322,8 @@ impl AnimationBar {
         ui.visuals_mut().widgets.noninteractive.bg_stroke = egui::Stroke::NONE;
         ui.visuals_mut().widgets.noninteractive.rounding = egui::Rounding::ZERO;
 
-        let response = ui.add(
+        let response = ui.add_sized(
+            [width, theme::ANIMATION_BAR_HEIGHT],
             egui::DragValue::new(value)
                 .range(range)
                 .speed(1.0),

--- a/crates/nodebox-gui/src/animation_bar.rs
+++ b/crates/nodebox-gui/src/animation_bar.rs
@@ -322,17 +322,17 @@ impl AnimationBar {
         ui.visuals_mut().widgets.noninteractive.bg_stroke = egui::Stroke::NONE;
         ui.visuals_mut().widgets.noninteractive.rounding = egui::Rounding::ZERO;
 
-        // Use a fixed-size scope to prevent expansion during text editing
-        let response = ui.scope(|ui| {
-            ui.set_width(width);
-            ui.set_height(theme::ANIMATION_BAR_HEIGHT);
-            ui.add(
-                egui::DragValue::new(value)
-                    .range(range)
-                    .speed(1.0)
-                    .update_while_editing(false),
-            )
-        }).inner;
+        // Allocate exact size and place widget inside to prevent any shifting
+        let (rect, _) = ui.allocate_exact_size(
+            egui::vec2(width, theme::ANIMATION_BAR_HEIGHT),
+            egui::Sense::hover(),
+        );
+        let response = ui.put(
+            rect,
+            egui::DragValue::new(value)
+                .range(range)
+                .speed(1.0),
+        );
 
         // Restore visuals
         *ui.visuals_mut() = old_visuals;

--- a/crates/nodebox-gui/src/animation_bar.rs
+++ b/crates/nodebox-gui/src/animation_bar.rs
@@ -295,8 +295,9 @@ impl AnimationBar {
     /// Styled DragValue that follows the style guide.
     /// Uses SLATE_800 for subtle elevation against SLATE_900 bar background.
     fn styled_drag_value(ui: &mut egui::Ui, value: &mut i32, range: std::ops::RangeInclusive<i32>, width: f32) -> egui::Response {
-        // Override visuals for this widget - use SLATE_800 for subtle elevation
+        // Override visuals and spacing for this widget
         let old_visuals = ui.visuals().clone();
+        let old_spacing = ui.spacing().clone();
 
         // All states: no borders, sharp corners, appropriate fill
         ui.visuals_mut().widgets.inactive.bg_fill = theme::SLATE_800;
@@ -304,23 +305,30 @@ impl AnimationBar {
         ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::NONE;
         ui.visuals_mut().widgets.inactive.fg_stroke = egui::Stroke::new(1.0, theme::TEXT_DEFAULT);
         ui.visuals_mut().widgets.inactive.rounding = egui::Rounding::ZERO;
+        ui.visuals_mut().widgets.inactive.expansion = 0.0;
 
         ui.visuals_mut().widgets.hovered.bg_fill = theme::SLATE_700;
         ui.visuals_mut().widgets.hovered.weak_bg_fill = theme::SLATE_700;
         ui.visuals_mut().widgets.hovered.bg_stroke = egui::Stroke::NONE;
         ui.visuals_mut().widgets.hovered.fg_stroke = egui::Stroke::new(1.0, theme::TEXT_STRONG);
         ui.visuals_mut().widgets.hovered.rounding = egui::Rounding::ZERO;
+        ui.visuals_mut().widgets.hovered.expansion = 0.0;
 
         ui.visuals_mut().widgets.active.bg_fill = theme::SLATE_700;
         ui.visuals_mut().widgets.active.weak_bg_fill = theme::SLATE_700;
         ui.visuals_mut().widgets.active.bg_stroke = egui::Stroke::NONE;
         ui.visuals_mut().widgets.active.fg_stroke = egui::Stroke::new(1.0, theme::TEXT_STRONG);
         ui.visuals_mut().widgets.active.rounding = egui::Rounding::ZERO;
+        ui.visuals_mut().widgets.active.expansion = 0.0;
 
         ui.visuals_mut().widgets.noninteractive.bg_fill = theme::SLATE_800;
         ui.visuals_mut().widgets.noninteractive.weak_bg_fill = theme::SLATE_800;
         ui.visuals_mut().widgets.noninteractive.bg_stroke = egui::Stroke::NONE;
         ui.visuals_mut().widgets.noninteractive.rounding = egui::Rounding::ZERO;
+        ui.visuals_mut().widgets.noninteractive.expansion = 0.0;
+
+        // Use consistent padding for button and text edit modes
+        ui.spacing_mut().button_padding = egui::vec2(4.0, 2.0);
 
         // Allocate exact size and place widget inside to prevent any shifting
         let (rect, _) = ui.allocate_exact_size(
@@ -334,8 +342,9 @@ impl AnimationBar {
                 .speed(1.0),
         );
 
-        // Restore visuals
+        // Restore visuals and spacing
         *ui.visuals_mut() = old_visuals;
+        *ui.spacing_mut() = old_spacing;
 
         response
     }

--- a/crates/nodebox-gui/src/animation_bar.rs
+++ b/crates/nodebox-gui/src/animation_bar.rs
@@ -293,21 +293,34 @@ impl AnimationBar {
     }
 
     /// Styled DragValue that follows the style guide.
+    /// Uses SLATE_800 for subtle elevation against SLATE_900 bar background.
     fn styled_drag_value(ui: &mut egui::Ui, value: &mut i32, range: std::ops::RangeInclusive<i32>) -> egui::Response {
-        // Override visuals for this widget
+        // Override visuals for this widget - use SLATE_800 for subtle elevation
         let old_visuals = ui.visuals().clone();
 
-        ui.visuals_mut().widgets.inactive.bg_fill = theme::TEXT_EDIT_BG;
+        // All states: no borders, sharp corners, appropriate fill
+        ui.visuals_mut().widgets.inactive.bg_fill = theme::SLATE_800;
+        ui.visuals_mut().widgets.inactive.weak_bg_fill = theme::SLATE_800;
         ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::NONE;
+        ui.visuals_mut().widgets.inactive.fg_stroke = egui::Stroke::new(1.0, theme::TEXT_DEFAULT);
         ui.visuals_mut().widgets.inactive.rounding = egui::Rounding::ZERO;
 
-        ui.visuals_mut().widgets.hovered.bg_fill = theme::HOVER_BG;
+        ui.visuals_mut().widgets.hovered.bg_fill = theme::SLATE_700;
+        ui.visuals_mut().widgets.hovered.weak_bg_fill = theme::SLATE_700;
         ui.visuals_mut().widgets.hovered.bg_stroke = egui::Stroke::NONE;
+        ui.visuals_mut().widgets.hovered.fg_stroke = egui::Stroke::new(1.0, theme::TEXT_STRONG);
         ui.visuals_mut().widgets.hovered.rounding = egui::Rounding::ZERO;
 
-        ui.visuals_mut().widgets.active.bg_fill = theme::WIDGET_ACTIVE_BG;
+        ui.visuals_mut().widgets.active.bg_fill = theme::SLATE_700;
+        ui.visuals_mut().widgets.active.weak_bg_fill = theme::SLATE_700;
         ui.visuals_mut().widgets.active.bg_stroke = egui::Stroke::NONE;
+        ui.visuals_mut().widgets.active.fg_stroke = egui::Stroke::new(1.0, theme::TEXT_STRONG);
         ui.visuals_mut().widgets.active.rounding = egui::Rounding::ZERO;
+
+        ui.visuals_mut().widgets.noninteractive.bg_fill = theme::SLATE_800;
+        ui.visuals_mut().widgets.noninteractive.weak_bg_fill = theme::SLATE_800;
+        ui.visuals_mut().widgets.noninteractive.bg_stroke = egui::Stroke::NONE;
+        ui.visuals_mut().widgets.noninteractive.rounding = egui::Rounding::ZERO;
 
         let response = ui.add(
             egui::DragValue::new(value)
@@ -326,17 +339,25 @@ impl AnimationBar {
         // Override visuals for this widget
         let old_visuals = ui.visuals().clone();
 
-        ui.visuals_mut().widgets.inactive.bg_fill = theme::TEXT_EDIT_BG;
+        ui.visuals_mut().widgets.inactive.bg_fill = theme::SLATE_800;
+        ui.visuals_mut().widgets.inactive.weak_bg_fill = theme::SLATE_800;
         ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::NONE;
         ui.visuals_mut().widgets.inactive.rounding = egui::Rounding::ZERO;
 
-        ui.visuals_mut().widgets.hovered.bg_fill = theme::HOVER_BG;
+        ui.visuals_mut().widgets.hovered.bg_fill = theme::SLATE_700;
+        ui.visuals_mut().widgets.hovered.weak_bg_fill = theme::SLATE_700;
         ui.visuals_mut().widgets.hovered.bg_stroke = egui::Stroke::NONE;
         ui.visuals_mut().widgets.hovered.rounding = egui::Rounding::ZERO;
 
-        ui.visuals_mut().widgets.active.bg_fill = theme::WIDGET_ACTIVE_BG;
+        ui.visuals_mut().widgets.active.bg_fill = theme::SLATE_700;
+        ui.visuals_mut().widgets.active.weak_bg_fill = theme::SLATE_700;
         ui.visuals_mut().widgets.active.bg_stroke = egui::Stroke::NONE;
         ui.visuals_mut().widgets.active.rounding = egui::Rounding::ZERO;
+
+        ui.visuals_mut().widgets.noninteractive.bg_fill = theme::SLATE_800;
+        ui.visuals_mut().widgets.noninteractive.weak_bg_fill = theme::SLATE_800;
+        ui.visuals_mut().widgets.noninteractive.bg_stroke = egui::Stroke::NONE;
+        ui.visuals_mut().widgets.noninteractive.rounding = egui::Rounding::ZERO;
 
         let response = ui.checkbox(checked, "");
 

--- a/crates/nodebox-gui/src/animation_bar.rs
+++ b/crates/nodebox-gui/src/animation_bar.rs
@@ -251,11 +251,7 @@ impl AnimationBar {
                     .size(theme::FONT_SIZE_SMALL),
             );
             let mut frame = self.frame as i32;
-            let frame_response = ui.add(
-                egui::DragValue::new(&mut frame)
-                    .range(self.start_frame as i32..=self.end_frame as i32)
-                    .speed(1.0),
-            );
+            let frame_response = Self::styled_drag_value(ui, &mut frame, self.start_frame as i32..=self.end_frame as i32);
             if frame_response.changed() {
                 self.frame = frame as u32;
                 event = AnimationEvent::FrameChanged(self.frame as f64);
@@ -276,11 +272,7 @@ impl AnimationBar {
                     .size(theme::FONT_SIZE_SMALL),
             );
             let mut fps = self.fps as i32;
-            let fps_response = ui.add(
-                egui::DragValue::new(&mut fps)
-                    .range(1..=120)
-                    .speed(1.0),
-            );
+            let fps_response = Self::styled_drag_value(ui, &mut fps, 1..=120);
             if fps_response.changed() {
                 self.fps = fps as u32;
                 event = AnimationEvent::FpsChanged(self.fps);
@@ -289,7 +281,7 @@ impl AnimationBar {
             ui.add_space(theme::PADDING);
 
             // Loop toggle
-            ui.checkbox(&mut self.loop_enabled, "");
+            Self::styled_checkbox(ui, &mut self.loop_enabled);
             ui.label(
                 egui::RichText::new("Loop")
                     .color(if self.loop_enabled { theme::TEXT_DEFAULT } else { theme::TEXT_SUBDUED })
@@ -298,6 +290,60 @@ impl AnimationBar {
         });
 
         event
+    }
+
+    /// Styled DragValue that follows the style guide.
+    fn styled_drag_value(ui: &mut egui::Ui, value: &mut i32, range: std::ops::RangeInclusive<i32>) -> egui::Response {
+        // Override visuals for this widget
+        let old_visuals = ui.visuals().clone();
+
+        ui.visuals_mut().widgets.inactive.bg_fill = theme::TEXT_EDIT_BG;
+        ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::NONE;
+        ui.visuals_mut().widgets.inactive.rounding = egui::Rounding::ZERO;
+
+        ui.visuals_mut().widgets.hovered.bg_fill = theme::HOVER_BG;
+        ui.visuals_mut().widgets.hovered.bg_stroke = egui::Stroke::NONE;
+        ui.visuals_mut().widgets.hovered.rounding = egui::Rounding::ZERO;
+
+        ui.visuals_mut().widgets.active.bg_fill = theme::WIDGET_ACTIVE_BG;
+        ui.visuals_mut().widgets.active.bg_stroke = egui::Stroke::NONE;
+        ui.visuals_mut().widgets.active.rounding = egui::Rounding::ZERO;
+
+        let response = ui.add(
+            egui::DragValue::new(value)
+                .range(range)
+                .speed(1.0),
+        );
+
+        // Restore visuals
+        *ui.visuals_mut() = old_visuals;
+
+        response
+    }
+
+    /// Styled checkbox that follows the style guide.
+    fn styled_checkbox(ui: &mut egui::Ui, checked: &mut bool) -> egui::Response {
+        // Override visuals for this widget
+        let old_visuals = ui.visuals().clone();
+
+        ui.visuals_mut().widgets.inactive.bg_fill = theme::TEXT_EDIT_BG;
+        ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::NONE;
+        ui.visuals_mut().widgets.inactive.rounding = egui::Rounding::ZERO;
+
+        ui.visuals_mut().widgets.hovered.bg_fill = theme::HOVER_BG;
+        ui.visuals_mut().widgets.hovered.bg_stroke = egui::Stroke::NONE;
+        ui.visuals_mut().widgets.hovered.rounding = egui::Rounding::ZERO;
+
+        ui.visuals_mut().widgets.active.bg_fill = theme::WIDGET_ACTIVE_BG;
+        ui.visuals_mut().widgets.active.bg_stroke = egui::Stroke::NONE;
+        ui.visuals_mut().widgets.active.rounding = egui::Rounding::ZERO;
+
+        let response = ui.checkbox(checked, "");
+
+        // Restore visuals
+        *ui.visuals_mut() = old_visuals;
+
+        response
     }
 
     /// Custom icon button with transparent background and hover effect.

--- a/crates/nodebox-gui/src/animation_bar.rs
+++ b/crates/nodebox-gui/src/animation_bar.rs
@@ -322,12 +322,17 @@ impl AnimationBar {
         ui.visuals_mut().widgets.noninteractive.bg_stroke = egui::Stroke::NONE;
         ui.visuals_mut().widgets.noninteractive.rounding = egui::Rounding::ZERO;
 
-        let response = ui.add_sized(
-            [width, theme::ANIMATION_BAR_HEIGHT],
-            egui::DragValue::new(value)
-                .range(range)
-                .speed(1.0),
-        );
+        // Use a fixed-size scope to prevent expansion during text editing
+        let response = ui.scope(|ui| {
+            ui.set_width(width);
+            ui.set_height(theme::ANIMATION_BAR_HEIGHT);
+            ui.add(
+                egui::DragValue::new(value)
+                    .range(range)
+                    .speed(1.0)
+                    .update_while_editing(false),
+            )
+        }).inner;
 
         // Restore visuals
         *ui.visuals_mut() = old_visuals;

--- a/crates/nodebox-gui/src/animation_bar.rs
+++ b/crates/nodebox-gui/src/animation_bar.rs
@@ -187,7 +187,7 @@ impl AnimationBar {
 
         // Clean background - seamless with panel
         let rect = ui.available_rect_before_wrap();
-        ui.painter().rect_filled(rect, 0.0, theme::PANEL_BG);
+        ui.painter().rect_filled(rect, 0.0, theme::ANIMATION_BAR_BACKGROUND);
 
         // Subtle top border only
         ui.painter().line_segment(
@@ -199,15 +199,15 @@ impl AnimationBar {
         );
 
         ui.horizontal(|ui| {
-            ui.add_space(theme::PADDING);
+            ui.add_space(theme::PADDING_SMALL);
 
-            // Compact playback controls - smaller buttons
-            if ui.small_button("⏮").on_hover_text("Rewind").clicked() {
+            // Playback control buttons - flush with bar height, transparent background
+            if self.icon_button(ui, "⏮", "Rewind") {
                 self.rewind();
                 event = AnimationEvent::Rewind;
             }
 
-            if ui.small_button("⏪").on_hover_text("Step backward").clicked() {
+            if self.icon_button(ui, "⏪", "Step backward") {
                 self.step_backward();
                 event = AnimationEvent::StepBack;
             }
@@ -217,7 +217,7 @@ impl AnimationBar {
             } else {
                 ("▶", "Play")
             };
-            if ui.small_button(play_icon).on_hover_text(play_tooltip).clicked() {
+            if self.icon_button(ui, play_icon, play_tooltip) {
                 if self.is_playing() {
                     self.pause();
                     event = AnimationEvent::Pause;
@@ -227,28 +227,28 @@ impl AnimationBar {
                 }
             }
 
-            if ui.small_button("⏩").on_hover_text("Step forward").clicked() {
+            if self.icon_button(ui, "⏩", "Step forward") {
                 self.step_forward();
                 event = AnimationEvent::StepForward;
             }
 
-            if ui.small_button("⏭").on_hover_text("Go to end").clicked() {
+            if self.icon_button(ui, "⏭", "Go to end") {
                 self.go_to_end();
                 event = AnimationEvent::GoToEnd;
             }
 
-            if ui.small_button("⏹").on_hover_text("Stop").clicked() {
+            if self.icon_button(ui, "⏹", "Stop") {
                 self.stop();
                 event = AnimationEvent::Stop;
             }
 
             ui.add_space(theme::PADDING);
 
-            // Frame counter - more compact
+            // Frame counter
             ui.label(
                 egui::RichText::new("Frame")
                     .color(theme::TEXT_SUBDUED)
-                    .size(10.0),
+                    .size(theme::FONT_SIZE_SMALL),
             );
             let mut frame = self.frame as i32;
             let frame_response = ui.add(
@@ -264,16 +264,16 @@ impl AnimationBar {
             ui.label(
                 egui::RichText::new(format!("/{}", self.end_frame))
                     .color(theme::TEXT_DISABLED)
-                    .size(10.0),
+                    .size(theme::FONT_SIZE_SMALL),
             );
 
             ui.add_space(theme::PADDING);
 
-            // FPS control - more compact
+            // FPS control
             ui.label(
                 egui::RichText::new("FPS")
                     .color(theme::TEXT_SUBDUED)
-                    .size(10.0),
+                    .size(theme::FONT_SIZE_SMALL),
             );
             let mut fps = self.fps as i32;
             let fps_response = ui.add(
@@ -288,15 +288,50 @@ impl AnimationBar {
 
             ui.add_space(theme::PADDING);
 
-            // Loop toggle - subtle checkbox
+            // Loop toggle
             ui.checkbox(&mut self.loop_enabled, "");
             ui.label(
                 egui::RichText::new("Loop")
                     .color(if self.loop_enabled { theme::TEXT_DEFAULT } else { theme::TEXT_SUBDUED })
-                    .size(10.0),
+                    .size(theme::FONT_SIZE_SMALL),
             );
         });
 
         event
+    }
+
+    /// Custom icon button with transparent background and hover effect.
+    /// Returns true if clicked.
+    fn icon_button(&self, ui: &mut egui::Ui, icon: &str, tooltip: &str) -> bool {
+        let button_size = egui::vec2(theme::ANIMATION_BAR_HEIGHT, theme::ANIMATION_BAR_HEIGHT);
+        let (rect, response) = ui.allocate_exact_size(button_size, egui::Sense::click());
+
+        if ui.is_rect_visible(rect) {
+            // Transparent background, lighter on hover
+            let bg_color = if response.hovered() {
+                theme::SLATE_800
+            } else {
+                egui::Color32::TRANSPARENT
+            };
+
+            ui.painter().rect_filled(rect, 0.0, bg_color);
+
+            // Icon color - brighter on hover
+            let text_color = if response.hovered() {
+                theme::TEXT_STRONG
+            } else {
+                theme::TEXT_DEFAULT
+            };
+
+            ui.painter().text(
+                rect.center(),
+                egui::Align2::CENTER_CENTER,
+                icon,
+                egui::FontId::proportional(theme::FONT_SIZE_BASE),
+                text_color,
+            );
+        }
+
+        response.on_hover_text(tooltip).clicked()
     }
 }

--- a/crates/nodebox-gui/src/network_view.rs
+++ b/crates/nodebox-gui/src/network_view.rs
@@ -72,8 +72,12 @@ impl Default for NetworkView {
 impl NetworkView {
     /// Create a new network view.
     pub fn new() -> Self {
+        // Start with an initial pan offset so the first grid lines don't hug the edges.
+        let mut pan_zoom = PanZoom::with_zoom_limits(0.25, 4.0);
+        pan_zoom.pan = Vec2::new(-1.0, -1.0);
+
         Self {
-            pan_zoom: PanZoom::with_zoom_limits(0.25, 4.0),
+            pan_zoom,
             selected: HashSet::new(),
             is_dragging_selection: false,
             creating_connection: None,


### PR DESCRIPTION
## Summary

- Add initial pan offset to network view so grid lines don't hug edges
- Restyle animation bar to follow the Linear-inspired style guide:
  - Icon buttons with transparent background, hover effect (SLATE_800)
  - Input fields use SLATE_800 background (subtle elevation from SLATE_900 bar)
  - Fixed width for Frame/FPS fields (40px, fits 3+ digits)
  - No borders, sharp corners throughout
  - Proper hover states
- Document egui DragValue fixed-size pattern in AGENTS.md

## Test plan

- [ ] Run `cargo run -p nodebox-gui` and verify animation bar appearance
- [ ] Click Frame/FPS fields - should not shift when entering edit mode
- [ ] Hover over icon buttons - should show subtle lighter background
- [ ] Verify all elements match the style guide colors

🤖 Generated with [Claude Code](https://claude.ai/code)