### PR TITLE
Add Visual/Data segmented control to Viewer pane header

### DIFF
--- a/crates/nodebox-gui/src/components.rs
+++ b/crates/nodebox-gui/src/components.rs
@@ -269,10 +269,14 @@ pub fn header_segmented_control(
     let width1 = galley1.size().x + padding_h * 2.0;
     let total_width = width0 + width1;
 
-    // Draw background flush with header (no rounded corners)
+    // Draw background flush with header content area (respecting 1px borders)
+    let content_top = header_rect.top() + 1.0;
+    let content_bottom = header_rect.bottom() - 1.0;
+    let content_height = content_bottom - content_top;
+
     let bg_rect = Rect::from_min_size(
-        egui::pos2(x, header_rect.top()),
-        egui::vec2(total_width, header_rect.height()),
+        egui::pos2(x, content_top),
+        egui::vec2(total_width, content_height),
     );
     ui.painter().rect_filled(
         bg_rect,
@@ -280,12 +284,12 @@ pub fn header_segmented_control(
         theme::SLATE_700,
     );
 
-    // Draw the selected segment highlight (flush with header)
+    // Draw the selected segment highlight
     let selected_x = if selected == 0 { x } else { x + width0 };
     let selected_width = if selected == 0 { width0 } else { width1 };
     let selected_rect = Rect::from_min_size(
-        egui::pos2(selected_x, header_rect.top()),
-        egui::vec2(selected_width, header_rect.height()),
+        egui::pos2(selected_x, content_top),
+        egui::vec2(selected_width, content_height),
     );
     ui.painter().rect_filled(
         selected_rect,

--- a/crates/nodebox-gui/src/components.rs
+++ b/crates/nodebox-gui/src/components.rs
@@ -251,7 +251,6 @@ pub fn header_segmented_control(
 ) -> (Option<usize>, f32) {
     let font = egui::FontId::proportional(11.0);
     let padding_h = 6.0; // Horizontal padding inside each segment
-    let segment_height = 16.0;
     let y_center = header_rect.center().y;
 
     // Calculate widths for each segment
@@ -270,27 +269,27 @@ pub fn header_segmented_control(
     let width1 = galley1.size().x + padding_h * 2.0;
     let total_width = width0 + width1;
 
-    // Draw background pill for the entire control
-    let bg_rect = Rect::from_center_size(
-        egui::pos2(x + total_width / 2.0, y_center),
-        egui::vec2(total_width, segment_height),
+    // Draw background flush with header (no rounded corners)
+    let bg_rect = Rect::from_min_size(
+        egui::pos2(x, header_rect.top()),
+        egui::vec2(total_width, header_rect.height()),
     );
     ui.painter().rect_filled(
         bg_rect,
-        theme::CORNER_RADIUS_SMALL,
+        0.0,
         theme::SLATE_700,
     );
 
-    // Draw the selected segment highlight
+    // Draw the selected segment highlight (flush with header)
     let selected_x = if selected == 0 { x } else { x + width0 };
     let selected_width = if selected == 0 { width0 } else { width1 };
-    let selected_rect = Rect::from_center_size(
-        egui::pos2(selected_x + selected_width / 2.0, y_center),
-        egui::vec2(selected_width, segment_height),
+    let selected_rect = Rect::from_min_size(
+        egui::pos2(selected_x, header_rect.top()),
+        egui::vec2(selected_width, header_rect.height()),
     );
     ui.painter().rect_filled(
         selected_rect,
-        theme::CORNER_RADIUS_SMALL,
+        0.0,
         theme::SLATE_500,
     );
 

--- a/crates/nodebox-gui/src/components.rs
+++ b/crates/nodebox-gui/src/components.rs
@@ -269,22 +269,12 @@ pub fn header_segmented_control(
     let width1 = galley1.size().x + padding_h * 2.0;
     let total_width = width0 + width1;
 
-    // Draw background flush with header content area (respecting 1px borders)
+    // Content area respecting 1px borders
     let content_top = header_rect.top() + 1.0;
     let content_bottom = header_rect.bottom() - 1.0;
     let content_height = content_bottom - content_top;
 
-    let bg_rect = Rect::from_min_size(
-        egui::pos2(x, content_top),
-        egui::vec2(total_width, content_height),
-    );
-    ui.painter().rect_filled(
-        bg_rect,
-        0.0,
-        theme::SLATE_700,
-    );
-
-    // Draw the selected segment highlight
+    // Only draw the selected segment (unselected is transparent/header bg)
     let selected_x = if selected == 0 { x } else { x + width0 };
     let selected_width = if selected == 0 { width0 } else { width1 };
     let selected_rect = Rect::from_min_size(
@@ -294,7 +284,7 @@ pub fn header_segmented_control(
     ui.painter().rect_filled(
         selected_rect,
         0.0,
-        theme::SLATE_500,
+        theme::SLATE_700,
     );
 
     // Create interaction rects and draw labels

--- a/crates/nodebox-gui/src/components.rs
+++ b/crates/nodebox-gui/src/components.rs
@@ -237,3 +237,110 @@ pub fn header_separator(ui: &mut egui::Ui, header_rect: Rect, x: f32) -> f32 {
     );
     x + theme::PADDING
 }
+
+/// Draw a segmented control with two options in a header.
+///
+/// Returns (clicked_index, new_x) where clicked_index is Some(0) or Some(1) if clicked,
+/// or None if nothing was clicked.
+pub fn header_segmented_control(
+    ui: &mut egui::Ui,
+    header_rect: Rect,
+    x: f32,
+    labels: [&str; 2],
+    selected: usize,
+) -> (Option<usize>, f32) {
+    let font = egui::FontId::proportional(11.0);
+    let padding_h = 6.0; // Horizontal padding inside each segment
+    let segment_height = 16.0;
+    let y_center = header_rect.center().y;
+
+    // Calculate widths for each segment
+    let galley0 = ui.painter().layout_no_wrap(
+        labels[0].to_string(),
+        font.clone(),
+        theme::TEXT_STRONG,
+    );
+    let galley1 = ui.painter().layout_no_wrap(
+        labels[1].to_string(),
+        font.clone(),
+        theme::TEXT_STRONG,
+    );
+
+    let width0 = galley0.size().x + padding_h * 2.0;
+    let width1 = galley1.size().x + padding_h * 2.0;
+    let total_width = width0 + width1;
+
+    // Draw background pill for the entire control
+    let bg_rect = Rect::from_center_size(
+        egui::pos2(x + total_width / 2.0, y_center),
+        egui::vec2(total_width, segment_height),
+    );
+    ui.painter().rect_filled(
+        bg_rect,
+        theme::CORNER_RADIUS_SMALL,
+        theme::SLATE_700,
+    );
+
+    // Draw the selected segment highlight
+    let selected_x = if selected == 0 { x } else { x + width0 };
+    let selected_width = if selected == 0 { width0 } else { width1 };
+    let selected_rect = Rect::from_center_size(
+        egui::pos2(selected_x + selected_width / 2.0, y_center),
+        egui::vec2(selected_width, segment_height),
+    );
+    ui.painter().rect_filled(
+        selected_rect,
+        theme::CORNER_RADIUS_SMALL,
+        theme::SLATE_500,
+    );
+
+    // Create interaction rects and draw labels
+    let rect0 = Rect::from_min_size(
+        egui::pos2(x, header_rect.top()),
+        egui::vec2(width0, header_rect.height()),
+    );
+    let rect1 = Rect::from_min_size(
+        egui::pos2(x + width0, header_rect.top()),
+        egui::vec2(width1, header_rect.height()),
+    );
+
+    let response0 = ui.interact(
+        rect0,
+        ui.id().with(format!("seg_{}", labels[0])),
+        egui::Sense::click(),
+    );
+    let response1 = ui.interact(
+        rect1,
+        ui.id().with(format!("seg_{}", labels[1])),
+        egui::Sense::click(),
+    );
+
+    // Draw text labels
+    let color0 = if selected == 0 { theme::TEXT_STRONG } else { theme::TEXT_SUBDUED };
+    let color1 = if selected == 1 { theme::TEXT_STRONG } else { theme::TEXT_SUBDUED };
+
+    ui.painter().text(
+        egui::pos2(x + width0 / 2.0, y_center),
+        egui::Align2::CENTER_CENTER,
+        labels[0],
+        font.clone(),
+        color0,
+    );
+    ui.painter().text(
+        egui::pos2(x + width0 + width1 / 2.0, y_center),
+        egui::Align2::CENTER_CENTER,
+        labels[1],
+        font,
+        color1,
+    );
+
+    let clicked = if response0.clicked() {
+        Some(0)
+    } else if response1.clicked() {
+        Some(1)
+    } else {
+        None
+    };
+
+    (clicked, x + total_width)
+}

--- a/crates/nodebox-gui/src/viewer_pane.rs
+++ b/crates/nodebox-gui/src/viewer_pane.rs
@@ -286,18 +286,19 @@ impl ViewerPane {
         // Draw header with "VIEWER" title and separator
         let (header_rect, mut x) = components::draw_pane_header_with_title(ui, "Viewer");
 
-        // Tab buttons after the separator
-        let (clicked, new_x) = components::header_tab_button(
+        // Segmented control for Visual/Data toggle
+        let selected_index = if self.current_tab == ViewerTab::Viewer { 0 } else { 1 };
+        let (clicked_index, new_x) = components::header_segmented_control(
             ui,
             header_rect,
             x,
-            "Data",
-            self.current_tab == ViewerTab::Data,
+            ["Visual", "Data"],
+            selected_index,
         );
-        if clicked {
-            self.current_tab = ViewerTab::Data;
+        if let Some(index) = clicked_index {
+            self.current_tab = if index == 0 { ViewerTab::Viewer } else { ViewerTab::Data };
         }
-        x = new_x;
+        x = new_x + theme::PADDING_XL; // 16px spacing after segmented control
 
         let (clicked, new_x) = components::header_tab_button(
             ui,


### PR DESCRIPTION
## Summary

- Add a segmented control in the Viewer pane header to switch between Visual and Data modes
- Visual mode is selected by default
- The control is flush with the header, respecting the 1px top and bottom borders
- Selected segment has a subtle highlight (SLATE_700), unselected is transparent
- 16px spacing between the segmented control and subsequent header controls

## Test plan

- [ ] Verify the segmented control appears in the Viewer pane header
- [ ] Click "Data" to switch to data view
- [ ] Click "Visual" to switch back to visual view
- [ ] Confirm the selected state is visually highlighted

🤖 Generated with [Claude Code](https://claude.ai/claude-code)