### PR TITLE
Add SVG import node with quadratic bezier support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,6 +642,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,6 +1097,12 @@ name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "directories"
@@ -1612,6 +1624,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
 name = "float-ord"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1667,6 +1685,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1e4d2d0cf79d38430cc9dc9aadec84774bff2e1ba30ae2bf6c16cfce9385a23"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e32eac81c1135c1df01d4e6d4233c47ba11f6a6d07f33e0bba09d18797077770"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser 0.21.1",
 ]
 
 [[package]]
@@ -2395,6 +2436,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "imagesize"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "029d73f573d8e8d63e6d5020011d3255b28c3ba85d6cf870a07184ed23de9284"
+
+[[package]]
 name = "imgref"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2554,6 +2601,17 @@ dependencies = [
  "accesskit",
  "accesskit_consumer 0.30.1",
  "parking_lot",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec",
 ]
 
 [[package]]
@@ -2947,6 +3005,8 @@ dependencies = [
  "nodebox-core",
  "proptest",
  "rayon",
+ "tempfile",
+ "usvg",
 ]
 
 [[package]]
@@ -3395,7 +3455,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
 dependencies = [
- "ttf-parser",
+ "ttf-parser 0.25.1",
 ]
 
 [[package]]
@@ -3490,7 +3550,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2b6aadb221872732e87d465213e9be5af2849b0e8cc5300a8ba98fffa2e00a"
 dependencies = [
  "color",
- "kurbo",
+ "kurbo 0.13.0",
  "linebender_resource_handle",
  "smallvec",
 ]
@@ -3544,6 +3604,12 @@ dependencies = [
  "siphasher",
  "unicase",
 ]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
@@ -4166,6 +4232,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
 
 [[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4228,6 +4300,22 @@ dependencies = [
  "quick-error 1.2.3",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "rustybuzz"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfb9cf8877777222e4a3bc7eb247e398b56baba500c38c1c46842431adc8b55c"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytemuck",
+ "smallvec",
+ "ttf-parser 0.21.1",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
 ]
 
 [[package]]
@@ -4365,6 +4453,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4499,12 +4596,25 @@ name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
 
 [[package]]
 name = "svg_fmt"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0193cc4331cfd2f3d2011ef287590868599a2f33c3e69bc22c1a3d3acf9e02fb"
+
+[[package]]
+name = "svgtypes"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
+dependencies = [
+ "kurbo 0.11.3",
+ "siphasher",
+]
 
 [[package]]
 name = "syn"
@@ -4670,6 +4780,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "toml"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4778,6 +4903,12 @@ dependencies = [
 
 [[package]]
 name = "ttf-parser"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
+
+[[package]]
+name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
@@ -4815,16 +4946,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-bidi-mirroring"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cb788ffebc92c5948d0e997106233eeb1d8b9512f93f41651f52b6c5f5af86"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df77b101bcc4ea3d78dafc5ad7e4f58ceffe0b2b16bf446aeb50b6cb4157656"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
 name = "unicode-width"
@@ -4856,6 +5023,33 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "usvg"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84ea542ae85c715f07b082438a4231c3760539d902e11d093847a0b22963032"
+dependencies = [
+ "base64",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize",
+ "kurbo 0.11.3",
+ "log",
+ "pico-args",
+ "roxmltree",
+ "rustybuzz",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
+]
 
 [[package]]
 name = "utf8_iter"
@@ -6042,6 +6236,12 @@ name = "xml-rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "y4m"

--- a/crates/nodebox-core/src/geometry/contour.rs
+++ b/crates/nodebox-core/src/geometry/contour.rs
@@ -75,6 +75,12 @@ impl Contour {
         self.points.push(PathPoint::curve_to(x3, y3));
     }
 
+    /// Adds a quadratic Bezier curve to (x2, y2) with control point (x1, y1).
+    pub fn quad_to(&mut self, cx: f64, cy: f64, x: f64, y: f64) {
+        self.points.push(PathPoint::quad_data(cx, cy));
+        self.points.push(PathPoint::quad_to(x, y));
+    }
+
     /// Closes this contour.
     pub fn close(&mut self) {
         self.closed = true;
@@ -131,7 +137,8 @@ impl Contour {
 
     /// Returns the segments of this contour.
     ///
-    /// A segment is either a line or a cubic bezier curve between two on-curve points.
+    /// A segment is either a line, a cubic bezier curve, or a quadratic bezier curve
+    /// between two on-curve points.
     pub fn segments(&self) -> Vec<Segment> {
         if self.points.is_empty() {
             return Vec::new();
@@ -155,6 +162,17 @@ impl Contour {
                         let end = self.points[i + 3].point;
                         segments.push(Segment::Cubic { start, ctrl1, ctrl2, end });
                         i += 3;
+                    } else {
+                        // Malformed curve, skip to end
+                        break;
+                    }
+                } else if next.point_type == PointType::QuadData {
+                    // This is a quadratic bezier: start, ctrl, end
+                    if i + 2 < self.points.len() {
+                        let ctrl = self.points[i + 1].point;
+                        let end = self.points[i + 2].point;
+                        segments.push(Segment::Quadratic { start, ctrl, end });
+                        i += 2;
                     } else {
                         // Malformed curve, skip to end
                         break;
@@ -328,7 +346,7 @@ impl Contour {
     }
 }
 
-/// A segment of a contour - either a line or a cubic bezier curve.
+/// A segment of a contour - either a line, a cubic bezier curve, or a quadratic bezier curve.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Segment {
     /// A straight line segment.
@@ -338,6 +356,12 @@ pub enum Segment {
         start: Point,
         ctrl1: Point,
         ctrl2: Point,
+        end: Point,
+    },
+    /// A quadratic bezier curve segment.
+    Quadratic {
+        start: Point,
+        ctrl: Point,
         end: Point,
     },
 }
@@ -353,6 +377,9 @@ impl Segment {
             Segment::Cubic { start, ctrl1, ctrl2, end } => {
                 Self::cubic_bezier_point(*start, *ctrl1, *ctrl2, *end, t)
             }
+            Segment::Quadratic { start, ctrl, end } => {
+                Self::quadratic_bezier_point(*start, *ctrl, *end, t)
+            }
         }
     }
 
@@ -362,6 +389,9 @@ impl Segment {
             Segment::Line { start, end } => start.distance_to(*end),
             Segment::Cubic { start, ctrl1, ctrl2, end } => {
                 Self::cubic_bezier_length(*start, *ctrl1, *ctrl2, *end)
+            }
+            Segment::Quadratic { start, ctrl, end } => {
+                Self::quadratic_bezier_length(*start, *ctrl, *end)
             }
         }
     }
@@ -392,6 +422,34 @@ impl Segment {
         for i in 1..=Self::BEZIER_SUBDIVISIONS {
             let t = i as f64 / Self::BEZIER_SUBDIVISIONS as f64;
             let current = Self::cubic_bezier_point(p0, p1, p2, p3, t);
+            length += prev.distance_to(current);
+            prev = current;
+        }
+
+        length
+    }
+
+    /// Evaluates a quadratic bezier curve using De Casteljau's algorithm.
+    ///
+    /// This is numerically stable and works for any t in [0, 1].
+    fn quadratic_bezier_point(p0: Point, p1: Point, p2: Point, t: f64) -> Point {
+        // De Casteljau's algorithm for quadratic bezier
+        // Level 1
+        let q0 = p0.lerp(p1, t);
+        let q1 = p1.lerp(p2, t);
+
+        // Level 2 (final point)
+        q0.lerp(q1, t)
+    }
+
+    /// Approximates the arc length of a quadratic bezier using subdivision.
+    fn quadratic_bezier_length(p0: Point, p1: Point, p2: Point) -> f64 {
+        let mut length = 0.0;
+        let mut prev = p0;
+
+        for i in 1..=Self::BEZIER_SUBDIVISIONS {
+            let t = i as f64 / Self::BEZIER_SUBDIVISIONS as f64;
+            let current = Self::quadratic_bezier_point(p0, p1, p2, t);
             length += prev.distance_to(current);
             prev = current;
         }
@@ -971,5 +1029,160 @@ mod tests {
         let p = seg.point_at(0.5);
         assert!((p.x - 0.5).abs() < 0.01);
         assert!((p.y - 0.5).abs() < 0.01);
+    }
+
+    // ========================================================================
+    // Quadratic Bezier Tests
+    // ========================================================================
+
+    #[test]
+    fn test_contour_quad_to() {
+        let mut c = Contour::new();
+        c.move_to(0.0, 0.0);
+        c.quad_to(50.0, 100.0, 100.0, 0.0);
+
+        assert_eq!(c.len(), 3); // 1 move + 1 control + 1 quad-to
+        assert_eq!(c.point_count(), 2); // Only on-curve points
+    }
+
+    #[test]
+    fn test_quad_to_segment_detection() {
+        let mut c = Contour::new();
+        c.move_to(0.0, 0.0);
+        c.quad_to(50.0, 100.0, 100.0, 0.0);
+
+        let segments = c.segments();
+        assert_eq!(segments.len(), 1);
+        match &segments[0] {
+            Segment::Quadratic { start, ctrl, end } => {
+                assert_eq!(*start, Point::new(0.0, 0.0));
+                assert_eq!(*ctrl, Point::new(50.0, 100.0));
+                assert_eq!(*end, Point::new(100.0, 0.0));
+            }
+            _ => panic!("Expected Quadratic segment"),
+        }
+    }
+
+    #[test]
+    fn test_segment_quadratic_endpoints() {
+        let seg = Segment::Quadratic {
+            start: Point::new(0.0, 0.0),
+            ctrl: Point::new(50.0, 100.0),
+            end: Point::new(100.0, 0.0),
+        };
+
+        let p0 = seg.point_at(0.0);
+        let p1 = seg.point_at(1.0);
+
+        assert_eq!(p0, Point::new(0.0, 0.0));
+        assert_eq!(p1, Point::new(100.0, 0.0));
+    }
+
+    #[test]
+    fn test_segment_quadratic_midpoint() {
+        // Symmetric quadratic curve - midpoint should be at x=50
+        let seg = Segment::Quadratic {
+            start: Point::new(0.0, 0.0),
+            ctrl: Point::new(50.0, 100.0),
+            end: Point::new(100.0, 0.0),
+        };
+
+        let p_half = seg.point_at(0.5);
+        assert!((p_half.x - 50.0).abs() < 0.001);
+        // For quadratic: B(t) = (1-t)^2*P0 + 2*(1-t)*t*P1 + t^2*P2
+        // At t=0.5: 0.25*0 + 0.5*100 + 0.25*0 = 50 for Y
+        assert!((p_half.y - 50.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_segment_straight_quadratic_length() {
+        // A "straight" quadratic bezier
+        let seg = Segment::Quadratic {
+            start: Point::new(0.0, 0.0),
+            ctrl: Point::new(50.0, 0.0),
+            end: Point::new(100.0, 0.0),
+        };
+
+        // Length should be approximately 100
+        assert!((seg.length() - 100.0).abs() < 1.0);
+    }
+
+    #[test]
+    fn test_quadratic_point_at() {
+        let mut c = Contour::new();
+        c.move_to(0.0, 0.0);
+        c.quad_to(50.0, 100.0, 100.0, 0.0);
+
+        // At t=0, should be at start
+        let p0 = c.point_at(0.0);
+        assert!((p0.x - 0.0).abs() < 0.001);
+        assert!((p0.y - 0.0).abs() < 0.001);
+
+        // At t=1, should be at end
+        let p1 = c.point_at(1.0);
+        assert!((p1.x - 100.0).abs() < 0.001);
+        assert!((p1.y - 0.0).abs() < 0.001);
+
+        // At t=0.5, should be at peak of the curve
+        let p_half = c.point_at(0.5);
+        assert!((p_half.x - 50.0).abs() < 1.0);
+        assert!(p_half.y > 0.0); // Should be above the baseline
+    }
+
+    #[test]
+    fn test_quadratic_length() {
+        let mut c = Contour::new();
+        c.move_to(0.0, 0.0);
+        c.quad_to(50.0, 0.0, 100.0, 0.0);
+
+        // A straight quadratic should have length approximately 100
+        assert!((c.length() - 100.0).abs() < 1.0);
+    }
+
+    #[test]
+    fn test_quadratic_make_points() {
+        let mut c = Contour::new();
+        c.move_to(0.0, 0.0);
+        c.quad_to(50.0, 100.0, 100.0, 0.0);
+
+        let points = c.make_points(5);
+        assert_eq!(points.len(), 5);
+
+        // First and last points should be at endpoints
+        assert!((points[0].x - 0.0).abs() < 0.001);
+        assert!((points[4].x - 100.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_quadratic_resample() {
+        let mut c = Contour::new();
+        c.move_to(0.0, 0.0);
+        c.quad_to(50.0, 100.0, 100.0, 0.0);
+
+        let resampled = c.resample_by_amount(10);
+        assert_eq!(resampled.points.len(), 10);
+
+        // First and last points should match original endpoints
+        assert!((resampled.points[0].x() - 0.0).abs() < 0.001);
+        assert!((resampled.points[0].y() - 0.0).abs() < 0.001);
+        assert!((resampled.points[9].x() - 100.0).abs() < 0.001);
+        assert!((resampled.points[9].y() - 0.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_mixed_segments() {
+        // Test a contour with line, cubic, and quadratic segments
+        let mut c = Contour::new();
+        c.move_to(0.0, 0.0);
+        c.line_to(50.0, 0.0);                           // Line
+        c.quad_to(75.0, 50.0, 100.0, 0.0);              // Quadratic
+        c.curve_to(125.0, -50.0, 175.0, -50.0, 200.0, 0.0); // Cubic
+
+        let segments = c.segments();
+        assert_eq!(segments.len(), 3);
+
+        assert!(matches!(segments[0], Segment::Line { .. }));
+        assert!(matches!(segments[1], Segment::Quadratic { .. }));
+        assert!(matches!(segments[2], Segment::Cubic { .. }));
     }
 }

--- a/crates/nodebox-core/src/geometry/path.rs
+++ b/crates/nodebox-core/src/geometry/path.rs
@@ -99,6 +99,11 @@ impl Path {
         self.current_contour().curve_to(x1, y1, x2, y2, x3, y3);
     }
 
+    /// Adds a quadratic Bezier curve to the current contour.
+    pub fn quad_to(&mut self, cx: f64, cy: f64, x: f64, y: f64) {
+        self.current_contour().quad_to(cx, cy, x, y);
+    }
+
     /// Closes the current contour.
     pub fn close(&mut self) {
         if let Some(contour) = self.contours.last_mut() {

--- a/crates/nodebox-core/src/geometry/point.rs
+++ b/crates/nodebox-core/src/geometry/point.rs
@@ -166,19 +166,23 @@ pub enum PointType {
     CurveTo,
     /// This is a control point for a cubic Bezier curve (not on the curve itself).
     CurveData,
+    /// This is the endpoint of a quadratic Bezier curve.
+    QuadTo,
+    /// This is a control point for a quadratic Bezier curve (not on the curve itself).
+    QuadData,
 }
 
 impl PointType {
-    /// Returns true if this point is on the curve (LineTo or CurveTo).
+    /// Returns true if this point is on the curve (LineTo, CurveTo, or QuadTo).
     #[inline]
     pub fn is_on_curve(self) -> bool {
-        !matches!(self, PointType::CurveData)
+        matches!(self, PointType::LineTo | PointType::CurveTo | PointType::QuadTo)
     }
 
     /// Returns true if this point is off the curve (a control point).
     #[inline]
     pub fn is_off_curve(self) -> bool {
-        matches!(self, PointType::CurveData)
+        matches!(self, PointType::CurveData | PointType::QuadData)
     }
 }
 
@@ -218,6 +222,18 @@ impl PathPoint {
     #[inline]
     pub const fn curve_data(x: f64, y: f64) -> Self {
         PathPoint::new(x, y, PointType::CurveData)
+    }
+
+    /// Creates a QuadTo path point (endpoint of a quadratic Bezier curve).
+    #[inline]
+    pub const fn quad_to(x: f64, y: f64) -> Self {
+        PathPoint::new(x, y, PointType::QuadTo)
+    }
+
+    /// Creates a QuadData path point (control point for quadratic Bezier).
+    #[inline]
+    pub const fn quad_data(x: f64, y: f64) -> Self {
+        PathPoint::new(x, y, PointType::QuadData)
     }
 
     /// Returns the x coordinate.
@@ -354,8 +370,11 @@ mod tests {
     fn test_point_type() {
         assert!(PointType::LineTo.is_on_curve());
         assert!(PointType::CurveTo.is_on_curve());
+        assert!(PointType::QuadTo.is_on_curve());
         assert!(!PointType::CurveData.is_on_curve());
+        assert!(!PointType::QuadData.is_on_curve());
         assert!(PointType::CurveData.is_off_curve());
+        assert!(PointType::QuadData.is_off_curve());
     }
 
     #[test]
@@ -370,6 +389,14 @@ mod tests {
 
         let pp3 = PathPoint::curve_data(50.0, 60.0);
         assert_eq!(pp3.point_type, PointType::CurveData);
+
+        let pp4 = PathPoint::quad_to(70.0, 80.0);
+        assert_eq!(pp4.point_type, PointType::QuadTo);
+        assert_eq!(pp4.x(), 70.0);
+        assert_eq!(pp4.y(), 80.0);
+
+        let pp5 = PathPoint::quad_data(90.0, 100.0);
+        assert_eq!(pp5.point_type, PointType::QuadData);
     }
 
     #[test]

--- a/crates/nodebox-gui/src/canvas.rs
+++ b/crates/nodebox-gui/src/canvas.rs
@@ -361,6 +361,48 @@ impl CanvasViewer {
                         // Skip curve data points, they're handled with CurveTo
                         i += 1;
                     }
+                    PointType::QuadTo => {
+                        // For quadratic curves, we need to sample points
+                        // Get the control point and end point
+                        if i + 1 < contour.points.len() {
+                            let ctrl = &contour.points[i];
+                            let end = &contour.points[i + 1];
+
+                            // Get last point as start
+                            let start = if let Some(&last) = egui_points.last() {
+                                last
+                            } else {
+                                screen_pt
+                            };
+
+                            let c = (Pos2::new(ctrl.point.x as f32, ctrl.point.y as f32).to_vec2()
+                                * self.zoom
+                                + self.pan
+                                + center)
+                                .to_pos2();
+                            let e = (Pos2::new(end.point.x as f32, end.point.y as f32).to_vec2()
+                                * self.zoom
+                                + self.pan
+                                + center)
+                                .to_pos2();
+
+                            // Sample the quadratic bezier
+                            for t in 1..=10 {
+                                let t = t as f32 / 10.0;
+                                let pt = quadratic_bezier(start, c, e, t);
+                                egui_points.push(pt);
+                            }
+
+                            i += 2;
+                        } else {
+                            egui_points.push(screen_pt);
+                            i += 1;
+                        }
+                    }
+                    PointType::QuadData => {
+                        // Skip quad data points, they're handled with QuadTo
+                        i += 1;
+                    }
                 }
             }
 
@@ -425,5 +467,17 @@ fn cubic_bezier(p0: Pos2, p1: Pos2, p2: Pos2, p3: Pos2, t: f32) -> Pos2 {
     Pos2::new(
         mt3 * p0.x + 3.0 * mt2 * t * p1.x + 3.0 * mt * t2 * p2.x + t3 * p3.x,
         mt3 * p0.y + 3.0 * mt2 * t * p1.y + 3.0 * mt * t2 * p2.y + t3 * p3.y,
+    )
+}
+
+/// Evaluate a quadratic bezier curve at parameter t.
+fn quadratic_bezier(p0: Pos2, p1: Pos2, p2: Pos2, t: f32) -> Pos2 {
+    let t2 = t * t;
+    let mt = 1.0 - t;
+    let mt2 = mt * mt;
+
+    Pos2::new(
+        mt2 * p0.x + 2.0 * mt * t * p1.x + t2 * p2.x,
+        mt2 * p0.y + 2.0 * mt * t * p1.y + t2 * p2.y,
     )
 }

--- a/crates/nodebox-gui/src/eval.rs
+++ b/crates/nodebox-gui/src/eval.rs
@@ -836,6 +836,27 @@ fn execute_node(node: &Node, inputs: &HashMap<String, NodeOutput>) -> NodeOutput
             NodeOutput::Paths(paths)
         }
 
+        // Import SVG
+        "corevector.import_svg" => {
+            let file_path = get_string(inputs, "file", "");
+            let centered = get_bool(inputs, "centered", true);
+            let position = get_point(inputs, "position", Point::ZERO);
+
+            match nodebox_ops::import_svg(&file_path, centered, position) {
+                Ok(geometry) => {
+                    if geometry.is_empty() {
+                        NodeOutput::None
+                    } else {
+                        NodeOutput::Paths(geometry.paths)
+                    }
+                }
+                Err(e) => {
+                    log::warn!("SVG import error: {}", e);
+                    NodeOutput::None
+                }
+            }
+        }
+
         // Default: pass-through or unknown node
         _ => {
             // For unknown nodes, try to pass through a shape input

--- a/crates/nodebox-gui/src/export.rs
+++ b/crates/nodebox-gui/src/export.rs
@@ -92,6 +92,30 @@ fn draw_path_with_transform(pixmap: &mut Pixmap, geo_path: &GeoPath, transform: 
                     // Skip curve data points, they're handled with CurveTo
                     i += 1;
                 }
+                PointType::QuadTo => {
+                    // Quadratic bezier: current point is control point
+                    if i + 1 < contour.points.len() {
+                        let ctrl = &contour.points[i];
+                        let end = &contour.points[i + 1];
+
+                        if first {
+                            builder.move_to(ctrl.point.x as f32, ctrl.point.y as f32);
+                            first = false;
+                        }
+
+                        builder.quad_to(
+                            ctrl.point.x as f32, ctrl.point.y as f32,
+                            end.point.x as f32, end.point.y as f32,
+                        );
+                        i += 2;
+                    } else {
+                        i += 1;
+                    }
+                }
+                PointType::QuadData => {
+                    // Skip quad data points, they're handled with QuadTo
+                    i += 1;
+                }
             }
         }
 

--- a/crates/nodebox-gui/src/node_library.rs
+++ b/crates/nodebox-gui/src/node_library.rs
@@ -6,7 +6,7 @@
 
 use eframe::egui;
 use nodebox_core::geometry::{Color, Point};
-use nodebox_core::node::{Node, NodeLibrary, Port, PortRange, PortType};
+use nodebox_core::node::{Node, NodeLibrary, Port, PortRange, PortType, Widget};
 
 /// Available node types that can be created.
 pub struct NodeTemplate {
@@ -118,6 +118,13 @@ pub const NODE_TEMPLATES: &[NodeTemplate] = &[
         prototype: "corevector.wiggle",
         category: "geometry",
         description: "Add random displacement to points",
+    },
+    // Import nodes
+    NodeTemplate {
+        name: "import_svg",
+        prototype: "corevector.import_svg",
+        category: "geometry",
+        description: "Import an SVG file as geometry",
     },
 ];
 
@@ -334,6 +341,12 @@ pub fn create_node_from_template(template: &NodeTemplate, library: &NodeLibrary,
                 .with_input(Port::string("scope", "points"))
                 .with_input(Port::point("offset", Point::new(10.0, 10.0)))
                 .with_input(Port::int("seed", 0));
+        }
+        "import_svg" => {
+            node = node
+                .with_input(Port::string("file", "").with_widget(Widget::File))
+                .with_input(Port::boolean("centered", true))
+                .with_input(Port::point("position", Point::ZERO));
         }
         _ => {}
     }

--- a/crates/nodebox-gui/src/panels.rs
+++ b/crates/nodebox-gui/src/panels.rs
@@ -306,6 +306,67 @@ impl ParameterPanel {
                     self.show_drag_value_float(ui, &mut point.y, None, None, 1.0, &key_y, is_editing_y);
                 }
             }
+            Widget::File => {
+                if let Value::String(ref mut path) = port.value {
+                    // Show filename or placeholder
+                    let display_text = if path.is_empty() {
+                        "(none)".to_string()
+                    } else {
+                        // Extract just the filename from the path
+                        std::path::Path::new(path)
+                            .file_name()
+                            .map(|s| s.to_string_lossy().to_string())
+                            .unwrap_or_else(|| path.clone())
+                    };
+
+                    let galley = ui.painter().layout_no_wrap(
+                        display_text,
+                        egui::FontId::proportional(11.0),
+                        if path.is_empty() { theme::TEXT_DISABLED } else { theme::VALUE_TEXT },
+                    );
+                    let rect = ui.available_rect_before_wrap();
+                    let text_pos = egui::pos2(rect.left(), rect.center().y - galley.size().y / 2.0);
+                    ui.painter().galley(text_pos, galley.clone(), theme::VALUE_TEXT);
+
+                    // Add browse button after the text
+                    let button_x = rect.left() + galley.size().x + 8.0;
+                    let button_rect = egui::Rect::from_min_size(
+                        egui::pos2(button_x, rect.center().y - 8.0),
+                        egui::vec2(16.0, 16.0),
+                    );
+
+                    let button_response = ui.allocate_rect(button_rect, Sense::click());
+
+                    // Draw folder icon or "..." button
+                    let button_color = if button_response.hovered() {
+                        theme::TEXT_BRIGHT
+                    } else {
+                        theme::TEXT_NORMAL
+                    };
+                    ui.painter().text(
+                        button_rect.center(),
+                        egui::Align2::CENTER_CENTER,
+                        "…",
+                        egui::FontId::proportional(14.0),
+                        button_color,
+                    );
+
+                    if button_response.hovered() {
+                        ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+                    }
+
+                    if button_response.clicked() {
+                        // Open file dialog
+                        if let Some(picked_path) = rfd::FileDialog::new()
+                            .add_filter("SVG files", &["svg"])
+                            .add_filter("All files", &["*"])
+                            .pick_file()
+                        {
+                            *path = picked_path.to_string_lossy().to_string();
+                        }
+                    }
+                }
+            }
             _ => {
                 // For geometry and other non-editable types, show type info (non-selectable)
                 let type_str = match port.port_type {

--- a/crates/nodebox-gui/src/vello_convert.rs
+++ b/crates/nodebox-gui/src/vello_convert.rs
@@ -89,6 +89,33 @@ pub fn contour_to_bezpath(contour: &Contour) -> BezPath {
                 path.line_to(point_to_kurbo(&pp.point));
                 i += 1;
             }
+            PointType::QuadData => {
+                // Quadratic bezier: QuadData (ctrl), QuadTo (end)
+                if i + 1 < points.len() {
+                    let ctrl = &points[i];
+                    let end = &points[i + 1];
+
+                    // Verify the structure is correct
+                    if ctrl.point_type == PointType::QuadData
+                        && end.point_type == PointType::QuadTo
+                    {
+                        path.quad_to(
+                            point_to_kurbo(&ctrl.point),
+                            point_to_kurbo(&end.point),
+                        );
+                        i += 2;
+                        continue;
+                    }
+                }
+                // Fallback: treat as line if structure is invalid
+                path.line_to(point_to_kurbo(&pp.point));
+                i += 1;
+            }
+            PointType::QuadTo => {
+                // Standalone QuadTo without preceding QuadData - treat as line
+                path.line_to(point_to_kurbo(&pp.point));
+                i += 1;
+            }
         }
     }
 

--- a/crates/nodebox-gui/src/viewer_pane.rs
+++ b/crates/nodebox-gui/src/viewer_pane.rs
@@ -811,8 +811,8 @@ impl ViewerPane {
                 // Draw point marker
                 let color = match pp.point_type {
                     PointType::LineTo => theme::POINT_LINE_TO,
-                    PointType::CurveTo => theme::POINT_CURVE_TO,
-                    PointType::CurveData => theme::POINT_CURVE_DATA,
+                    PointType::CurveTo | PointType::QuadTo => theme::POINT_CURVE_TO,
+                    PointType::CurveData | PointType::QuadData => theme::POINT_CURVE_DATA,
                 };
                 painter.circle_filled(screen_pt, 3.0, color);
             }
@@ -906,6 +906,36 @@ impl ViewerPane {
                     }
                     PointType::CurveTo => {
                         // Standalone CurveTo without preceding CurveData - treat as line
+                        egui_points.push(screen_pt);
+                        i += 1;
+                    }
+                    PointType::QuadData => {
+                        // QuadData is a control point - look ahead for the full quadratic bezier
+                        // Structure: QuadData (ctrl), QuadTo (end)
+                        if i + 1 < contour.points.len() {
+                            let ctrl = &contour.points[i];
+                            let end = &contour.points[i + 1];
+
+                            // Get start point (last point in egui_points, or first point of contour)
+                            let start = egui_points.last().copied().unwrap_or(screen_pt);
+
+                            let c = self.world_to_screen(ctrl.point, center);
+                            let e = self.world_to_screen(end.point, center);
+
+                            // Sample the quadratic bezier
+                            for t in 1..=10 {
+                                let t = t as f32 / 10.0;
+                                let pt = quadratic_bezier(start, c, e, t);
+                                egui_points.push(pt);
+                            }
+
+                            i += 2; // Skip ctrl, end
+                        } else {
+                            i += 1;
+                        }
+                    }
+                    PointType::QuadTo => {
+                        // Standalone QuadTo without preceding QuadData - treat as line
                         egui_points.push(screen_pt);
                         i += 1;
                     }
@@ -1083,5 +1113,17 @@ fn cubic_bezier(p0: Pos2, p1: Pos2, p2: Pos2, p3: Pos2, t: f32) -> Pos2 {
     Pos2::new(
         mt3 * p0.x + 3.0 * mt2 * t * p1.x + 3.0 * mt * t2 * p2.x + t3 * p3.x,
         mt3 * p0.y + 3.0 * mt2 * t * p1.y + 3.0 * mt * t2 * p2.y + t3 * p3.y,
+    )
+}
+
+/// Evaluate a quadratic bezier curve at parameter t.
+fn quadratic_bezier(p0: Pos2, p1: Pos2, p2: Pos2, t: f32) -> Pos2 {
+    let t2 = t * t;
+    let mt = 1.0 - t;
+    let mt2 = mt * mt;
+
+    Pos2::new(
+        mt2 * p0.x + 2.0 * mt * t * p1.x + t2 * p2.x,
+        mt2 * p0.y + 2.0 * mt * t * p1.y + t2 * p2.y,
     )
 }

--- a/crates/nodebox-ops/Cargo.toml
+++ b/crates/nodebox-ops/Cargo.toml
@@ -10,6 +10,7 @@ authors.workspace = true
 [dependencies]
 nodebox-core = { path = "../nodebox-core" }
 rayon = "1.10"
+usvg = "0.42"
 
 [features]
 default = []
@@ -18,3 +19,4 @@ parallel = []
 [dev-dependencies]
 proptest = { workspace = true }
 approx = { workspace = true }
+tempfile = "3"

--- a/crates/nodebox-ops/src/lib.rs
+++ b/crates/nodebox-ops/src/lib.rs
@@ -11,6 +11,7 @@
 //! - [`list`] - List manipulation operations (sort, filter, combine, etc.)
 //! - [`string`] - String manipulation operations (case, split, format, etc.)
 //! - [`parallel`] - Parallel versions of operations using Rayon
+//! - [`svg`] - SVG import functionality
 
 pub mod generators;
 pub mod filters;
@@ -18,6 +19,8 @@ pub mod math;
 pub mod list;
 pub mod string;
 pub mod parallel;
+pub mod svg;
 
 pub use generators::*;
 pub use filters::*;
+pub use svg::import_svg;

--- a/crates/nodebox-ops/src/svg.rs
+++ b/crates/nodebox-ops/src/svg.rs
@@ -1,0 +1,447 @@
+//! SVG import functionality.
+//!
+//! This module provides functions to import SVG files and convert them to NodeBox geometry.
+
+use nodebox_core::geometry::{Color, Contour, Geometry, Path, Point, Transform};
+use std::path::Path as StdPath;
+use usvg::{tiny_skia_path::PathSegment, Tree};
+
+/// Import an SVG file and convert it to NodeBox Geometry.
+///
+/// # Arguments
+/// * `file_path` - Path to the SVG file
+/// * `centered` - If true, center the geometry at the origin before applying position
+/// * `position` - Position offset to apply after optional centering
+///
+/// # Returns
+/// * `Ok(Geometry)` - The imported geometry
+/// * `Err(String)` - Error message if import fails
+///
+/// # Examples
+///
+/// ```ignore
+/// use nodebox_core::geometry::Point;
+/// use nodebox_ops::import_svg;
+///
+/// let geometry = import_svg("shape.svg", true, Point::ZERO)?;
+/// ```
+pub fn import_svg(file_path: &str, centered: bool, position: Point) -> Result<Geometry, String> {
+    // Empty path returns empty geometry
+    if file_path.is_empty() {
+        return Ok(Geometry::new());
+    }
+
+    // Check if file exists
+    let path = StdPath::new(file_path);
+    if !path.exists() {
+        return Err(format!("SVG file not found: {}", file_path));
+    }
+
+    // Read and parse the SVG file
+    let svg_data =
+        std::fs::read(file_path).map_err(|e| format!("Failed to read SVG file: {}", e))?;
+
+    // Parse SVG using usvg with default options
+    let options = usvg::Options::default();
+    let tree =
+        Tree::from_data(&svg_data, &options).map_err(|e| format!("Failed to parse SVG: {}", e))?;
+
+    // Convert the usvg tree to NodeBox geometry
+    let mut geometry = convert_tree_to_geometry(&tree);
+
+    // Apply centering if requested
+    if centered {
+        if let Some(bounds) = geometry.bounds() {
+            let center = bounds.center();
+            let centering_transform = Transform::translate(-center.x, -center.y);
+            geometry = geometry.transform(&centering_transform);
+        }
+    }
+
+    // Apply position offset
+    if position.x != 0.0 || position.y != 0.0 {
+        let position_transform = Transform::translate(position.x, position.y);
+        geometry = geometry.transform(&position_transform);
+    }
+
+    Ok(geometry)
+}
+
+/// Convert a usvg Tree to NodeBox Geometry.
+fn convert_tree_to_geometry(tree: &Tree) -> Geometry {
+    let mut geometry = Geometry::new();
+
+    // Process all nodes in the tree
+    for node in tree.root().children() {
+        process_node(&node, Transform::IDENTITY, &mut geometry);
+    }
+
+    geometry
+}
+
+/// Recursively process a usvg node.
+fn process_node(node: &usvg::Node, parent_transform: Transform, geometry: &mut Geometry) {
+    match node {
+        usvg::Node::Group(group) => {
+            // Combine parent transform with group transform
+            let group_transform = usvg_transform_to_nodebox(&group.transform());
+            let combined_transform = parent_transform.then(&group_transform);
+
+            // Process children
+            for child in group.children() {
+                process_node(&child, combined_transform, geometry);
+            }
+        }
+        usvg::Node::Path(path) => {
+            if let Some(nodebox_path) = convert_path(path, &parent_transform) {
+                geometry.add(nodebox_path);
+            }
+        }
+        usvg::Node::Image(_) => {
+            // Images are not supported, skip
+        }
+        usvg::Node::Text(_) => {
+            // Text is not supported, skip (as per requirements)
+        }
+    }
+}
+
+/// Convert a usvg Transform to a NodeBox Transform.
+fn usvg_transform_to_nodebox(t: &usvg::Transform) -> Transform {
+    Transform::new(t.sx as f64, t.ky as f64, t.kx as f64, t.sy as f64, t.tx as f64, t.ty as f64)
+}
+
+/// Convert a usvg Path to a NodeBox Path.
+fn convert_path(usvg_path: &usvg::Path, transform: &Transform) -> Option<Path> {
+    let data = usvg_path.data();
+
+    // Create contours from path data
+    let contours = convert_path_data(data);
+
+    if contours.is_empty() {
+        return None;
+    }
+
+    // Create the NodeBox path
+    let mut path = Path::from_contours(contours);
+
+    // Apply fill
+    if let Some(fill) = usvg_path.fill() {
+        path.fill = usvg_paint_to_color(&fill.paint(), fill.opacity().get());
+    } else {
+        path.fill = None;
+    }
+
+    // Apply stroke
+    if let Some(stroke) = usvg_path.stroke() {
+        path.stroke = usvg_paint_to_color(&stroke.paint(), stroke.opacity().get());
+        // Get the stroke width and scale it with the transform
+        let base_width = stroke.width().get() as f64;
+        // Apply transform scale to stroke width (use average of x and y scale)
+        let transform_array = transform.as_array();
+        let scale_x = (transform_array[0] * transform_array[0]
+            + transform_array[1] * transform_array[1])
+            .sqrt();
+        let scale_y = (transform_array[2] * transform_array[2]
+            + transform_array[3] * transform_array[3])
+            .sqrt();
+        let avg_scale = (scale_x + scale_y) / 2.0;
+        path.stroke_width = base_width * avg_scale;
+    } else {
+        path.stroke = None;
+    }
+
+    // Apply the transform to the path
+    let transformed_path = path.transform(transform);
+
+    Some(transformed_path)
+}
+
+/// Convert usvg path data to NodeBox contours.
+fn convert_path_data(data: &usvg::tiny_skia_path::Path) -> Vec<Contour> {
+    let mut contours: Vec<Contour> = Vec::new();
+    let mut current_contour: Option<Contour> = None;
+
+    for segment in data.segments() {
+        match segment {
+            PathSegment::MoveTo(pt) => {
+                // Start a new contour
+                if let Some(contour) = current_contour.take() {
+                    if !contour.is_empty() {
+                        contours.push(contour);
+                    }
+                }
+                let mut new_contour = Contour::new();
+                new_contour.move_to(pt.x as f64, pt.y as f64);
+                current_contour = Some(new_contour);
+            }
+            PathSegment::LineTo(pt) => {
+                if let Some(ref mut contour) = current_contour {
+                    contour.line_to(pt.x as f64, pt.y as f64);
+                }
+            }
+            PathSegment::QuadTo(ctrl, end) => {
+                if let Some(ref mut contour) = current_contour {
+                    contour.quad_to(ctrl.x as f64, ctrl.y as f64, end.x as f64, end.y as f64);
+                }
+            }
+            PathSegment::CubicTo(ctrl1, ctrl2, end) => {
+                if let Some(ref mut contour) = current_contour {
+                    contour.curve_to(
+                        ctrl1.x as f64,
+                        ctrl1.y as f64,
+                        ctrl2.x as f64,
+                        ctrl2.y as f64,
+                        end.x as f64,
+                        end.y as f64,
+                    );
+                }
+            }
+            PathSegment::Close => {
+                if let Some(ref mut contour) = current_contour {
+                    contour.close();
+                }
+            }
+        }
+    }
+
+    // Push any remaining contour
+    if let Some(contour) = current_contour {
+        if !contour.is_empty() {
+            contours.push(contour);
+        }
+    }
+
+    contours
+}
+
+/// Convert a usvg Paint to an optional NodeBox Color.
+fn usvg_paint_to_color(paint: &usvg::Paint, opacity: f32) -> Option<Color> {
+    match paint {
+        usvg::Paint::Color(c) => {
+            // Convert u8 components (0-255) to f64 (0.0-1.0)
+            let r = c.red as f64 / 255.0;
+            let g = c.green as f64 / 255.0;
+            let b = c.blue as f64 / 255.0;
+            let a = opacity as f64;
+            Some(Color::rgba(r, g, b, a))
+        }
+        usvg::Paint::LinearGradient(_) | usvg::Paint::RadialGradient(_) | usvg::Paint::Pattern(_) => {
+            // Gradients and patterns are not supported, return None
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_import_empty_path() {
+        let result = import_svg("", false, Point::ZERO);
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_import_missing_file() {
+        let result = import_svg("/nonexistent/path/to/file.svg", false, Point::ZERO);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("not found"));
+    }
+
+    #[test]
+    fn test_usvg_transform_identity() {
+        let usvg_t = usvg::Transform::identity();
+        let nodebox_t = usvg_transform_to_nodebox(&usvg_t);
+        assert!(nodebox_t.is_identity());
+    }
+
+    #[test]
+    fn test_usvg_transform_translate() {
+        let usvg_t = usvg::Transform::from_translate(10.0, 20.0);
+        let nodebox_t = usvg_transform_to_nodebox(&usvg_t);
+        let p = nodebox_t.transform_point(Point::ZERO);
+        assert!((p.x - 10.0).abs() < 0.001);
+        assert!((p.y - 20.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_usvg_paint_to_color_solid() {
+        let paint = usvg::Paint::Color(usvg::Color::new_rgb(255, 128, 0));
+        let color = usvg_paint_to_color(&paint, 1.0);
+        assert!(color.is_some());
+        let c = color.unwrap();
+        assert!((c.r - 1.0).abs() < 0.01);
+        assert!((c.g - 128.0 / 255.0).abs() < 0.01);
+        assert!((c.b - 0.0).abs() < 0.01);
+        assert!((c.a - 1.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_usvg_paint_to_color_with_opacity() {
+        let paint = usvg::Paint::Color(usvg::Color::new_rgb(255, 255, 255));
+        let color = usvg_paint_to_color(&paint, 0.5);
+        assert!(color.is_some());
+        let c = color.unwrap();
+        assert!((c.a - 0.5).abs() < 0.02);
+    }
+
+    #[test]
+    fn test_import_svg_from_data() {
+        // Test importing from an in-memory SVG
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let svg_content = r##"<?xml version="1.0" encoding="UTF-8"?>
+            <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+                <rect x="10" y="10" width="80" height="80" fill="#ff0000"/>
+                <circle cx="50" cy="50" r="25" fill="#00ff00"/>
+            </svg>"##;
+
+        // Write to a temp file
+        let mut temp_file = NamedTempFile::new().unwrap();
+        temp_file.write_all(svg_content.as_bytes()).unwrap();
+
+        let result = import_svg(temp_file.path().to_str().unwrap(), false, Point::ZERO);
+        assert!(result.is_ok(), "Failed to import SVG: {:?}", result);
+
+        let geometry = result.unwrap();
+        assert!(!geometry.is_empty(), "Geometry should not be empty");
+
+        // Should have at least 2 paths (rect and circle)
+        assert!(
+            geometry.len() >= 2,
+            "Should have at least 2 paths, got {}",
+            geometry.len()
+        );
+    }
+
+    #[test]
+    fn test_import_svg_centered() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let svg_content = r##"<?xml version="1.0" encoding="UTF-8"?>
+            <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+                <rect x="0" y="0" width="100" height="100" fill="#000000"/>
+            </svg>"##;
+
+        let mut temp_file = NamedTempFile::new().unwrap();
+        temp_file.write_all(svg_content.as_bytes()).unwrap();
+        let path = temp_file.path().to_str().unwrap();
+
+        // Import without centering
+        let not_centered = import_svg(path, false, Point::ZERO).unwrap();
+        let bounds_not_centered = not_centered.bounds().unwrap();
+
+        // Import with centering
+        let centered = import_svg(path, true, Point::ZERO).unwrap();
+        let bounds_centered = centered.bounds().unwrap();
+
+        // Centered version should have center at (0, 0)
+        let center = bounds_centered.center();
+        assert!(
+            center.x.abs() < 1.0,
+            "Centered X should be near 0, got {}",
+            center.x
+        );
+        assert!(
+            center.y.abs() < 1.0,
+            "Centered Y should be near 0, got {}",
+            center.y
+        );
+
+        // Not centered should have different bounds
+        let not_centered_center = bounds_not_centered.center();
+        assert!(
+            (not_centered_center.x - 50.0).abs() < 1.0,
+            "Not centered X should be near 50, got {}",
+            not_centered_center.x
+        );
+    }
+
+    #[test]
+    fn test_import_svg_with_position() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let svg_content = r##"<?xml version="1.0" encoding="UTF-8"?>
+            <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+                <rect x="0" y="0" width="100" height="100" fill="#000000"/>
+            </svg>"##;
+
+        let mut temp_file = NamedTempFile::new().unwrap();
+        temp_file.write_all(svg_content.as_bytes()).unwrap();
+
+        let offset = Point::new(200.0, 300.0);
+        let result = import_svg(temp_file.path().to_str().unwrap(), true, offset).unwrap();
+        let bounds = result.bounds().unwrap();
+
+        // Center should be at the offset position
+        let center = bounds.center();
+        assert!(
+            (center.x - 200.0).abs() < 1.0,
+            "Center X should be 200, got {}",
+            center.x
+        );
+        assert!(
+            (center.y - 300.0).abs() < 1.0,
+            "Center Y should be 300, got {}",
+            center.y
+        );
+    }
+
+    #[test]
+    fn test_import_svg_colors() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let svg_content = r##"<?xml version="1.0" encoding="UTF-8"?>
+            <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+                <rect x="0" y="0" width="100" height="100" fill="#ff0000" stroke="#0000ff" stroke-width="2"/>
+            </svg>"##;
+
+        let mut temp_file = NamedTempFile::new().unwrap();
+        temp_file.write_all(svg_content.as_bytes()).unwrap();
+
+        let result = import_svg(temp_file.path().to_str().unwrap(), false, Point::ZERO).unwrap();
+        assert!(!result.is_empty());
+
+        let path = &result.paths[0];
+
+        // Check fill color (should be red)
+        assert!(path.fill.is_some(), "Path should have fill");
+        let fill = path.fill.unwrap();
+        assert!(
+            (fill.r - 1.0).abs() < 0.01,
+            "Fill red should be 1.0, got {}",
+            fill.r
+        );
+        assert!(fill.g < 0.01, "Fill green should be 0.0, got {}", fill.g);
+        assert!(fill.b < 0.01, "Fill blue should be 0.0, got {}", fill.b);
+
+        // Check stroke color (should be blue)
+        assert!(path.stroke.is_some(), "Path should have stroke");
+        let stroke = path.stroke.unwrap();
+        assert!(stroke.r < 0.01, "Stroke red should be 0.0, got {}", stroke.r);
+        assert!(
+            stroke.g < 0.01,
+            "Stroke green should be 0.0, got {}",
+            stroke.g
+        );
+        assert!(
+            (stroke.b - 1.0).abs() < 0.01,
+            "Stroke blue should be 1.0, got {}",
+            stroke.b
+        );
+
+        // Check stroke width
+        assert!(
+            (path.stroke_width - 2.0).abs() < 0.1,
+            "Stroke width should be 2.0, got {}",
+            path.stroke_width
+        );
+    }
+}

--- a/crates/nodebox-python/src/convert.rs
+++ b/crates/nodebox-python/src/convert.rs
@@ -206,6 +206,8 @@ fn convert_path_like(py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<CorePat
             let point_type = match point_type_str.to_lowercase().as_str() {
                 "curveto" | "curve_to" => CorePointType::CurveTo,
                 "curvedata" | "curve_data" => CorePointType::CurveData,
+                "quadto" | "quad_to" => CorePointType::QuadTo,
+                "quaddata" | "quad_data" => CorePointType::QuadData,
                 _ => CorePointType::LineTo,
             };
 

--- a/crates/nodebox-svg/src/renderer.rs
+++ b/crates/nodebox-svg/src/renderer.rs
@@ -322,6 +322,31 @@ fn contour_to_svg_data(data: &mut String, contour: &Contour, precision: usize) {
                 write!(data, " L{:.prec$},{:.prec$}", pt.point.x, pt.point.y, prec = precision).unwrap();
                 i += 1;
             }
+            PointType::QuadData => {
+                // Quadratic bezier: ctrl, end
+                if i + 1 < points.len() {
+                    let ctrl = &points[i];
+                    let end = &points[i + 1];
+
+                    write!(
+                        data,
+                        " Q{:.prec$},{:.prec$} {:.prec$},{:.prec$}",
+                        ctrl.point.x, ctrl.point.y,
+                        end.point.x, end.point.y,
+                        prec = precision
+                    ).unwrap();
+
+                    i += 2;
+                } else {
+                    // Malformed curve data, skip
+                    i += 1;
+                }
+            }
+            PointType::QuadTo => {
+                // This shouldn't happen without preceding QuadData
+                write!(data, " L{:.prec$},{:.prec$}", pt.point.x, pt.point.y, prec = precision).unwrap();
+                i += 1;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Add native quadratic bezier curve support to the geometry system (QuadTo/QuadData point types, Quadratic segment)
- Implement SVG import using usvg crate with support for basic shapes, paths, colors, stroke width, and transforms
- Add `import_svg` node to the node library with file picker widget
- Update all renderers (canvas, viewer_pane, export, vello, svg) to handle quadratic beziers

## Test plan

- [x] All existing tests pass
- [x] New SVG import tests pass (10 tests)
- [x] New quadratic bezier tests pass
- [x] Manual test: Import SVG file with rect, circle, and path elements
- [x] Manual test: Verify centering and position parameters work correctly
- [x] Manual test: Verify colors and stroke width are imported

🤖 Generated with [Claude Code](https://claude.ai/code)