### PR TITLE
Add .ndbx file saving with XML serialization

### DIFF
--- a/crates/nodebox-gui/src/state.rs
+++ b/crates/nodebox-gui/src/state.rs
@@ -143,7 +143,8 @@ impl AppState {
 
     /// Save the current document.
     pub fn save_file(&mut self, path: &Path) -> Result<(), String> {
-        // TODO: Implement proper .ndbx saving
+        nodebox_ndbx::serialize_to_file(&self.library, path)
+            .map_err(|e| e.to_string())?;
         self.current_file = Some(path.to_path_buf());
         self.dirty = false;
         Ok(())

--- a/crates/nodebox-gui/tests/file_tests.rs
+++ b/crates/nodebox-gui/tests/file_tests.rs
@@ -1,120 +1,166 @@
-//! Tests for loading and evaluating .ndbx files from the examples directory.
+//! Tests for loading and evaluating .ndbx files.
+//!
+//! Note: The Rust implementation only supports .ndbx format version 21+.
+//! Older example files (version 17) from the Java implementation are rejected.
+//! These tests verify that behavior and test evaluation with programmatically
+//! created libraries.
 
 use std::path::PathBuf;
 
+use nodebox_core::geometry::{Color, Point};
+use nodebox_core::node::{Connection, Node, NodeLibrary, Port};
 use nodebox_gui::eval::evaluate_network;
 use nodebox_gui::{populate_default_ports, AppState};
+use nodebox_ndbx::NdbxError;
 
 /// Get the path to the examples directory.
 fn examples_dir() -> PathBuf {
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    manifest_dir.parent().unwrap().parent().unwrap().join("examples")
+    manifest_dir
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("examples")
 }
 
-/// Load and parse an .ndbx file from the examples directory.
-/// Also populates default ports for proper evaluation.
-fn load_example(relative_path: &str) -> nodebox_core::node::NodeLibrary {
-    let path = examples_dir().join(relative_path);
-    let mut library = nodebox_ndbx::parse_file(&path).unwrap_or_else(|e| {
-        panic!("Failed to parse {}: {}", path.display(), e);
-    });
+/// Get the path to the libraries directory.
+fn libraries_dir() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("libraries")
+}
+
+// ============================================================================
+// Version compatibility tests
+// ============================================================================
+
+#[test]
+fn test_old_version_files_are_rejected() {
+    // The Primitives example has formatVersion="17" which is below our minimum (21)
+    let path = examples_dir().join("01 Basics/01 Shape/01 Primitives/01 Primitives.ndbx");
+    if !path.exists() {
+        println!("Skipping test - example file not found");
+        return;
+    }
+
+    let result = nodebox_ndbx::parse_file(&path);
+    assert!(result.is_err(), "Old version files should be rejected");
+
+    match result.unwrap_err() {
+        NdbxError::UnsupportedVersion(v) => {
+            assert_eq!(v, 17, "Expected version 17 rejection");
+        }
+        other => panic!("Expected UnsupportedVersion error, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_library_files_can_be_loaded() {
+    // Library files (corevector, etc.) have no formatVersion attribute,
+    // which defaults to 21 and is supported
+    let path = libraries_dir().join("corevector/corevector.ndbx");
+    if !path.exists() {
+        println!("Skipping test - library file not found");
+        return;
+    }
+
+    let library = nodebox_ndbx::parse_file(&path).expect("Library files should load");
+
+    // After upgrade, format version should be 22
+    assert_eq!(library.format_version, 22);
+
+    // Check that key nodes exist
+    assert!(library.root.child("rect").is_some(), "Missing rect node");
+    assert!(
+        library.root.child("ellipse").is_some(),
+        "Missing ellipse node"
+    );
+}
+
+// ============================================================================
+// Evaluation tests with programmatically created libraries
+// ============================================================================
+
+/// Create a test library similar to the Primitives example
+fn create_primitives_library() -> NodeLibrary {
+    let mut library = NodeLibrary::new("test");
+    library.set_width(1000.0);
+    library.set_height(1000.0);
+
+    // Create nodes similar to the Primitives example
+    let rect1 = Node::new("rect1")
+        .with_prototype("corevector.rect")
+        .with_position(1.0, 1.0)
+        .with_input(Port::point("position", Point::new(-100.0, 0.0)))
+        .with_input(Port::float("width", 100.0))
+        .with_input(Port::float("height", 100.0));
+
+    let ellipse1 = Node::new("ellipse1")
+        .with_prototype("corevector.ellipse")
+        .with_position(4.0, 1.0)
+        .with_input(Port::point("position", Point::new(10.0, 0.0)))
+        .with_input(Port::float("width", 100.0))
+        .with_input(Port::float("height", 100.0));
+
+    let polygon1 = Node::new("polygon1")
+        .with_prototype("corevector.polygon")
+        .with_position(7.0, 1.0)
+        .with_input(Port::point("position", Point::new(100.0, 0.0)))
+        .with_input(Port::float("radius", 60.0))
+        .with_input(Port::int("sides", 6));
+
+    let colorize1 = Node::new("colorize1")
+        .with_prototype("corevector.colorize")
+        .with_position(1.0, 3.0)
+        .with_input(Port::color("fill", Color::rgba(0.82, 0.42, 0.15, 1.0)));
+
+    let colorize2 = Node::new("colorize2")
+        .with_prototype("corevector.colorize")
+        .with_position(4.0, 3.0)
+        .with_input(Port::color("fill", Color::rgba(0.31, 0.62, 0.96, 1.0)));
+
+    let colorize3 = Node::new("colorize3")
+        .with_prototype("corevector.colorize")
+        .with_position(7.0, 3.0)
+        .with_input(Port::color("fill", Color::rgba(0.0, 0.10, 0.18, 1.0)));
+
+    let combine1 = Node::new("combine1")
+        .with_prototype("list.combine")
+        .with_position(3.0, 5.0);
+
+    library.root = Node::network("root")
+        .with_child(rect1)
+        .with_child(ellipse1)
+        .with_child(polygon1)
+        .with_child(colorize1)
+        .with_child(colorize2)
+        .with_child(colorize3)
+        .with_child(combine1)
+        .with_connection(Connection::new("rect1", "colorize1", "shape"))
+        .with_connection(Connection::new("ellipse1", "colorize2", "shape"))
+        .with_connection(Connection::new("polygon1", "colorize3", "shape"))
+        .with_connection(Connection::new("colorize1", "combine1", "list1"))
+        .with_connection(Connection::new("colorize2", "combine1", "list2"))
+        .with_connection(Connection::new("colorize3", "combine1", "list3"))
+        .with_rendered_child("combine1");
+
     // Populate default ports so connections work properly
     populate_default_ports(&mut library.root);
+
     library
 }
 
-// ============================================================================
-// 01 Basics / 01 Shape
-// ============================================================================
-
-#[test]
-fn test_load_primitives() {
-    let library = load_example("01 Basics/01 Shape/01 Primitives/01 Primitives.ndbx");
-
-    // Verify basic structure
-    assert_eq!(library.root.name, "root");
-    assert_eq!(library.root.rendered_child, Some("combine1".to_string()));
-    assert_eq!(library.width(), 1000.0);
-    assert_eq!(library.height(), 1000.0);
-
-    // Verify nodes were loaded
-    assert!(!library.root.children.is_empty());
-
-    // Find specific nodes
-    let rect = library.root.child("rect1");
-    assert!(rect.is_some(), "rect1 node should exist");
-    assert_eq!(
-        rect.unwrap().prototype,
-        Some("corevector.rect".to_string())
-    );
-
-    let ellipse = library.root.child("ellipse1");
-    assert!(ellipse.is_some(), "ellipse1 node should exist");
-
-    let polygon = library.root.child("polygon1");
-    assert!(polygon.is_some(), "polygon1 node should exist");
-
-    // Verify connections
-    assert!(!library.root.connections.is_empty());
-}
-
-#[test]
-fn test_load_lines() {
-    let library = load_example("01 Basics/01 Shape/02 Lines/02 Lines.ndbx");
-
-    assert_eq!(library.root.name, "root");
-    assert!(!library.root.children.is_empty());
-}
-
-#[test]
-fn test_load_grid() {
-    let library = load_example("01 Basics/01 Shape/04 Grid/04 Grid.ndbx");
-
-    assert_eq!(library.root.name, "root");
-
-    // This file should have a grid node
-    let has_grid = library
-        .root
-        .children
-        .iter()
-        .any(|n| n.prototype.as_deref() == Some("corevector.grid"));
-    assert!(has_grid, "Should contain a grid node");
-}
-
-#[test]
-fn test_load_copy() {
-    let library = load_example("01 Basics/01 Shape/05 Copy/05 Copy.ndbx");
-
-    assert_eq!(library.root.name, "root");
-
-    // This file should have a copy node
-    let has_copy = library
-        .root
-        .children
-        .iter()
-        .any(|n| n.prototype.as_deref() == Some("corevector.copy"));
-    assert!(has_copy, "Should contain a copy node");
-}
-
-#[test]
-fn test_load_transformations() {
-    let library = load_example("01 Basics/01 Shape/06 Transformations/06 Transformations.ndbx");
-
-    assert_eq!(library.root.name, "root");
-    assert!(!library.root.children.is_empty());
-}
-
-// ============================================================================
-// Evaluation tests - verify we can evaluate loaded files
-// ============================================================================
-
 #[test]
 fn test_evaluate_primitives() {
-    let library = load_example("01 Basics/01 Shape/01 Primitives/01 Primitives.ndbx");
+    let library = create_primitives_library();
 
     // Create a library with just the rect node rendered
-    let mut test_library = nodebox_core::node::NodeLibrary::new("test");
-    test_library.root = library.root.clone();
+    let mut test_library = library.clone();
     test_library.root.rendered_child = Some("rect1".to_string());
 
     let (paths, _errors) = evaluate_network(&test_library);
@@ -133,10 +179,9 @@ fn test_evaluate_primitives() {
 
 #[test]
 fn test_evaluate_primitives_full() {
-    let library = load_example("01 Basics/01 Shape/01 Primitives/01 Primitives.ndbx");
+    let library = create_primitives_library();
 
     // The rendered child is "combine1" which uses list.combine
-    // Now that list.combine is implemented, we can evaluate the full network
     let (paths, _errors) = evaluate_network(&library);
 
     // Should have 3 shapes: rect, ellipse, polygon (each colorized)
@@ -150,10 +195,9 @@ fn test_evaluate_primitives_full() {
 
 #[test]
 fn test_evaluate_colorized_primitives() {
-    let library = load_example("01 Basics/01 Shape/01 Primitives/01 Primitives.ndbx");
+    let library = create_primitives_library();
 
-    let mut test_library = nodebox_core::node::NodeLibrary::new("test");
-    test_library.root = library.root.clone();
+    let mut test_library = library.clone();
 
     // Test colorized rect (colorize1 <- rect1)
     test_library.root.rendered_child = Some("colorize1".to_string());
@@ -163,120 +207,17 @@ fn test_evaluate_colorized_primitives() {
     assert!(paths[0].fill.is_some(), "colorized path should have fill");
 }
 
-#[test]
-fn test_evaluate_copy() {
-    let library = load_example("01 Basics/01 Shape/05 Copy/05 Copy.ndbx");
-
-    // Find a copy node and try to evaluate its output
-    let copy_node = library
-        .root
-        .children
-        .iter()
-        .find(|n| n.prototype.as_deref() == Some("corevector.copy"));
-
-    if let Some(copy) = copy_node {
-        let mut test_library = nodebox_core::node::NodeLibrary::new("test");
-        test_library.root = library.root.clone();
-        test_library.root.rendered_child = Some(copy.name.clone());
-
-        let (paths, _errors) = evaluate_network(&test_library);
-        // Copy should produce multiple paths
-        assert!(
-            !paths.is_empty(),
-            "Copy node {} should produce paths",
-            copy.name
-        );
-    }
-}
-
-// ============================================================================
-// Color examples
-// ============================================================================
-
-#[test]
-fn test_load_color_example() {
-    let path = examples_dir().join("01 Basics/02 Color");
-    if path.exists() {
-        // Find any .ndbx file in color examples
-        if let Ok(entries) = std::fs::read_dir(&path) {
-            for entry in entries.flatten() {
-                let entry_path = entry.path();
-                if entry_path.is_dir() {
-                    if let Ok(files) = std::fs::read_dir(&entry_path) {
-                        for file in files.flatten() {
-                            if file
-                                .path()
-                                .extension()
-                                .map_or(false, |e| e == "ndbx")
-                            {
-                                let library = nodebox_ndbx::parse_file(file.path()).unwrap();
-                                assert_eq!(library.root.name, "root");
-                                return; // Found and tested one file
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-// ============================================================================
-// AppState::load_file integration test
-// ============================================================================
-
-#[test]
-fn test_app_state_load_file() {
-    let mut state = AppState::new();
-
-    // Initially has demo content
-    assert!(!state.library.root.children.is_empty());
-
-    // Load the primitives example
-    let path = examples_dir().join("01 Basics/01 Shape/01 Primitives/01 Primitives.ndbx");
-    let result = state.load_file(&path);
-
-    assert!(result.is_ok(), "load_file should succeed");
-    assert_eq!(state.current_file, Some(path.clone()));
-    assert!(!state.dirty);
-
-    // Verify the library was loaded
-    assert_eq!(state.library.root.name, "root");
-    assert!(state.library.root.child("rect1").is_some());
-    assert!(state.library.root.child("ellipse1").is_some());
-    assert!(state.library.root.child("polygon1").is_some());
-
-    // Verify geometry was evaluated (should have 3 shapes)
-    assert_eq!(state.geometry.len(), 3, "Should have 3 rendered shapes");
-}
-
-#[test]
-fn test_app_state_load_file_nonexistent() {
-    let mut state = AppState::new();
-
-    let path = examples_dir().join("nonexistent.ndbx");
-    let result = state.load_file(&path);
-
-    assert!(result.is_err(), "load_file should fail for nonexistent file");
-}
-
 // ============================================================================
 // Position port tests - verify shapes respect the "position" Point port
 // ============================================================================
 
 #[test]
 fn test_primitives_shapes_at_different_positions() {
-    // This test verifies that shapes loaded from the primitives example
-    // are at DIFFERENT positions, not all at the origin.
-    // The file defines:
-    //   rect1: position="-100.00,0.00"
-    //   ellipse1: position="10.00,0.00"
-    //   polygon1: position="100.00,0.00"
-    let library = load_example("01 Basics/01 Shape/01 Primitives/01 Primitives.ndbx");
+    // This test verifies that shapes are at DIFFERENT positions, not all at the origin.
+    let library = create_primitives_library();
 
     // Evaluate rect1 alone
-    let mut test_library = nodebox_core::node::NodeLibrary::new("test");
-    test_library.root = library.root.clone();
+    let mut test_library = library.clone();
     test_library.root.rendered_child = Some("rect1".to_string());
     let (rect_paths, _errors) = evaluate_network(&test_library);
     assert_eq!(rect_paths.len(), 1, "rect1 should produce one path");
@@ -297,7 +238,7 @@ fn test_primitives_shapes_at_different_positions() {
     let polygon_bounds = polygon_paths[0].bounds().unwrap();
     let polygon_center_x = polygon_bounds.x + polygon_bounds.width / 2.0;
 
-    // Verify they are at DIFFERENT x positions as defined in the file
+    // Verify they are at DIFFERENT x positions as defined
     // rect1 should be at x=-100, ellipse1 at x=10, polygon1 at x=100
     assert!(
         (rect_center_x - (-100.0)).abs() < 10.0,
@@ -332,14 +273,14 @@ fn test_primitives_shapes_at_different_positions() {
 
 #[test]
 fn test_position_port_is_point_type() {
-    // Verify that the loaded nodes have "position" port with Point type
-    let library = load_example("01 Basics/01 Shape/01 Primitives/01 Primitives.ndbx");
+    // Verify that created nodes have "position" port with Point type
+    let library = create_primitives_library();
 
     let rect = library.root.child("rect1").expect("rect1 should exist");
     let position_port = rect.input("position");
     assert!(
         position_port.is_some(),
-        "rect1 should have a 'position' port after loading"
+        "rect1 should have a 'position' port"
     );
     if let Some(port) = position_port {
         match &port.value {
@@ -358,48 +299,134 @@ fn test_position_port_is_point_type() {
     let position_port = ellipse.input("position");
     assert!(
         position_port.is_some(),
-        "ellipse1 should have a 'position' port after loading"
+        "ellipse1 should have a 'position' port"
     );
 
     let polygon = library.root.child("polygon1").expect("polygon1 should exist");
     let position_port = polygon.input("position");
     assert!(
         position_port.is_some(),
-        "polygon1 should have a 'position' port after loading"
+        "polygon1 should have a 'position' port"
     );
 }
 
 // ============================================================================
-// Bulk loading test - verify all example files can be parsed
+// AppState tests
 // ============================================================================
 
 #[test]
-fn test_load_all_example_files() {
-    let examples = examples_dir();
-    if !examples.exists() {
-        println!("Examples directory not found, skipping test");
+fn test_app_state_new() {
+    let state = AppState::new();
+
+    // Initially has demo content
+    assert!(!state.library.root.children.is_empty());
+    assert!(!state.dirty);
+    assert!(state.current_file.is_none());
+}
+
+#[test]
+fn test_app_state_load_file_old_version() {
+    let mut state = AppState::new();
+
+    // Try to load an old version file - should fail
+    let path = examples_dir().join("01 Basics/01 Shape/01 Primitives/01 Primitives.ndbx");
+    if !path.exists() {
+        println!("Skipping test - example file not found");
+        return;
+    }
+
+    let result = state.load_file(&path);
+    assert!(
+        result.is_err(),
+        "load_file should fail for old version files"
+    );
+}
+
+#[test]
+fn test_app_state_load_file_nonexistent() {
+    let mut state = AppState::new();
+
+    let path = examples_dir().join("nonexistent.ndbx");
+    let result = state.load_file(&path);
+
+    assert!(
+        result.is_err(),
+        "load_file should fail for nonexistent file"
+    );
+}
+
+// ============================================================================
+// Round-trip serialization test
+// ============================================================================
+
+#[test]
+fn test_save_and_reload() {
+    // Create a library
+    let original = create_primitives_library();
+
+    // Serialize to string
+    let xml = nodebox_ndbx::serialize(&original);
+
+    // Parse back
+    let reloaded = nodebox_ndbx::parse(&xml).expect("Should be able to parse serialized content");
+
+    // Verify key properties
+    assert_eq!(reloaded.format_version, 22);
+    assert_eq!(reloaded.root.name, "root");
+    assert_eq!(
+        reloaded.root.rendered_child,
+        Some("combine1".to_string())
+    );
+    assert_eq!(reloaded.root.children.len(), 7);
+    assert_eq!(reloaded.root.connections.len(), 6);
+
+    // Verify a specific node
+    let rect = reloaded.root.child("rect1").expect("Missing rect1");
+    assert_eq!(rect.prototype, Some("corevector.rect".to_string()));
+}
+
+// ============================================================================
+// Bulk loading test for library files (which have no version and default to 21)
+// ============================================================================
+
+#[test]
+fn test_load_all_library_files() {
+    let libs = libraries_dir();
+    if !libs.exists() {
+        println!("Libraries directory not found, skipping test");
         return;
     }
 
     let mut loaded = 0;
     let mut failed = Vec::new();
 
-    // Walk all directories
-    fn walk_dir(dir: &PathBuf, loaded: &mut usize, failed: &mut Vec<(PathBuf, String)>) {
-        if let Ok(entries) = std::fs::read_dir(dir) {
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if path.is_dir() {
-                    walk_dir(&path, loaded, failed);
-                } else if path.extension().map_or(false, |e| e == "ndbx") {
-                    match nodebox_ndbx::parse_file(&path) {
-                        Ok(library) => {
-                            // Basic sanity check
-                            assert!(!library.root.name.is_empty());
-                            *loaded += 1;
-                        }
-                        Err(e) => {
-                            failed.push((path, e.to_string()));
+    // Walk all library directories
+    if let Ok(entries) = std::fs::read_dir(&libs) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                // Look for .ndbx file in the directory
+                if let Ok(files) = std::fs::read_dir(&path) {
+                    for file in files.flatten() {
+                        if file
+                            .path()
+                            .extension()
+                            .map_or(false, |e| e == "ndbx")
+                        {
+                            match nodebox_ndbx::parse_file(file.path()) {
+                                Ok(library) => {
+                                    // Basic sanity check
+                                    assert!(!library.root.name.is_empty());
+                                    assert_eq!(
+                                        library.format_version, 22,
+                                        "Library should be upgraded to v22"
+                                    );
+                                    loaded += 1;
+                                }
+                                Err(e) => {
+                                    failed.push((file.path(), e.to_string()));
+                                }
+                            }
                         }
                     }
                 }
@@ -407,9 +434,7 @@ fn test_load_all_example_files() {
         }
     }
 
-    walk_dir(&examples, &mut loaded, &mut failed);
-
-    println!("Loaded {} example files", loaded);
+    println!("Loaded {} library files", loaded);
 
     if !failed.is_empty() {
         println!("Failed to load {} files:", failed.len());
@@ -418,7 +443,5 @@ fn test_load_all_example_files() {
         }
     }
 
-    assert!(loaded > 0, "Should have loaded at least one example file");
-    // Note: We don't assert on failed.is_empty() since some files may have
-    // features not yet implemented in the parser
+    assert!(loaded > 0, "Should have loaded at least one library file");
 }

--- a/crates/nodebox-gui/tests/handle_tests.rs
+++ b/crates/nodebox-gui/tests/handle_tests.rs
@@ -248,16 +248,35 @@ fn test_star_handle_reads_position_port() {
 // ============================================================================
 
 #[test]
-fn test_loaded_primitives_handles_read_correct_positions() {
-    use std::path::PathBuf;
+fn test_primitives_handles_read_correct_positions() {
+    use nodebox_core::node::{Connection, NodeLibrary};
 
-    // Get examples directory
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let examples_dir = manifest_dir.parent().unwrap().parent().unwrap().join("examples");
-    let path = examples_dir.join("01 Basics/01 Shape/01 Primitives/01 Primitives.ndbx");
+    // Create a library similar to the Primitives example
+    let mut library = NodeLibrary::new("test");
 
-    // Load the file
-    let mut library = nodebox_ndbx::parse_file(&path).expect("Failed to load primitives example");
+    let rect1 = Node::new("rect1")
+        .with_prototype("corevector.rect")
+        .with_input(Port::point("position", Point::new(-100.0, 0.0)))
+        .with_input(Port::float("width", 100.0))
+        .with_input(Port::float("height", 100.0));
+
+    let ellipse1 = Node::new("ellipse1")
+        .with_prototype("corevector.ellipse")
+        .with_input(Port::point("position", Point::new(10.0, 0.0)))
+        .with_input(Port::float("width", 100.0))
+        .with_input(Port::float("height", 100.0));
+
+    let polygon1 = Node::new("polygon1")
+        .with_prototype("corevector.polygon")
+        .with_input(Port::point("position", Point::new(100.0, 0.0)))
+        .with_input(Port::float("radius", 60.0))
+        .with_input(Port::int("sides", 6));
+
+    library.root = Node::network("root")
+        .with_child(rect1)
+        .with_child(ellipse1)
+        .with_child(polygon1);
+
     nodebox_gui::populate_default_ports(&mut library.root);
 
     // Get nodes
@@ -270,10 +289,10 @@ fn test_loaded_primitives_handles_read_correct_positions() {
     let ellipse_pos = get_position_from_node(ellipse);
     let polygon_pos = get_position_from_node(polygon);
 
-    // These are the values from the file:
-    // rect1: position="-100.00,0.00"
-    // ellipse1: position="10.00,0.00"
-    // polygon1: position="100.00,0.00"
+    // These are the values we set:
+    // rect1: position="-100.0,0.0"
+    // ellipse1: position="10.0,0.0"
+    // polygon1: position="100.0,0.0"
 
     assert!(
         (rect_pos.x - (-100.0)).abs() < 0.1,

--- a/crates/nodebox-ndbx/src/lib.rs
+++ b/crates/nodebox-ndbx/src/lib.rs
@@ -1,19 +1,26 @@
-//! NDBX file format parser for NodeBox.
+//! NDBX file format parser and serializer for NodeBox.
 //!
 //! This crate parses `.ndbx` files (XML-based) into NodeBox's internal
-//! node graph representation.
+//! node graph representation, and serializes them back to XML.
 //!
 //! # Example
 //!
 //! ```no_run
-//! use nodebox_ndbx::parse_file;
+//! use nodebox_ndbx::{parse_file, serialize_to_file};
 //!
 //! let library = parse_file("examples/my_project.ndbx").unwrap();
 //! println!("Loaded library: {}", library.name);
+//!
+//! // Save the library back to a file
+//! serialize_to_file(&library, "output.ndbx").unwrap();
 //! ```
 
-mod parser;
 mod error;
+mod parser;
+mod serializer;
+mod upgrades;
 
 pub use error::{NdbxError, Result};
 pub use parser::{parse, parse_file};
+pub use serializer::{serialize, serialize_to_file};
+pub use upgrades::{upgrade, CURRENT_FORMAT_VERSION, MIN_SUPPORTED_VERSION};

--- a/crates/nodebox-ndbx/src/parser.rs
+++ b/crates/nodebox-ndbx/src/parser.rs
@@ -11,11 +11,16 @@ use nodebox_core::geometry::Point;
 use nodebox_core::Value;
 
 use crate::error::{NdbxError, Result};
+use crate::upgrades::upgrade;
 
 /// Parses an NDBX file from the given path.
+///
+/// After parsing, the library is automatically upgraded to the current format version.
 pub fn parse_file(path: impl AsRef<Path>) -> Result<NodeLibrary> {
     let content = fs::read_to_string(path)?;
-    parse(&content)
+    let mut library = parse(&content)?;
+    upgrade(&mut library)?;
+    Ok(library)
 }
 
 /// Parses NDBX content from a string.

--- a/crates/nodebox-ndbx/src/serializer.rs
+++ b/crates/nodebox-ndbx/src/serializer.rs
@@ -1,0 +1,533 @@
+//! XML serializer for .ndbx files.
+//!
+//! This module converts NodeLibrary data structures back to XML format.
+
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+use nodebox_core::node::{Connection, MenuItem, Node, NodeLibrary, Port, PortRange, PortType, Widget};
+use nodebox_core::Value;
+
+use crate::error::Result;
+use crate::upgrades::CURRENT_FORMAT_VERSION;
+
+/// Serializes a NodeLibrary to an XML string.
+pub fn serialize(library: &NodeLibrary) -> String {
+    let mut output = String::new();
+    output.push_str(r#"<?xml version="1.0" encoding="UTF-8"?>"#);
+    output.push('\n');
+
+    // Start ndbx element
+    output.push_str(&format!(
+        r#"<ndbx formatVersion="{}" type="file""#,
+        CURRENT_FORMAT_VERSION
+    ));
+
+    if let Some(uuid) = &library.uuid {
+        output.push_str(&format!(r#" uuid="{}""#, escape_xml(uuid)));
+    }
+
+    output.push_str(">\n");
+
+    // Write properties (sorted for deterministic output)
+    let mut properties: Vec<_> = library.properties.iter().collect();
+    properties.sort_by_key(|(k, _)| *k);
+
+    for (name, value) in properties {
+        // Skip link properties and the "type" property (it's in the ndbx element)
+        if name.starts_with("link.") || name == "type" {
+            continue;
+        }
+        output.push_str(&format!(
+            r#"    <property name="{}" value="{}"/>"#,
+            escape_xml(name),
+            escape_xml(value)
+        ));
+        output.push('\n');
+    }
+
+    // Write root node
+    write_node(&mut output, &library.root, 1);
+
+    output.push_str("</ndbx>\n");
+
+    output
+}
+
+/// Serializes a NodeLibrary to a file.
+pub fn serialize_to_file(library: &NodeLibrary, path: impl AsRef<Path>) -> Result<()> {
+    let content = serialize(library);
+    let mut file = fs::File::create(path)?;
+    file.write_all(content.as_bytes())?;
+    Ok(())
+}
+
+fn write_node(output: &mut String, node: &Node, indent: usize) {
+    let indent_str = "    ".repeat(indent);
+
+    // Start node element
+    output.push_str(&indent_str);
+    output.push_str(&format!(r#"<node name="{}""#, escape_xml(&node.name)));
+
+    // Write prototype
+    if let Some(prototype) = &node.prototype {
+        output.push_str(&format!(r#" prototype="{}""#, escape_xml(prototype)));
+    }
+
+    // Write function (if different from prototype-inferred)
+    if let Some(function) = &node.function {
+        output.push_str(&format!(r#" function="{}""#, escape_xml(function)));
+    }
+
+    // Write position (if non-zero)
+    if node.position.x != 0.0 || node.position.y != 0.0 {
+        output.push_str(&format!(
+            r#" position="{:.2},{:.2}""#,
+            node.position.x, node.position.y
+        ));
+    }
+
+    // Write category (if non-empty)
+    if !node.category.is_empty() {
+        output.push_str(&format!(r#" category="{}""#, escape_xml(&node.category)));
+    }
+
+    // Write description
+    if let Some(desc) = &node.description {
+        output.push_str(&format!(r#" description="{}""#, escape_xml(desc)));
+    }
+
+    // Write output type (if not default Geometry)
+    if node.output_type != PortType::Geometry {
+        output.push_str(&format!(r#" outputType="{}""#, format_port_type(&node.output_type)));
+    }
+
+    // Write output range (if list)
+    if node.output_range == PortRange::List && !node.is_network {
+        output.push_str(r#" outputRange="list""#);
+    }
+
+    // Write rendered child
+    if let Some(rendered) = &node.rendered_child {
+        output.push_str(&format!(r#" renderedChild="{}""#, escape_xml(rendered)));
+    }
+
+    // Write handle
+    if let Some(handle) = &node.handle {
+        output.push_str(&format!(r#" handle="{}""#, escape_xml(handle)));
+    }
+
+    // Write alwaysRendered
+    if node.always_rendered {
+        output.push_str(r#" alwaysRendered="true""#);
+    }
+
+    // Check if node has content
+    let has_content = !node.inputs.is_empty() || !node.children.is_empty() || !node.connections.is_empty();
+
+    if has_content {
+        output.push_str(">\n");
+
+        // Write input ports
+        for port in &node.inputs {
+            write_port(output, port, indent + 1);
+        }
+
+        // Write child nodes
+        for child in &node.children {
+            write_node(output, child, indent + 1);
+        }
+
+        // Write connections
+        for conn in &node.connections {
+            write_connection(output, conn, indent + 1);
+        }
+
+        output.push_str(&indent_str);
+        output.push_str("</node>\n");
+    } else {
+        output.push_str("/>\n");
+    }
+}
+
+fn write_port(output: &mut String, port: &Port, indent: usize) {
+    let indent_str = "    ".repeat(indent);
+
+    output.push_str(&indent_str);
+    output.push_str(&format!(r#"<port name="{}""#, escape_xml(&port.name)));
+
+    // Write type
+    output.push_str(&format!(r#" type="{}""#, format_port_type(&port.port_type)));
+
+    // Write value (if not null/default)
+    if !port.value.is_null() {
+        if let Some(value_str) = format_value(&port.value, &port.port_type) {
+            output.push_str(&format!(r#" value="{}""#, escape_xml(&value_str)));
+        }
+    }
+
+    // Write range (if list)
+    if port.range == PortRange::List {
+        output.push_str(r#" range="list""#);
+    }
+
+    // Write widget (if not default for type)
+    let default_widget = Widget::default_for_type(&port.port_type);
+    if port.widget != default_widget && port.widget != Widget::None {
+        output.push_str(&format!(r#" widget="{}""#, format_widget(&port.widget)));
+    }
+
+    // Write min/max
+    if let Some(min) = port.min {
+        output.push_str(&format!(r#" min="{}""#, min));
+    }
+    if let Some(max) = port.max {
+        output.push_str(&format!(r#" max="{}""#, max));
+    }
+
+    // Write label
+    if let Some(label) = &port.label {
+        output.push_str(&format!(r#" label="{}""#, escape_xml(label)));
+    }
+
+    // Write description
+    if let Some(desc) = &port.description {
+        output.push_str(&format!(r#" description="{}""#, escape_xml(desc)));
+    }
+
+    // Check if port has menu items
+    if !port.menu_items.is_empty() {
+        output.push_str(">\n");
+
+        for item in &port.menu_items {
+            write_menu_item(output, item, indent + 1);
+        }
+
+        output.push_str(&indent_str);
+        output.push_str("</port>\n");
+    } else {
+        output.push_str("/>\n");
+    }
+}
+
+fn write_menu_item(output: &mut String, item: &MenuItem, indent: usize) {
+    let indent_str = "    ".repeat(indent);
+    output.push_str(&indent_str);
+    output.push_str(&format!(
+        r#"<menu key="{}" label="{}"/>"#,
+        escape_xml(&item.key),
+        escape_xml(&item.label)
+    ));
+    output.push('\n');
+}
+
+fn write_connection(output: &mut String, conn: &Connection, indent: usize) {
+    let indent_str = "    ".repeat(indent);
+    output.push_str(&indent_str);
+    output.push_str(&format!(
+        r#"<conn input="{}.{}" output="{}"/>"#,
+        escape_xml(&conn.input_node),
+        escape_xml(&conn.input_port),
+        escape_xml(&conn.output_node)
+    ));
+    output.push('\n');
+}
+
+fn format_port_type(port_type: &PortType) -> &str {
+    port_type.as_str()
+}
+
+fn format_widget(widget: &Widget) -> &str {
+    match widget {
+        Widget::None => "none",
+        Widget::Int => "int",
+        Widget::Float => "float",
+        Widget::Angle => "angle",
+        Widget::String => "string",
+        Widget::Text => "text",
+        Widget::Password => "password",
+        Widget::Toggle => "toggle",
+        Widget::Color => "color",
+        Widget::Point => "point",
+        Widget::Menu => "menu",
+        Widget::File => "file",
+        Widget::Font => "font",
+        Widget::Image => "image",
+        Widget::Data => "data",
+        Widget::Seed => "seed",
+        Widget::Gradient => "gradient",
+    }
+}
+
+fn format_value(value: &Value, _port_type: &PortType) -> Option<String> {
+    match value {
+        Value::Null => None,
+        Value::Int(i) => Some(i.to_string()),
+        Value::Float(f) => Some(format_float(*f)),
+        Value::String(s) => Some(s.clone()),
+        Value::Boolean(b) => Some(if *b { "true".to_string() } else { "false".to_string() }),
+        Value::Point(p) => Some(format!("{:.2},{:.2}", p.x, p.y)),
+        Value::Color(c) => Some(c.to_hex().to_lowercase()),
+        Value::Path(_) | Value::Geometry(_) | Value::List(_) | Value::Map(_) => None,
+    }
+}
+
+fn format_float(f: f64) -> String {
+    // Format floats consistently - use decimal point, avoid scientific notation
+    if f.fract() == 0.0 {
+        format!("{:.1}", f)
+    } else {
+        // Remove trailing zeros but keep at least one decimal place
+        let s = format!("{:.6}", f);
+        let s = s.trim_end_matches('0');
+        if s.ends_with('.') {
+            format!("{}0", s)
+        } else {
+            s.to_string()
+        }
+    }
+}
+
+fn escape_xml(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nodebox_core::geometry::{Color, Point};
+    use nodebox_core::node::Connection;
+
+    #[test]
+    fn test_serialize_empty_library() {
+        let library = NodeLibrary::new("test");
+        let xml = serialize(&library);
+
+        assert!(xml.contains(r#"formatVersion="22""#));
+        assert!(xml.contains(r#"<node name="root""#));
+    }
+
+    #[test]
+    fn test_serialize_with_uuid() {
+        let mut library = NodeLibrary::new("test");
+        library.uuid = Some("test-uuid-123".to_string());
+        let xml = serialize(&library);
+
+        assert!(xml.contains(r#"uuid="test-uuid-123""#));
+    }
+
+    #[test]
+    fn test_serialize_with_properties() {
+        let mut library = NodeLibrary::new("test");
+        library.set_width(800.0);
+        library.set_height(600.0);
+        let xml = serialize(&library);
+
+        assert!(xml.contains(r#"<property name="canvasHeight" value="600"/>"#));
+        assert!(xml.contains(r#"<property name="canvasWidth" value="800"/>"#));
+    }
+
+    #[test]
+    fn test_serialize_node_with_position() {
+        let mut library = NodeLibrary::new("test");
+        library.root = Node::network("root")
+            .with_child(
+                Node::new("rect1")
+                    .with_prototype("corevector.rect")
+                    .with_position(1.5, 2.5)
+            );
+        let xml = serialize(&library);
+
+        assert!(xml.contains(r#"name="rect1""#));
+        assert!(xml.contains(r#"prototype="corevector.rect""#));
+        assert!(xml.contains(r#"position="1.50,2.50""#));
+    }
+
+    #[test]
+    fn test_serialize_port_with_float_value() {
+        let mut library = NodeLibrary::new("test");
+        library.root = Node::network("root")
+            .with_child(
+                Node::new("rect1")
+                    .with_prototype("corevector.rect")
+                    .with_input(Port::float("width", 100.0))
+            );
+        let xml = serialize(&library);
+
+        assert!(xml.contains(r#"<port name="width" type="float" value="100.0"/>"#));
+    }
+
+    #[test]
+    fn test_serialize_port_with_color_value() {
+        let mut library = NodeLibrary::new("test");
+        library.root = Node::network("root")
+            .with_child(
+                Node::new("colorize1")
+                    .with_prototype("corevector.colorize")
+                    .with_input(Port::color("fill", Color::rgba(1.0, 0.0, 0.0, 1.0)))
+            );
+        let xml = serialize(&library);
+
+        assert!(xml.contains(r#"type="color""#));
+        assert!(xml.contains("value=\"#ff0000ff\""));
+    }
+
+    #[test]
+    fn test_serialize_port_with_point_value() {
+        let mut library = NodeLibrary::new("test");
+        library.root = Node::network("root")
+            .with_child(
+                Node::new("rect1")
+                    .with_input(Port::point("position", Point::new(10.5, -20.25)))
+            );
+        let xml = serialize(&library);
+
+        assert!(xml.contains(r#"type="point""#));
+        assert!(xml.contains(r#"value="10.50,-20.25""#));
+    }
+
+    #[test]
+    fn test_serialize_port_with_boolean_value() {
+        let mut library = NodeLibrary::new("test");
+        library.root = Node::network("root")
+            .with_child(
+                Node::new("connect1")
+                    .with_input(Port::boolean("closed", true))
+            );
+        let xml = serialize(&library);
+
+        assert!(xml.contains(r#"type="boolean""#));
+        assert!(xml.contains(r#"value="true""#));
+    }
+
+    #[test]
+    fn test_serialize_connection() {
+        let mut library = NodeLibrary::new("test");
+        library.root = Node::network("root")
+            .with_child(Node::new("rect1"))
+            .with_child(Node::new("colorize1"))
+            .with_connection(Connection::new("rect1", "colorize1", "shape"))
+            .with_rendered_child("colorize1");
+        let xml = serialize(&library);
+
+        assert!(xml.contains(r#"<conn input="colorize1.shape" output="rect1"/>"#));
+        assert!(xml.contains(r#"renderedChild="colorize1""#));
+    }
+
+    #[test]
+    fn test_serialize_port_with_menu() {
+        let mut library = NodeLibrary::new("test");
+        let mut port = Port::string("halign", "center");
+        port.widget = Widget::Menu;
+        port.menu_items = vec![
+            MenuItem::new("left", "Left"),
+            MenuItem::new("center", "Center"),
+            MenuItem::new("right", "Right"),
+        ];
+
+        library.root = Node::network("root")
+            .with_child(
+                Node::new("align1")
+                    .with_input(port)
+            );
+        let xml = serialize(&library);
+
+        assert!(xml.contains(r#"widget="menu""#));
+        assert!(xml.contains(r#"<menu key="left" label="Left"/>"#));
+        assert!(xml.contains(r#"<menu key="center" label="Center"/>"#));
+    }
+
+    #[test]
+    fn test_escape_xml() {
+        assert_eq!(escape_xml("hello"), "hello");
+        assert_eq!(escape_xml("<>&\"'"), "&lt;&gt;&amp;&quot;&apos;");
+    }
+
+    #[test]
+    fn test_format_float() {
+        assert_eq!(format_float(100.0), "100.0");
+        assert_eq!(format_float(10.5), "10.5");
+        assert_eq!(format_float(3.14159), "3.14159");
+    }
+
+    #[test]
+    fn test_round_trip() {
+        use crate::parse;
+
+        // Create a library with various node types and properties
+        let mut original = NodeLibrary::new("test");
+        original.uuid = Some("test-uuid-456".to_string());
+        original.format_version = 22;
+        original.set_width(800.0);
+        original.set_height(600.0);
+
+        original.root = Node::network("root")
+            .with_child(
+                Node::new("rect1")
+                    .with_prototype("corevector.rect")
+                    .with_position(1.0, 2.0)
+                    .with_input(Port::float("width", 100.0))
+                    .with_input(Port::float("height", 50.0))
+                    .with_input(Port::point("position", Point::new(-50.0, 25.0)))
+            )
+            .with_child(
+                Node::new("colorize1")
+                    .with_prototype("corevector.colorize")
+                    .with_position(1.0, 4.0)
+                    .with_input(Port::color("fill", Color::rgba(1.0, 0.5, 0.0, 1.0)))
+                    .with_input(Port::boolean("enabled", true))
+            )
+            .with_connection(Connection::new("rect1", "colorize1", "shape"))
+            .with_rendered_child("colorize1");
+
+        // Serialize to XML
+        let xml = serialize(&original);
+
+        // Parse back
+        let parsed = parse(&xml).expect("Failed to parse serialized XML");
+
+        // Verify key properties
+        assert_eq!(parsed.format_version, 22);
+        assert_eq!(parsed.uuid, Some("test-uuid-456".to_string()));
+        assert_eq!(parsed.width(), 800.0);
+        assert_eq!(parsed.height(), 600.0);
+
+        // Verify root node
+        assert_eq!(parsed.root.name, "root");
+        assert_eq!(parsed.root.rendered_child, Some("colorize1".to_string()));
+        assert_eq!(parsed.root.children.len(), 2);
+        assert_eq!(parsed.root.connections.len(), 1);
+
+        // Verify rect1 node
+        let rect = parsed.root.child("rect1").expect("Missing rect1");
+        assert_eq!(rect.prototype, Some("corevector.rect".to_string()));
+        assert_eq!(rect.position.x, 1.0);
+        assert_eq!(rect.position.y, 2.0);
+        assert_eq!(rect.inputs.len(), 3);
+
+        let width_port = rect.input("width").expect("Missing width port");
+        assert_eq!(width_port.value.as_float(), Some(100.0));
+
+        // Verify colorize1 node
+        let colorize = parsed.root.child("colorize1").expect("Missing colorize1");
+        let fill_port = colorize.input("fill").expect("Missing fill port");
+        if let Value::Color(c) = &fill_port.value {
+            assert!((c.r - 1.0).abs() < 0.01);
+            assert!((c.g - 0.5).abs() < 0.01);
+            assert!((c.b - 0.0).abs() < 0.01);
+        } else {
+            panic!("Expected color value for fill port");
+        }
+
+        // Verify connection
+        let conn = &parsed.root.connections[0];
+        assert_eq!(conn.output_node, "rect1");
+        assert_eq!(conn.input_node, "colorize1");
+        assert_eq!(conn.input_port, "shape");
+    }
+}

--- a/crates/nodebox-ndbx/src/upgrades.rs
+++ b/crates/nodebox-ndbx/src/upgrades.rs
@@ -1,0 +1,74 @@
+//! Version upgrades for .ndbx files.
+//!
+//! This module handles upgrading older .ndbx file formats to the current version.
+//! Currently supports upgrading from Java's version 21 to Rust's version 22.
+
+use nodebox_core::node::NodeLibrary;
+
+use crate::error::NdbxError;
+
+/// The current format version used when saving .ndbx files.
+pub const CURRENT_FORMAT_VERSION: u32 = 22;
+
+/// The minimum format version we can load (Java's latest).
+pub const MIN_SUPPORTED_VERSION: u32 = 21;
+
+/// Upgrades a NodeLibrary to the current format version.
+///
+/// # Errors
+///
+/// Returns an error if the format version is too old (< 21) or too new (> 22).
+pub fn upgrade(library: &mut NodeLibrary) -> Result<(), NdbxError> {
+    match library.format_version {
+        v if v < MIN_SUPPORTED_VERSION => Err(NdbxError::UnsupportedVersion(v)),
+        21 => {
+            // Upgrade from Java version 21 to Rust version 22
+            // Currently a no-op (format is compatible)
+            library.format_version = CURRENT_FORMAT_VERSION;
+            Ok(())
+        }
+        22 => Ok(()), // Already current
+        v => Err(NdbxError::UnsupportedVersion(v)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_upgrade_v21_to_v22() {
+        let mut library = NodeLibrary::default();
+        library.format_version = 21;
+
+        upgrade(&mut library).unwrap();
+        assert_eq!(library.format_version, 22);
+    }
+
+    #[test]
+    fn test_upgrade_v22_no_change() {
+        let mut library = NodeLibrary::default();
+        library.format_version = 22;
+
+        upgrade(&mut library).unwrap();
+        assert_eq!(library.format_version, 22);
+    }
+
+    #[test]
+    fn test_upgrade_old_version_error() {
+        let mut library = NodeLibrary::default();
+        library.format_version = 20;
+
+        let result = upgrade(&mut library);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_upgrade_future_version_error() {
+        let mut library = NodeLibrary::default();
+        library.format_version = 99;
+
+        let result = upgrade(&mut library);
+        assert!(result.is_err());
+    }
+}

--- a/crates/nodebox-ndbx/tests/parse_examples.rs
+++ b/crates/nodebox-ndbx/tests/parse_examples.rs
@@ -1,11 +1,11 @@
 //! Integration tests for parsing actual NDBX files.
 
-use nodebox_ndbx::parse_file;
+use nodebox_ndbx::{parse_file, NdbxError, MIN_SUPPORTED_VERSION};
 use std::path::Path;
 
-/// Test parsing the Primitives example.
+/// Test that parsing old format versions (< 21) returns an error.
 #[test]
-fn test_parse_primitives_example() {
+fn test_parse_old_version_returns_error() {
     let path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../../examples/01 Basics/01 Shape/01 Primitives/01 Primitives.ndbx");
 
@@ -14,36 +14,21 @@ fn test_parse_primitives_example() {
         return;
     }
 
-    let library = parse_file(&path).expect("Failed to parse Primitives.ndbx");
+    // This file has formatVersion="17" which is below our minimum supported version
+    let result = parse_file(&path);
+    assert!(result.is_err(), "Expected error for old format version");
 
-    assert_eq!(library.format_version, 17);
-    assert!(library.uuid.is_some());
-    assert_eq!(library.width(), 1000.0);
-    assert_eq!(library.height(), 1000.0);
-
-    // Root should be a network with "combine1" as rendered child
-    assert_eq!(library.root.name, "root");
-    assert_eq!(library.root.rendered_child, Some("combine1".to_string()));
-
-    // Should have several child nodes
-    assert!(!library.root.children.is_empty());
-
-    // Check some specific nodes exist
-    let has_rect = library.root.children.iter().any(|n| n.name == "rect1");
-    let has_ellipse = library.root.children.iter().any(|n| n.name == "ellipse1");
-    let has_polygon = library.root.children.iter().any(|n| n.name == "polygon1");
-    let has_combine = library.root.children.iter().any(|n| n.name == "combine1");
-
-    assert!(has_rect, "Missing rect1 node");
-    assert!(has_ellipse, "Missing ellipse1 node");
-    assert!(has_polygon, "Missing polygon1 node");
-    assert!(has_combine, "Missing combine1 node");
-
-    // Check connections exist
-    assert!(!library.root.connections.is_empty());
+    match result.unwrap_err() {
+        NdbxError::UnsupportedVersion(v) => {
+            assert!(v < MIN_SUPPORTED_VERSION, "Expected version < 21, got {}", v);
+        }
+        other => panic!("Expected UnsupportedVersion error, got: {:?}", other),
+    }
 }
 
 /// Test parsing the corevector library.
+/// Library files have no formatVersion attribute, which defaults to 21.
+/// After loading, the library is upgraded to version 22.
 #[test]
 fn test_parse_corevector_library() {
     let path = Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -55,6 +40,9 @@ fn test_parse_corevector_library() {
     }
 
     let library = parse_file(&path).expect("Failed to parse corevector.ndbx");
+
+    // After parsing and upgrading, format version should be 22
+    assert_eq!(library.format_version, 22, "Expected upgraded format version");
 
     // Check that key nodes exist
     let child_names: Vec<&str> = library.root.children.iter().map(|n| n.name.as_str()).collect();
@@ -73,9 +61,9 @@ fn test_parse_corevector_library() {
     assert!(rect_port_names.contains(&"height"), "rect missing height port");
 }
 
-/// Test parsing a simple demo file.
+/// Test that parsing a very old demo file (version 0) returns an error.
 #[test]
-fn test_parse_demo_file() {
+fn test_parse_old_demo_file_returns_error() {
     let path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../../src/test/files/demo.ndbx");
 
@@ -84,8 +72,7 @@ fn test_parse_demo_file() {
         return;
     }
 
-    let library = parse_file(&path).expect("Failed to parse demo.ndbx");
-
-    // Should parse without error and have a root node with a name
-    assert!(!library.root.name.is_empty());
+    // This file has an old/missing format version
+    let result = parse_file(&path);
+    assert!(result.is_err(), "Expected error for old format version");
 }


### PR DESCRIPTION
## Summary
- Add `serializer` module with `serialize()` and `serialize_to_file()` functions
- Add `upgrades` module with version upgrade support (v21 → v22)
- Define `CURRENT_FORMAT_VERSION` (22) and `MIN_SUPPORTED_VERSION` (21)
- Integrate upgrade call into `parse_file()` for automatic version migration
- Update `save_file()` in state.rs to use the new serializer

## Details
The Rust implementation uses format version 22. It can load files from Java's version 21, which are automatically upgraded to v22 on parse. Older versions (< 21) are rejected with an error.

## Test plan
- [x] Load an existing v21 .ndbx file - upgrades to v22
- [x] Load a v20 file - returns "unsupported version" error
- [x] Save to a new file - has formatVersion="22"
- [x] Re-open saved file - loads correctly
- [x] `cargo test -p nodebox-ndbx`

🤖 Generated with [Claude Code](https://claude.ai/code)