### PR TITLE
Add menu/dropdown widgets for node parameters

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -434,6 +434,146 @@ use crate::theme::{
 
 ---
 
+## egui Styling System
+
+NodeBox uses egui for its GUI. Understanding how to properly configure egui's styling is essential for maintaining visual consistency.
+
+### Global Style Configuration
+
+All global styles are configured in `theme.rs` in the `configure_style()` function. This function is called once at startup.
+
+```rust
+pub fn configure_style(ctx: &egui::Context) {
+    let mut style = Style::default();
+    let mut visuals = Visuals::dark();
+
+    // ... configure style and visuals ...
+
+    style.visuals = visuals;
+    ctx.set_style(style);
+}
+```
+
+### Widget Visuals: Set ALL Properties
+
+**Critical:** egui widgets have multiple background properties. If you only set `bg_fill`, egui will use its default brownish-gray for other properties. Always set ALL of these:
+
+```rust
+// For each widget state (noninteractive, inactive, hovered, active, open):
+visuals.widgets.inactive.bg_fill = SLATE_700;       // Primary background
+visuals.widgets.inactive.weak_bg_fill = SLATE_700;  // IMPORTANT: Button frames use this!
+visuals.widgets.inactive.fg_stroke = Stroke::new(1.0, SLATE_200);  // Text/icon color
+visuals.widgets.inactive.bg_stroke = Stroke::NONE;  // Border (usually none)
+visuals.widgets.inactive.corner_radius = CornerRadius::ZERO;
+```
+
+The `weak_bg_fill` property is particularly important - it's used for:
+- Button backgrounds
+- ComboBox button backgrounds
+- Frame backgrounds for "weak" (unfocused) widgets
+
+If you see brownish-gray colors appearing, you likely forgot to set `weak_bg_fill`.
+
+### Widget States
+
+egui has five widget states, each needs full configuration:
+
+| State | When Used |
+|-------|-----------|
+| `noninteractive` | Labels, static text, disabled widgets |
+| `inactive` | Buttons/widgets not being interacted with |
+| `hovered` | Mouse hovering over widget |
+| `active` | Widget being clicked/pressed |
+| `open` | ComboBox/menu when popup is open |
+
+### Menu and Popup Styling
+
+For menus and popups (like ComboBox dropdowns):
+
+```rust
+// Sharp corners on menu popups
+visuals.menu_corner_radius = CornerRadius::ZERO;
+
+// No shadow on popups
+visuals.popup_shadow = egui::Shadow::NONE;
+
+// Tight menu margins
+style.spacing.menu_margin = egui::Margin::same(2);
+```
+
+### Selection Styling
+
+For selected items in lists and menus:
+
+```rust
+visuals.selection.bg_fill = SELECTION_BG;  // Background color (violet)
+visuals.selection.stroke = Stroke::new(1.0, TEXT_STRONG);  // Text visibility
+```
+
+**Note:** `selection.stroke` helps ensure text remains visible on the selection background.
+
+### Local Style Overrides
+
+For widget-specific styling, modify `ui.style_mut()` before rendering:
+
+```rust
+// Example: Smaller font for a specific widget
+let style = ui.style_mut();
+style.override_font_id = Some(egui::FontId::proportional(FONT_SIZE_SMALL));
+
+// Then render your widget
+egui::ComboBox::from_id_salt(id)
+    .selected_text(label)
+    .show_ui(ui, |ui| { ... });
+```
+
+### Common Styling Properties
+
+| Property | Location | Purpose |
+|----------|----------|---------|
+| `style.spacing.button_padding` | Spacing | Internal button padding |
+| `style.spacing.menu_margin` | Spacing | Menu interior margin |
+| `style.spacing.item_spacing` | Spacing | Gap between items |
+| `visuals.window_corner_radius` | Visuals | Window/dialog corners |
+| `visuals.menu_corner_radius` | Visuals | Menu popup corners |
+| `visuals.popup_shadow` | Visuals | Shadow on popups |
+| `visuals.window_shadow` | Visuals | Shadow on windows |
+| `visuals.selection.bg_fill` | Visuals | Selection highlight color |
+| `visuals.widgets.*.bg_fill` | Visuals | Widget background |
+| `visuals.widgets.*.weak_bg_fill` | Visuals | Widget frame/button background |
+| `visuals.widgets.*.fg_stroke` | Visuals | Widget text/icon color |
+
+### Debugging Style Issues
+
+If a widget has wrong colors:
+
+1. **Brownish-gray background?** → Set `weak_bg_fill` for all widget states
+2. **Wrong text color?** → Check `fg_stroke` for the relevant state
+3. **Rounded corners appearing?** → Set `corner_radius = CornerRadius::ZERO`
+4. **Selection not visible?** → Check `selection.bg_fill` and `selection.stroke`
+5. **Menu has shadows?** → Set `popup_shadow = Shadow::NONE`
+
+### Example: Full Widget State Configuration
+
+```rust
+// Inactive state (not hovered, not clicked)
+visuals.widgets.inactive.bg_fill = SLATE_700;
+visuals.widgets.inactive.weak_bg_fill = SLATE_700;
+visuals.widgets.inactive.fg_stroke = Stroke::new(1.0, SLATE_200);
+visuals.widgets.inactive.corner_radius = CornerRadius::ZERO;
+visuals.widgets.inactive.bg_stroke = Stroke::NONE;
+
+// Hovered state
+visuals.widgets.hovered.bg_fill = SLATE_600;
+visuals.widgets.hovered.weak_bg_fill = SLATE_600;
+visuals.widgets.hovered.fg_stroke = Stroke::new(1.0, SLATE_100);
+visuals.widgets.hovered.corner_radius = CornerRadius::ZERO;
+visuals.widgets.hovered.expansion = 0.0;  // No size change on hover
+visuals.widgets.hovered.bg_stroke = Stroke::NONE;
+```
+
+---
+
 ## Evolution
 
 This design system is living documentation. When adding new patterns:

--- a/crates/nodebox-core/src/node/port.rs
+++ b/crates/nodebox-core/src/node/port.rs
@@ -338,6 +338,22 @@ impl Port {
         self.description = Some(description.into());
         self
     }
+
+    /// Sets the menu items and widget type to Menu.
+    pub fn with_menu_items(mut self, items: Vec<MenuItem>) -> Self {
+        self.widget = Widget::Menu;
+        self.menu_items = items;
+        self
+    }
+
+    /// Creates a menu port with options.
+    pub fn menu(name: impl Into<String>, default_key: impl Into<String>, items: Vec<MenuItem>) -> Self {
+        let mut port = Port::new(name, PortType::String);
+        port.value = Value::String(default_key.into());
+        port.widget = Widget::Menu;
+        port.menu_items = items;
+        port
+    }
 }
 
 #[cfg(test)]

--- a/crates/nodebox-gui/src/panels.rs
+++ b/crates/nodebox-gui/src/panels.rs
@@ -306,6 +306,32 @@ impl ParameterPanel {
                     self.show_drag_value_float(ui, &mut point.y, None, None, 1.0, &key_y, is_editing_y);
                 }
             }
+            Widget::Menu => {
+                if let Value::String(ref mut value) = port.value {
+                    // Find current label from menu_items
+                    let current_label = port.menu_items.iter()
+                        .find(|item| item.key == *value)
+                        .map(|item| item.label.as_str())
+                        .unwrap_or(value.as_str());
+
+                    // Use smaller font to match other controls
+                    let style = ui.style_mut();
+                    style.override_font_id = Some(egui::FontId::proportional(theme::FONT_SIZE_SMALL));
+
+                    // Use egui ComboBox
+                    let combo_id = ui.make_persistent_id((&port_key.0, &port_key.1));
+                    egui::ComboBox::from_id_salt(combo_id)
+                        .selected_text(current_label)
+                        .width(120.0)
+                        .show_ui(ui, |ui| {
+                            for item in &port.menu_items {
+                                if ui.selectable_label(*value == item.key, &item.label).clicked() {
+                                    *value = item.key.clone();
+                                }
+                            }
+                        });
+                }
+            }
             Widget::File => {
                 if let Value::String(ref mut path) = port.value {
                     // Show filename or placeholder

--- a/crates/nodebox-gui/src/state.rs
+++ b/crates/nodebox-gui/src/state.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use nodebox_core::geometry::{Path as GeoPath, Color};
-use nodebox_core::node::{Node, NodeLibrary, Port, PortRange};
+use nodebox_core::node::{Node, NodeLibrary, MenuItem, Port, PortRange, Widget};
 use crate::eval;
 
 /// The main application state.
@@ -210,7 +210,11 @@ pub fn populate_default_ports(node: &mut Node) {
                 ensure_port(node, "height", || Port::float("height", 100.0));
                 ensure_port(node, "start_angle", || Port::float("start_angle", 0.0));
                 ensure_port(node, "degrees", || Port::float("degrees", 45.0));
-                ensure_port(node, "type", || Port::string("type", "pie"));
+                ensure_port(node, "type", || Port::menu("type", "pie", vec![
+                    MenuItem::new("pie", "Pie"),
+                    MenuItem::new("chord", "Chord"),
+                    MenuItem::new("open", "Open"),
+                ]));
             }
             // Filters
             "corevector.colorize" => {
@@ -236,7 +240,14 @@ pub fn populate_default_ports(node: &mut Node) {
             "corevector.copy" => {
                 ensure_port(node, "shape", || Port::geometry("shape"));
                 ensure_port(node, "copies", || Port::int("copies", 1));
-                ensure_port(node, "order", || Port::string("order", "tsr"));
+                ensure_port(node, "order", || Port::menu("order", "tsr", vec![
+                    MenuItem::new("srt", "Scale Rot Trans"),
+                    MenuItem::new("str", "Scale Trans Rot"),
+                    MenuItem::new("rst", "Rot Scale Trans"),
+                    MenuItem::new("rtr", "Rot Trans Scale"),
+                    MenuItem::new("tsr", "Trans Scale Rot"),
+                    MenuItem::new("trs", "Trans Rot Scale"),
+                ]));
                 ensure_port(node, "translate", || Port::point("translate", nodebox_core::geometry::Point::ZERO));
                 ensure_port(node, "rotate", || Port::float("rotate", 0.0));
                 ensure_port(node, "scale", || Port::point("scale", nodebox_core::geometry::Point::new(100.0, 100.0)));
@@ -244,8 +255,18 @@ pub fn populate_default_ports(node: &mut Node) {
             "corevector.align" => {
                 ensure_port(node, "shape", || Port::geometry("shape"));
                 ensure_port(node, "position", || Port::point("position", nodebox_core::geometry::Point::ZERO));
-                ensure_port(node, "halign", || Port::string("halign", "center"));
-                ensure_port(node, "valign", || Port::string("valign", "middle"));
+                ensure_port(node, "halign", || Port::menu("halign", "center", vec![
+                    MenuItem::new("none", "No Change"),
+                    MenuItem::new("left", "Left"),
+                    MenuItem::new("center", "Center"),
+                    MenuItem::new("right", "Right"),
+                ]));
+                ensure_port(node, "valign", || Port::menu("valign", "middle", vec![
+                    MenuItem::new("none", "No Change"),
+                    MenuItem::new("top", "Top"),
+                    MenuItem::new("middle", "Middle"),
+                    MenuItem::new("bottom", "Bottom"),
+                ]));
             }
             "corevector.fit" => {
                 ensure_port(node, "shape", || Port::geometry("shape"));
@@ -256,11 +277,21 @@ pub fn populate_default_ports(node: &mut Node) {
             }
             "corevector.resample" => {
                 ensure_port(node, "shape", || Port::geometry("shape"));
+                ensure_port(node, "method", || Port::menu("method", "length", vec![
+                    MenuItem::new("length", "By length"),
+                    MenuItem::new("amount", "By amount"),
+                ]));
+                ensure_port(node, "length", || Port::float("length", 10.0));
                 ensure_port(node, "points", || Port::int("points", 10));
+                ensure_port(node, "per_contour", || Port::boolean("per_contour", false));
             }
             "corevector.wiggle" => {
                 ensure_port(node, "shape", || Port::geometry("shape"));
-                ensure_port(node, "scope", || Port::string("scope", "points"));
+                ensure_port(node, "scope", || Port::menu("scope", "points", vec![
+                    MenuItem::new("points", "Points"),
+                    MenuItem::new("contours", "Contours"),
+                    MenuItem::new("paths", "Paths"),
+                ]));
                 ensure_port(node, "offset", || Port::point("offset", nodebox_core::geometry::Point::new(10.0, 10.0)));
                 ensure_port(node, "seed", || Port::int("seed", 0));
             }
@@ -274,12 +305,23 @@ pub fn populate_default_ports(node: &mut Node) {
             }
             "corevector.stack" => {
                 ensure_port(node, "shapes", || Port::geometry("shapes").with_port_range(PortRange::List));
-                ensure_port(node, "direction", || Port::string("direction", "east"));
-                ensure_port(node, "margin", || Port::float("margin", 0.0));
+                ensure_port(node, "direction", || Port::menu("direction", "e", vec![
+                    MenuItem::new("n", "North"),
+                    MenuItem::new("e", "East"),
+                    MenuItem::new("s", "South"),
+                    MenuItem::new("w", "West"),
+                ]));
+                ensure_port(node, "margin", || Port::float("margin", 5.0));
             }
             "corevector.sort" => {
                 ensure_port(node, "shapes", || Port::geometry("shapes").with_port_range(PortRange::List));
-                ensure_port(node, "order_by", || Port::string("order_by", "x"));
+                ensure_port(node, "order_by", || Port::menu("order_by", "none", vec![
+                    MenuItem::new("none", "No Change"),
+                    MenuItem::new("x", "X"),
+                    MenuItem::new("y", "Y"),
+                    MenuItem::new("angle", "Angle to Point"),
+                    MenuItem::new("distance", "Distance to Point"),
+                ]));
                 ensure_port(node, "position", || Port::point("position", nodebox_core::geometry::Point::ZERO));
             }
             "list.combine" => {
@@ -315,17 +357,113 @@ pub fn populate_default_ports(node: &mut Node) {
                 ensure_port(node, "t", || Port::float("t", 50.0));
                 ensure_port(node, "distance", || Port::float("distance", 50.0));
             }
+            "corevector.compound" => {
+                ensure_port(node, "shape1", || Port::geometry("shape1"));
+                ensure_port(node, "shape2", || Port::geometry("shape2"));
+                ensure_port(node, "function", || Port::menu("function", "united", vec![
+                    MenuItem::new("united", "Union"),
+                    MenuItem::new("subtracted", "Difference"),
+                    MenuItem::new("intersected", "Intersection"),
+                ]));
+                ensure_port(node, "invert_difference", || Port::boolean("invert_difference", false));
+            }
+            "corevector.link" => {
+                ensure_port(node, "shape1", || Port::geometry("shape1"));
+                ensure_port(node, "shape2", || Port::geometry("shape2"));
+                ensure_port(node, "orientation", || Port::menu("orientation", "horizontal", vec![
+                    MenuItem::new("horizontal", "Horizontal"),
+                    MenuItem::new("vertical", "Vertical"),
+                ]));
+            }
+            "corevector.textpath" => {
+                ensure_port(node, "text", || Port::string("text", "hello"));
+                ensure_port(node, "font_name", || Port::string("font_name", "Verdana").with_widget(Widget::Font));
+                ensure_port(node, "font_size", || Port::float("font_size", 24.0));
+                ensure_port(node, "align", || Port::menu("align", "CENTER", vec![
+                    MenuItem::new("LEFT", "Left"),
+                    MenuItem::new("CENTER", "Center"),
+                    MenuItem::new("RIGHT", "Right"),
+                    MenuItem::new("JUSTIFY", "Justify"),
+                ]));
+                ensure_port(node, "position", || Port::point("position", nodebox_core::geometry::Point::ZERO));
+                ensure_port(node, "width", || Port::float("width", 0.0));
+            }
+            "corevector.delete" => {
+                ensure_port(node, "shape", || Port::geometry("shape"));
+                ensure_port(node, "bounding", || Port::geometry("bounding"));
+                ensure_port(node, "scope", || Port::menu("scope", "points", vec![
+                    MenuItem::new("points", "Points"),
+                    MenuItem::new("paths", "Paths"),
+                ]));
+                ensure_port(node, "operation", || Port::menu("operation", "selected", vec![
+                    MenuItem::new("selected", "Delete Selected"),
+                    MenuItem::new("non-selected", "Delete Non-selected"),
+                ]));
+            }
+            "corevector.distribute" => {
+                ensure_port(node, "shapes", || Port::geometry("shapes").with_port_range(PortRange::List));
+                ensure_port(node, "horizontal", || Port::menu("horizontal", "none", vec![
+                    MenuItem::new("none", "No Change"),
+                    MenuItem::new("left", "Left"),
+                    MenuItem::new("center", "Center"),
+                    MenuItem::new("right", "Right"),
+                ]));
+                ensure_port(node, "vertical", || Port::menu("vertical", "none", vec![
+                    MenuItem::new("none", "No Change"),
+                    MenuItem::new("top", "Top"),
+                    MenuItem::new("middle", "Middle"),
+                    MenuItem::new("bottom", "Bottom"),
+                ]));
+            }
+            "corevector.shape_on_path" => {
+                ensure_port(node, "shape", || Port::geometry("shape").with_port_range(PortRange::List));
+                ensure_port(node, "path", || Port::geometry("path"));
+                ensure_port(node, "amount", || Port::int("amount", 1));
+                ensure_port(node, "alignment", || Port::menu("alignment", "leading", vec![
+                    MenuItem::new("leading", "Leading"),
+                    MenuItem::new("trailing", "Trailing"),
+                    MenuItem::new("distributed", "Distributed"),
+                ]));
+                ensure_port(node, "spacing", || Port::float("spacing", 20.0));
+                ensure_port(node, "margin", || Port::float("margin", 0.0));
+                ensure_port(node, "baseline_offset", || Port::float("baseline_offset", 0.0));
+            }
+            "corevector.text_on_path" => {
+                ensure_port(node, "text", || Port::string("text", "text following a path"));
+                ensure_port(node, "path", || Port::geometry("path"));
+                ensure_port(node, "font_name", || Port::string("font_name", "Verdana").with_widget(Widget::Font));
+                ensure_port(node, "font_size", || Port::float("font_size", 24.0));
+                ensure_port(node, "alignment", || Port::menu("alignment", "leading", vec![
+                    MenuItem::new("leading", "Leading"),
+                    MenuItem::new("trailing", "Trailing"),
+                ]));
+                ensure_port(node, "margin", || Port::float("margin", 0.0));
+                ensure_port(node, "baseline_offset", || Port::float("baseline_offset", 0.0));
+            }
             _ => {}
         }
     }
 }
 
-/// Ensure a port exists on a node, adding it with the default if missing.
+/// Ensure a port exists on a node with the correct widget and menu items.
+///
+/// If the port doesn't exist, it's created with the default.
+/// If the port exists but has Widget::String and the default has Widget::Menu,
+/// update the widget type and menu items (preserving the existing value).
 fn ensure_port<F>(node: &mut Node, name: &str, default: F)
 where
     F: FnOnce() -> Port,
 {
-    if node.input(name).is_none() {
+    if let Some(existing) = node.inputs.iter_mut().find(|p| p.name == name) {
+        // Port exists - check if we need to update widget/menu items
+        let default_port = default();
+        if existing.widget == Widget::String && default_port.widget == Widget::Menu {
+            // Update to menu widget and add menu items
+            existing.widget = Widget::Menu;
+            existing.menu_items = default_port.menu_items;
+        }
+    } else {
+        // Port doesn't exist - add it
         node.inputs.push(default());
     }
 }

--- a/crates/nodebox-gui/src/theme.rs
+++ b/crates/nodebox-gui/src/theme.rs
@@ -71,6 +71,8 @@ pub const GRAY_775: Color32 = SLATE_100;
 
 /// Selection background (subtle violet tint)
 pub const VIOLET_900: Color32 = Color32::from_rgb(45, 38, 64);
+/// Lighter selection background (for better text contrast)
+pub const VIOLET_800: Color32 = Color32::from_rgb(76, 58, 118);
 /// Darker pressed state
 pub const VIOLET_600: Color32 = Color32::from_rgb(124, 58, 237);
 /// Primary accent color
@@ -112,8 +114,8 @@ pub const SURFACE_ELEVATED: Color32 = SLATE_700;
 pub const TEXT_EDIT_BG: Color32 = SLATE_700;
 /// Hover state background
 pub const HOVER_BG: Color32 = SLATE_600;
-/// Selection background (subtle violet)
-pub const SELECTION_BG: Color32 = VIOLET_900;
+/// Selection background (visible violet with good text contrast)
+pub const SELECTION_BG: Color32 = VIOLET_800;
 
 // =============================================================================
 // SEMANTIC COLORS - Text
@@ -133,9 +135,9 @@ pub const TEXT_DISABLED: Color32 = SLATE_500;
 // =============================================================================
 
 /// Widget inactive background
-pub const WIDGET_INACTIVE_BG: Color32 = SLATE_600;
+pub const WIDGET_INACTIVE_BG: Color32 = SLATE_700;
 /// Widget hovered background
-pub const WIDGET_HOVERED_BG: Color32 = SLATE_500;
+pub const WIDGET_HOVERED_BG: Color32 = SLATE_600;
 /// Widget active/pressed background
 pub const WIDGET_ACTIVE_BG: Color32 = SLATE_400;
 /// Non-interactive widget background
@@ -373,10 +375,10 @@ pub fn configure_style(ctx: &egui::Context) {
         FontId::monospace(FONT_SIZE_BASE),
     );
 
-    // Spacing - generous for a modern, breathable feel
+    // Spacing - compact for a minimal feel
     style.spacing.item_spacing = egui::vec2(ITEM_SPACING, ITEM_SPACING);
-    style.spacing.button_padding = egui::vec2(PADDING_LARGE, PADDING);
-    style.spacing.menu_margin = egui::Margin::same(MENU_SPACING as i8);
+    style.spacing.button_padding = egui::vec2(8.0, 4.0); // Compact button padding
+    style.spacing.menu_margin = egui::Margin::same(2); // Tight menu margins
     style.spacing.indent = INDENT;
     style.spacing.scroll = egui::style::ScrollStyle {
         bar_width: SCROLL_BAR_WIDTH,
@@ -391,41 +393,50 @@ pub fn configure_style(ctx: &egui::Context) {
     visuals.window_corner_radius = CornerRadius::ZERO; // Sharp 90° corners
     visuals.window_shadow = egui::Shadow::NONE;
 
+    // Visuals - Menu/popup (sharp corners, no shadow)
+    visuals.menu_corner_radius = CornerRadius::ZERO;
+    visuals.popup_shadow = egui::Shadow::NONE;
+
     // Visuals - Panel (no borders, use background differentiation)
     visuals.panel_fill = PANEL_BG;
     visuals.faint_bg_color = SLATE_800;
     visuals.extreme_bg_color = SLATE_950;
 
     // Visuals - Widgets (sharp corners, minimal borders)
-    visuals.widgets.noninteractive.bg_fill = WIDGET_NONINTERACTIVE_BG;
+    visuals.widgets.noninteractive.bg_fill = SLATE_800;
+    visuals.widgets.noninteractive.weak_bg_fill = SLATE_800;
     visuals.widgets.noninteractive.fg_stroke = Stroke::new(1.0, TEXT_SUBDUED);
     visuals.widgets.noninteractive.corner_radius = CornerRadius::ZERO;
     visuals.widgets.noninteractive.bg_stroke = Stroke::NONE;
 
-    visuals.widgets.inactive.bg_fill = WIDGET_INACTIVE_BG;
-    visuals.widgets.inactive.fg_stroke = Stroke::new(1.0, TEXT_DEFAULT);
+    visuals.widgets.inactive.bg_fill = SLATE_700;
+    visuals.widgets.inactive.weak_bg_fill = SLATE_700;
+    visuals.widgets.inactive.fg_stroke = Stroke::new(1.0, SLATE_200);
     visuals.widgets.inactive.corner_radius = CornerRadius::ZERO;
     visuals.widgets.inactive.bg_stroke = Stroke::NONE;
 
-    visuals.widgets.hovered.bg_fill = WIDGET_HOVERED_BG;
-    visuals.widgets.hovered.fg_stroke = Stroke::new(1.0, TEXT_STRONG);
+    visuals.widgets.hovered.bg_fill = SLATE_600;
+    visuals.widgets.hovered.weak_bg_fill = SLATE_600;
+    visuals.widgets.hovered.fg_stroke = Stroke::new(1.0, SLATE_100);
     visuals.widgets.hovered.corner_radius = CornerRadius::ZERO;
     visuals.widgets.hovered.expansion = 0.0; // No expansion, just color change
     visuals.widgets.hovered.bg_stroke = Stroke::NONE;
 
-    visuals.widgets.active.bg_fill = WIDGET_ACTIVE_BG;
-    visuals.widgets.active.fg_stroke = Stroke::new(1.0, TEXT_STRONG);
+    visuals.widgets.active.bg_fill = SLATE_600;
+    visuals.widgets.active.weak_bg_fill = SLATE_600;
+    visuals.widgets.active.fg_stroke = Stroke::new(1.0, SLATE_100);
     visuals.widgets.active.corner_radius = CornerRadius::ZERO;
     visuals.widgets.active.expansion = 0.0;
     visuals.widgets.active.bg_stroke = Stroke::NONE;
 
-    visuals.widgets.open.bg_fill = WIDGET_ACTIVE_BG;
-    visuals.widgets.open.fg_stroke = Stroke::new(1.0, TEXT_STRONG);
+    visuals.widgets.open.bg_fill = SLATE_600;
+    visuals.widgets.open.weak_bg_fill = SLATE_600;
+    visuals.widgets.open.fg_stroke = Stroke::new(1.0, SLATE_200);
     visuals.widgets.open.corner_radius = CornerRadius::ZERO;
 
-    // Selection (violet tint, no stroke for cleaner look)
+    // Selection (violet tint with visible text)
     visuals.selection.bg_fill = SELECTION_BG;
-    visuals.selection.stroke = Stroke::NONE;
+    visuals.selection.stroke = Stroke::new(1.0, TEXT_STRONG);
 
     // Separators - almost invisible
     visuals.widgets.noninteractive.bg_stroke = Stroke::NONE;


### PR DESCRIPTION
## Summary
- Add `Port::with_menu_items()` and `Port::menu()` helper methods for creating menu-based parameters
- Render `Widget::Menu` using egui's ComboBox in the parameter panel
- Convert string parameters to dropdown menus for nodes: arc, copy, align, resample, wiggle, stack, sort, compound, link, textpath, delete, distribute, shape_on_path, text_on_path
- Update `ensure_port()` to automatically migrate existing String widgets to Menu widgets
- Fix egui widget styling (set `weak_bg_fill` for all states to prevent brownish-gray colors)
- Add `VIOLET_800` selection background for better text contrast
- Add egui styling documentation to STYLE_GUIDE.md

## Test plan
- [ ] Create an Arc node → verify "type" dropdown shows Pie/Chord/Open
- [ ] Create a Copy node → verify "order" dropdown shows transform order options
- [ ] Create an Align node → verify halign/valign dropdowns work
- [ ] Check menu styling: sharp corners, no shadows, proper selection highlighting

🤖 Generated with [Claude Code](https://claude.com/claude-code)