### PR TITLE
Add Port trait for sandboxed file access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,9 +262,9 @@ cargo build --workspace --exclude nodebox-python
 cargo test --workspace --exclude nodebox-python
 ```
 
-### Running specific crates
+### Running the application
 ```bash
-cargo run -p nodebox-gui          # Run the GUI
+cargo run                         # Run the desktop GUI application
 cargo run -p nodebox-cli          # Run the CLI
 cargo test -p nodebox-core        # Test specific crate
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2977,9 +2977,9 @@ dependencies = [
  "nodebox-core",
  "nodebox-ndbx",
  "nodebox-ops",
+ "nodebox-port",
  "nodebox-svg",
  "pollster",
- "rfd",
  "serde",
  "serde_json",
  "smol",
@@ -3008,6 +3008,19 @@ dependencies = [
  "rayon",
  "tempfile",
  "usvg",
+]
+
+[[package]]
+name = "nodebox-port"
+version = "0.1.0"
+dependencies = [
+ "arboard",
+ "directories",
+ "log",
+ "rfd",
+ "tempfile",
+ "thiserror 1.0.69",
+ "ureq",
 ]
 
 [[package]]
@@ -4233,6 +4246,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4283,6 +4310,41 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -4617,6 +4679,12 @@ checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 dependencies = [
  "float-cmp",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "svg_fmt"
@@ -5024,6 +5092,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5423,6 +5513,24 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "url",
  "web-sys",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.5",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -6438,6 +6546,12 @@ dependencies = [
  "syn 2.0.114",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,6 @@
 name = "nodebox"
 version.workspace = true
 edition.workspace = true
-
 default-run = "NodeBox"
 
 [[bin]]
@@ -16,18 +15,19 @@ eframe = "0.33"
 [workspace]
 resolver = "2"
 members = [
+    ".",
     "crates/nodebox-core",
     "crates/nodebox-ndbx",
     "crates/nodebox-ops",
     "crates/nodebox-svg",
     "crates/nodebox-cli",
     "crates/nodebox-gui",
+    "crates/nodebox-port",
     "crates/nodebox-python",
 ]
 
-# Default members exclude nodebox-python since it requires Python development libraries.
-# To build nodebox-python, install Python dev headers and run:
-#   cargo build -p nodebox-python
+# Default members exclude nodebox-python (requires Python development libraries).
+# To build it: cargo build -p nodebox-python
 default-members = [
     ".",
     "crates/nodebox-core",
@@ -36,6 +36,7 @@ default-members = [
     "crates/nodebox-svg",
     "crates/nodebox-cli",
     "crates/nodebox-gui",
+    "crates/nodebox-port",
 ]
 
 [workspace.package]

--- a/crates/nodebox-gui/Cargo.toml
+++ b/crates/nodebox-gui/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/lib.rs"
 nodebox-core = { path = "../nodebox-core" }
 nodebox-ops = { path = "../nodebox-ops" }
 nodebox-ndbx = { path = "../nodebox-ndbx" }
+nodebox-port = { path = "../nodebox-port" }
 nodebox-svg = { path = "../nodebox-svg" }
 
 # GUI
@@ -22,9 +23,6 @@ eframe = "0.33"
 egui = "0.33"
 egui_extras = { version = "0.33", features = ["image"] }
 egui-wgpu = { version = "0.33", optional = true }
-
-# File dialogs
-rfd = "0.15"
 
 # Recent files persistence
 directories = "5"

--- a/crates/nodebox-gui/src/app.rs
+++ b/crates/nodebox-gui/src/app.rs
@@ -2,6 +2,9 @@
 
 use eframe::egui::{self, Pos2, Rect, Vec2};
 use nodebox_core::geometry::Point;
+use nodebox_port::{Port, ProjectContext};
+use std::sync::Arc;
+
 use crate::address_bar::{AddressBar, AddressBarAction};
 use crate::animation_bar::AnimationBar;
 use crate::components;
@@ -19,6 +22,10 @@ use crate::viewer_pane::{HandleResult, ViewerPane};
 
 /// The main NodeBox application.
 pub struct NodeBoxApp {
+    /// Port for platform-abstracted file operations.
+    port: Arc<dyn Port>,
+    /// Project context for the current project (tracks save location).
+    project_context: ProjectContext,
     state: AppState,
     address_bar: AddressBar,
     viewer_pane: ViewerPane,
@@ -44,36 +51,46 @@ pub struct NodeBoxApp {
 }
 
 impl NodeBoxApp {
-    /// Create a new NodeBox application instance.
-    #[allow(dead_code)]
-    pub fn new(_cc: &eframe::CreationContext<'_>) -> Self {
-        Self::new_with_file(_cc, None, None)
-    }
-
-    /// Create a new NodeBox application instance, optionally loading an initial file.
-    pub fn new_with_file(
+    /// Create a new NodeBox application instance with a Port for file operations.
+    ///
+    /// This is the primary constructor that accepts an `Arc<dyn Port>` for
+    /// platform-abstracted file operations.
+    pub fn new_with_port(
         cc: &eframe::CreationContext<'_>,
+        port: Arc<dyn Port>,
         initial_file: Option<std::path::PathBuf>,
-        native_menu: Option<NativeMenuHandle>,
     ) -> Self {
         // Configure the global theme/style
         theme::configure_style(&cc.egui_ctx);
+
+        // Initialize native menu bar (macOS)
+        let native_menu = Some(NativeMenuHandle::new());
 
         let mut state = AppState::new();
 
         // Load recent files from disk
         let mut recent_files = RecentFiles::load();
 
-        // Load the initial file if provided
-        if let Some(ref path) = initial_file {
+        // Determine project context from initial file
+        let project_context = if let Some(ref path) = initial_file {
             if let Err(e) = state.load_file(path) {
                 log::error!("Failed to load initial file {:?}: {}", path, e);
+                ProjectContext::new_unsaved()
             } else {
                 // Add to recent files on successful load
                 recent_files.add_file(path.clone());
                 recent_files.save();
+
+                // Create project context from file path
+                if let (Some(parent), Some(file_name)) = (path.parent(), path.file_name()) {
+                    ProjectContext::new(parent, file_name.to_string_lossy().to_string())
+                } else {
+                    ProjectContext::new_unsaved()
+                }
             }
-        }
+        } else {
+            ProjectContext::new_unsaved()
+        };
 
         // Rebuild native menu with recent files
         if let Some(ref menu) = native_menu {
@@ -82,6 +99,88 @@ impl NodeBoxApp {
 
         let hash = Self::hash_library(&state.library);
         Self {
+            port,
+            project_context,
+            state,
+            address_bar: AddressBar::new(),
+            viewer_pane: ViewerPane::new(),
+            network_view: NetworkView::new(),
+            parameters: ParameterPanel::new(),
+            animation_bar: AnimationBar::new(),
+            node_dialog: NodeSelectionDialog::new(),
+            icon_cache: IconCache::new(),
+            history: History::new(),
+            previous_library_hash: hash,
+            render_worker: RenderWorkerHandle::spawn(),
+            render_state: RenderState::new(),
+            render_pending: false, // Initial geometry is already evaluated in AppState::new()
+            native_menu,
+            recent_files,
+        }
+    }
+
+    /// Create a new NodeBox application instance (legacy constructor).
+    ///
+    /// This constructor creates a DesktopPort internally for backwards compatibility.
+    /// Prefer using `new_with_port` for new code.
+    #[allow(dead_code)]
+    pub fn new(_cc: &eframe::CreationContext<'_>) -> Self {
+        Self::new_with_file(_cc, None, None)
+    }
+
+    /// Create a new NodeBox application instance, optionally loading an initial file.
+    ///
+    /// This constructor creates a DesktopPort internally for backwards compatibility.
+    /// Prefer using `new_with_port` for new code.
+    pub fn new_with_file(
+        cc: &eframe::CreationContext<'_>,
+        initial_file: Option<std::path::PathBuf>,
+        native_menu: Option<NativeMenuHandle>,
+    ) -> Self {
+        // Configure the global theme/style
+        theme::configure_style(&cc.egui_ctx);
+
+        // Create a default DesktopPort for backwards compatibility
+        #[cfg(not(target_arch = "wasm32"))]
+        let port: Arc<dyn Port> = Arc::new(nodebox_port::DesktopPort::new());
+        #[cfg(target_arch = "wasm32")]
+        compile_error!("WASM builds must use new_with_port with a custom Port implementation");
+
+        let mut state = AppState::new();
+
+        // Load recent files from disk
+        let mut recent_files = RecentFiles::load();
+
+        // Determine project context from initial file
+        let project_context = if let Some(ref path) = initial_file {
+            if let Err(e) = state.load_file(path) {
+                log::error!("Failed to load initial file {:?}: {}", path, e);
+                ProjectContext::new_unsaved()
+            } else {
+                // Add to recent files on successful load
+                recent_files.add_file(path.clone());
+                recent_files.save();
+
+                // Create project context from file path
+                if let (Some(parent), Some(file_name)) = (path.parent(), path.file_name()) {
+                    ProjectContext::new(parent, file_name.to_string_lossy().to_string())
+                } else {
+                    ProjectContext::new_unsaved()
+                }
+            }
+        } else {
+            ProjectContext::new_unsaved()
+        };
+
+        // Rebuild native menu with recent files
+        if let Some(ref menu) = native_menu {
+            menu.rebuild_recent_menu(&recent_files.files());
+        }
+
+        let hash = Self::hash_library(&state.library);
+        Self {
+            port,
+            project_context,
             state,
             address_bar: AddressBar::new(),
             viewer_pane: ViewerPane::new(),
@@ -110,6 +209,8 @@ impl NodeBoxApp {
         let state = AppState::new();
         let hash = Self::hash_library(&state.library);
         Self {
+            port: Arc::new(nodebox_port::DesktopPort::new()),
+            project_context: ProjectContext::new_unsaved(),
             state,
             address_bar: AddressBar::new(),
             viewer_pane: ViewerPane::new(),
@@ -139,6 +240,8 @@ impl NodeBoxApp {
         state.geometry.clear();
         let hash = Self::hash_library(&state.library);
         Self {
+            port: Arc::new(nodebox_port::DesktopPort::new()),
+            project_context: ProjectContext::new_unsaved(),
             state,
             address_bar: AddressBar::new(),
             viewer_pane: ViewerPane::new(),
@@ -181,13 +284,38 @@ impl NodeBoxApp {
         &mut self.history
     }
 
+    /// Get a reference to the Port for file operations.
+    #[allow(dead_code)]
+    pub fn port(&self) -> &Arc<dyn Port> {
+        &self.port
+    }
+
+    /// Get a reference to the project context.
+    #[allow(dead_code)]
+    pub fn project_context(&self) -> &ProjectContext {
+        &self.project_context
+    }
+
     /// Synchronously evaluate the network for testing.
     ///
     /// Unlike the normal async flow, this directly evaluates and updates geometry.
     #[cfg(test)]
     #[allow(dead_code)]
     pub fn evaluate_for_testing(&mut self) {
-        self.state.evaluate();
+        let (geometry, errors) = crate::eval::evaluate_network(
+            &self.state.library,
+            &self.port,
+            &self.project_context,
+        );
+        if errors.is_empty() {
+            self.state.geometry = geometry;
+            self.state.node_errors.clear();
+        } else {
+            self.state.node_errors = errors
+                .into_iter()
+                .map(|e| (e.node_name, e.message))
+                .collect();
+        }
     }
 
     /// Simulate a frame update for testing purposes.
@@ -204,8 +332,8 @@ impl NodeBoxApp {
             self.previous_library_hash = current_hash;
             self.state.dirty = true;
         }
-        // Synchronously evaluate
-        self.state.evaluate();
+        // Synchronously evaluate using the app's port
+        self.evaluate_for_testing();
     }
 
     /// Compute a simple hash of the library for change detection.
@@ -288,6 +416,8 @@ impl NodeBoxApp {
                 id,
                 self.state.library.clone(),
                 cancel_token,
+                self.port.clone(),
+                self.project_context.clone(),
             );
             self.render_pending = false;
         }
@@ -562,7 +692,8 @@ impl eframe::App for NodeBoxApp {
 
                 ui.scope_builder(egui::UiBuilder::new().max_rect(params_rect), |ui| {
                     ui.set_clip_rect(params_rect);
-                    self.parameters.show(ui, &mut self.state);
+                    self.parameters
+                        .show(ui, &mut self.state, self.port.as_ref(), &self.project_context);
                 });
 
                 // Bottom: Network pane (headers have their own borders)
@@ -789,15 +920,23 @@ impl NodeBoxApp {
     }
 
     fn open_file(&mut self) {
-        if let Some(path) = rfd::FileDialog::new()
-            .add_filter("NodeBox Files", &["ndbx"])
-            .pick_file()
-        {
-            if let Err(e) = self.state.load_file(&path) {
-                log::error!("Failed to load file: {}", e);
-            } else {
-                self.add_to_recent_files(path);
+        use nodebox_port::FileFilter;
+
+        match self.port.show_open_project_dialog(&[FileFilter::nodebox()]) {
+            Ok(Some(path)) => {
+                if let Err(e) = self.state.load_file(&path) {
+                    log::error!("Failed to load file: {}", e);
+                } else {
+                    // Update project context with new file location
+                    if let (Some(parent), Some(file_name)) = (path.parent(), path.file_name()) {
+                        self.project_context =
+                            ProjectContext::new(parent, file_name.to_string_lossy().to_string());
+                    }
+                    self.add_to_recent_files(path);
+                }
             }
+            Ok(None) => {} // User cancelled
+            Err(e) => log::error!("Failed to open file dialog: {}", e),
         }
     }
 
@@ -806,6 +945,11 @@ impl NodeBoxApp {
         if let Err(e) = self.state.load_file(path) {
             log::error!("Failed to load recent file: {}", e);
         } else {
+            // Update project context with new file location
+            if let (Some(parent), Some(file_name)) = (path.parent(), path.file_name()) {
+                self.project_context =
+                    ProjectContext::new(parent, file_name.to_string_lossy().to_string());
+            }
             self.add_to_recent_files(path.to_path_buf());
         }
     }
@@ -839,50 +983,66 @@ impl NodeBoxApp {
     }
 
     fn save_file_as(&mut self) {
-        if let Some(path) = rfd::FileDialog::new()
-            .add_filter("NodeBox Files", &["ndbx"])
-            .save_file()
-        {
-            if let Err(e) = self.state.save_file(&path) {
-                log::error!("Failed to save file: {}", e);
-            } else {
-                self.add_to_recent_files(path);
+        use nodebox_port::FileFilter;
+
+        match self.port.show_save_project_dialog(&[FileFilter::nodebox()], Some("untitled.ndbx")) {
+            Ok(Some(path)) => {
+                if let Err(e) = self.state.save_file(&path) {
+                    log::error!("Failed to save file: {}", e);
+                } else {
+                    // Update project context with new file location
+                    if let (Some(parent), Some(file_name)) = (path.parent(), path.file_name()) {
+                        self.project_context =
+                            ProjectContext::new(parent, file_name.to_string_lossy().to_string());
+                    }
+                    self.add_to_recent_files(path);
+                }
             }
+            Ok(None) => {} // User cancelled
+            Err(e) => log::error!("Failed to open save dialog: {}", e),
         }
     }
 
     fn export_svg(&mut self) {
-        if let Some(path) = rfd::FileDialog::new()
-            .add_filter("SVG Files", &["svg"])
-            .save_file()
-        {
-            // Use document dimensions for export
-            let width = self.state.library.width();
-            let height = self.state.library.height();
-            if let Err(e) = self.state.export_svg(&path, width, height) {
-                log::error!("Failed to export SVG: {}", e);
+        use nodebox_port::FileFilter;
+
+        // Export dialogs use save_project_dialog since exports are not sandboxed
+        match self.port.show_save_project_dialog(&[FileFilter::svg()], Some("export.svg")) {
+            Ok(Some(path)) => {
+                // Use document dimensions for export
+                let width = self.state.library.width();
+                let height = self.state.library.height();
+                if let Err(e) = self.state.export_svg(&path, width, height) {
+                    log::error!("Failed to export SVG: {}", e);
+                }
             }
+            Ok(None) => {} // User cancelled
+            Err(e) => log::error!("Failed to open export dialog: {}", e),
         }
     }
 
     fn export_png(&mut self) {
-        if let Some(path) = rfd::FileDialog::new()
-            .add_filter("PNG Files", &["png"])
-            .save_file()
-        {
-            // Use document dimensions for export
-            let width = self.state.library.width() as u32;
-            let height = self.state.library.height() as u32;
+        use nodebox_port::FileFilter;
 
-            if let Err(e) = crate::export::export_png(
-                &self.state.geometry,
-                &path,
-                width,
-                height,
-                self.state.background_color,
-            ) {
-                log::error!("Failed to export PNG: {}", e);
+        // Export dialogs use save_project_dialog since exports are not sandboxed
+        match self.port.show_save_project_dialog(&[FileFilter::png()], Some("export.png")) {
+            Ok(Some(path)) => {
+                // Use document dimensions for export
+                let width = self.state.library.width() as u32;
+                let height = self.state.library.height() as u32;
+
+                if let Err(e) = crate::export::export_png(
+                    &self.state.geometry,
+                    &path,
+                    width,
+                    height,
+                    self.state.background_color,
+                ) {
+                    log::error!("Failed to export PNG: {}", e);
+                }
             }
+            Ok(None) => {} // User cancelled
+            Err(e) => log::error!("Failed to open export dialog: {}", e),
         }
     }
 }

--- a/crates/nodebox-gui/src/eval.rs
+++ b/crates/nodebox-gui/src/eval.rs
@@ -1,10 +1,12 @@
 //! Network evaluation - executes node graphs to produce geometry.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 use nodebox_core::geometry::{Path, Point, Color, Contour, PathPoint, PointType};
 use nodebox_core::node::{Node, NodeLibrary, EvalError};
 use nodebox_core::node::PortRange;
 use nodebox_core::Value;
+use nodebox_port::{Port, ProjectContext};
 use crate::render_worker::CancellationToken;
 
 /// Error information for a specific node.
@@ -145,7 +147,13 @@ impl NodeOutput {
 /// Evaluate a node network and return the output of the rendered node along with any errors.
 ///
 /// Returns a tuple of (paths, errors). If there are errors, paths will be empty.
-pub fn evaluate_network(library: &NodeLibrary) -> (Vec<Path>, Vec<NodeError>) {
+///
+/// The `port` and `project_context` are used for sandboxed file access (e.g., import_svg).
+pub fn evaluate_network(
+    library: &NodeLibrary,
+    port: &Arc<dyn Port>,
+    project_context: &ProjectContext,
+) -> (Vec<Path>, Vec<NodeError>) {
     let network = &library.root;
 
     // Find the rendered child
@@ -161,7 +169,7 @@ pub fn evaluate_network(library: &NodeLibrary) -> (Vec<Path>, Vec<NodeError>) {
     let mut cache: HashMap<String, EvalResult> = HashMap::new();
 
     // Evaluate the rendered node (this will recursively evaluate dependencies)
-    let result = evaluate_node(network, &rendered_name, &mut cache);
+    let result = evaluate_node(network, &rendered_name, &mut cache, port, project_context);
 
     match result {
         Ok(output) => (output.to_paths(), Vec::new()),
@@ -200,10 +208,14 @@ pub fn evaluate_network(library: &NodeLibrary) -> (Vec<Path>, Vec<NodeError>) {
 ///
 /// The cache parameter is both input (for reusing previous results) and output
 /// (for preserving partial results on cancellation).
+///
+/// The `port` and `project_context` are used for sandboxed file access (e.g., import_svg).
 pub fn evaluate_network_cancellable(
     library: &NodeLibrary,
     cancel_token: &CancellationToken,
     cache: &mut HashMap<String, NodeOutput>,
+    port: &Arc<dyn Port>,
+    project_context: &ProjectContext,
 ) -> EvalOutcome {
     let network = &library.root;
 
@@ -236,6 +248,8 @@ pub fn evaluate_network_cancellable(
         &rendered_name,
         &mut eval_cache,
         cancel_token,
+        port,
+        project_context,
     );
 
     // Convert cache back to NodeOutput format (preserve successful results)
@@ -379,6 +393,8 @@ fn evaluate_node_cancellable(
     node_name: &str,
     cache: &mut HashMap<String, EvalResult>,
     cancel_token: &CancellationToken,
+    port: &Arc<dyn Port>,
+    project_context: &ProjectContext,
 ) -> EvalResult {
     // Check cancellation before starting this node
     if cancel_token.is_cancelled() {
@@ -400,7 +416,7 @@ fn evaluate_node_cancellable(
     let mut inputs: HashMap<String, NodeOutput> = HashMap::new();
 
     // For each input port, check if there are connections
-    for port in &node.inputs {
+    for node_port in &node.inputs {
         // Check cancellation during input collection
         if cancel_token.is_cancelled() {
             return Err(EvalError::Cancelled);
@@ -409,12 +425,12 @@ fn evaluate_node_cancellable(
         // Get ALL connections to this port (for merge/combine operations)
         let connections: Vec<_> = network.connections
             .iter()
-            .filter(|c| c.input_node == node_name && c.input_port == port.name)
+            .filter(|c| c.input_node == node_name && c.input_port == node_port.name)
             .collect();
 
         if connections.is_empty() {
             // No connections - use the port's default value
-            inputs.insert(port.name.clone(), value_to_output(&port.value));
+            inputs.insert(node_port.name.clone(), value_to_output(&node_port.value));
         } else if connections.len() == 1 {
             // Single connection - evaluate and use directly
             let upstream_output = evaluate_node_cancellable(
@@ -422,8 +438,10 @@ fn evaluate_node_cancellable(
                 &connections[0].output_node,
                 cache,
                 cancel_token,
+                port,
+                project_context,
             )?;
-            inputs.insert(port.name.clone(), upstream_output);
+            inputs.insert(node_port.name.clone(), upstream_output);
         } else {
             // Multiple connections - collect all outputs as paths
             let mut all_paths: Vec<Path> = Vec::new();
@@ -433,10 +451,12 @@ fn evaluate_node_cancellable(
                     &conn.output_node,
                     cache,
                     cancel_token,
+                    port,
+                    project_context,
                 )?;
                 all_paths.extend(upstream_output.to_paths());
             }
-            inputs.insert(port.name.clone(), NodeOutput::Paths(all_paths));
+            inputs.insert(node_port.name.clone(), NodeOutput::Paths(all_paths));
         }
     }
 
@@ -460,6 +480,8 @@ fn evaluate_node_cancellable(
                     &conn.output_node,
                     cache,
                     cancel_token,
+                    port,
+                    project_context,
                 )?;
                 inputs.insert(conn.input_port.clone(), upstream_output);
             } else {
@@ -471,6 +493,8 @@ fn evaluate_node_cancellable(
                         &c.output_node,
                         cache,
                         cancel_token,
+                        port,
+                        project_context,
                     )?;
                     all_paths.extend(upstream_output.to_paths());
                 }
@@ -485,9 +509,9 @@ fn evaluate_node_cancellable(
     let result = match iteration_count {
         None => {
             // Empty list input: still call execute_node to detect missing required inputs
-            execute_node(node, &inputs)
+            execute_node(node, &inputs, port, project_context)
         }
-        Some(1) => execute_node(node, &inputs), // Single iteration (optimization)
+        Some(1) => execute_node(node, &inputs, port, project_context), // Single iteration (optimization)
         Some(count) => {
             // Multiple iterations: list matching with cancellation checks
             let mut results = Vec::with_capacity(count);
@@ -498,7 +522,7 @@ fn evaluate_node_cancellable(
                 }
 
                 let iter_inputs = build_iteration_inputs(&inputs, node, i);
-                let result = execute_node(node, &iter_inputs)?;
+                let result = execute_node(node, &iter_inputs, port, project_context)?;
                 results.push(result);
             }
             Ok(collect_results(results))
@@ -515,6 +539,8 @@ fn evaluate_node(
     network: &Node,
     node_name: &str,
     cache: &mut HashMap<String, EvalResult>,
+    port: &Arc<dyn Port>,
+    project_context: &ProjectContext,
 ) -> EvalResult {
     // Check cache first
     if let Some(result) = cache.get(node_name) {
@@ -531,28 +557,28 @@ fn evaluate_node(
     let mut inputs: HashMap<String, NodeOutput> = HashMap::new();
 
     // For each input port, check if there are connections
-    for port in &node.inputs {
+    for node_port in &node.inputs {
         // Get ALL connections to this port (for merge/combine operations)
         let connections: Vec<_> = network.connections
             .iter()
-            .filter(|c| c.input_node == node_name && c.input_port == port.name)
+            .filter(|c| c.input_node == node_name && c.input_port == node_port.name)
             .collect();
 
         if connections.is_empty() {
             // No connections - use the port's default value
-            inputs.insert(port.name.clone(), value_to_output(&port.value));
+            inputs.insert(node_port.name.clone(), value_to_output(&node_port.value));
         } else if connections.len() == 1 {
             // Single connection - evaluate and use directly
-            let upstream_output = evaluate_node(network, &connections[0].output_node, cache)?;
-            inputs.insert(port.name.clone(), upstream_output);
+            let upstream_output = evaluate_node(network, &connections[0].output_node, cache, port, project_context)?;
+            inputs.insert(node_port.name.clone(), upstream_output);
         } else {
             // Multiple connections - collect all outputs as paths
             let mut all_paths: Vec<Path> = Vec::new();
             for conn in connections {
-                let upstream_output = evaluate_node(network, &conn.output_node, cache)?;
+                let upstream_output = evaluate_node(network, &conn.output_node, cache, port, project_context)?;
                 all_paths.extend(upstream_output.to_paths());
             }
-            inputs.insert(port.name.clone(), NodeOutput::Paths(all_paths));
+            inputs.insert(node_port.name.clone(), NodeOutput::Paths(all_paths));
         }
     }
 
@@ -567,13 +593,13 @@ fn evaluate_node(
                 .collect();
 
             if all_conns.len() == 1 {
-                let upstream_output = evaluate_node(network, &conn.output_node, cache)?;
+                let upstream_output = evaluate_node(network, &conn.output_node, cache, port, project_context)?;
                 inputs.insert(conn.input_port.clone(), upstream_output);
             } else {
                 // Multiple connections - collect all outputs as paths
                 let mut all_paths: Vec<Path> = Vec::new();
                 for c in all_conns {
-                    let upstream_output = evaluate_node(network, &c.output_node, cache)?;
+                    let upstream_output = evaluate_node(network, &c.output_node, cache, port, project_context)?;
                     all_paths.extend(upstream_output.to_paths());
                 }
                 inputs.insert(conn.input_port.clone(), NodeOutput::Paths(all_paths));
@@ -588,15 +614,15 @@ fn evaluate_node(
         None => {
             // Empty list input: still call execute_node to detect missing required inputs
             // This ensures nodes that require inputs produce proper errors
-            execute_node(node, &inputs)
+            execute_node(node, &inputs, port, project_context)
         }
-        Some(1) => execute_node(node, &inputs), // Single iteration (optimization)
+        Some(1) => execute_node(node, &inputs, port, project_context), // Single iteration (optimization)
         Some(count) => {
             // Multiple iterations: list matching
             let mut results = Vec::with_capacity(count);
             for i in 0..count {
                 let iter_inputs = build_iteration_inputs(&inputs, node, i);
-                let result = execute_node(node, &iter_inputs)?;
+                let result = execute_node(node, &iter_inputs, port, project_context)?;
                 results.push(result);
             }
             Ok(collect_results(results))
@@ -719,7 +745,12 @@ fn require_paths(inputs: &HashMap<String, NodeOutput>, node_name: &str, port_nam
 }
 
 /// Execute a node and return its output.
-fn execute_node(node: &Node, inputs: &HashMap<String, NodeOutput>) -> EvalResult {
+fn execute_node(
+    node: &Node,
+    inputs: &HashMap<String, NodeOutput>,
+    port: &Arc<dyn Port>,
+    project_context: &ProjectContext,
+) -> EvalResult {
     // Get the function name (prototype determines what the node does)
     let proto = match &node.prototype {
         Some(p) => p.as_str(),
@@ -1098,7 +1129,22 @@ fn execute_node(node: &Node, inputs: &HashMap<String, NodeOutput>) -> EvalResult
             let centered = get_bool(inputs, "centered", true);
             let position = get_point(inputs, "position", Point::ZERO);
 
-            match nodebox_ops::import_svg(&file_path, centered, position) {
+            // Empty path returns empty geometry
+            if file_path.is_empty() {
+                return Ok(NodeOutput::None);
+            }
+
+            // Read the SVG file through the Port system (sandboxed)
+            let svg_content = match port.read_text_file(project_context, &file_path) {
+                Ok(content) => content,
+                Err(e) => {
+                    log::warn!("SVG import: {}", e);
+                    return Ok(NodeOutput::None);
+                }
+            };
+
+            // Parse the SVG content
+            match nodebox_ops::import_svg(&svg_content, centered, position) {
                 Ok(geometry) => {
                     if geometry.is_empty() {
                         Ok(NodeOutput::None)
@@ -1107,7 +1153,7 @@ fn execute_node(node: &Node, inputs: &HashMap<String, NodeOutput>) -> EvalResult
                     }
                 }
                 Err(e) => {
-                    log::warn!("SVG import error: {}", e);
+                    log::warn!("SVG parse error: {}", e);
                     Ok(NodeOutput::None)
                 }
             }
@@ -1131,7 +1177,13 @@ fn execute_node(node: &Node, inputs: &HashMap<String, NodeOutput>) -> EvalResult
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nodebox_core::node::{Port, Connection, PortRange};
+    use nodebox_core::node::{Port as NodePort, Connection, PortRange};
+    use nodebox_port::{TestPort, ProjectContext};
+
+    /// Create a test port and project context for evaluation tests.
+    fn test_port_and_context() -> (Arc<dyn nodebox_port::Port>, ProjectContext) {
+        (Arc::new(TestPort::new()), ProjectContext::new_unsaved())
+    }
 
     #[test]
     fn test_evaluate_simple_ellipse() {
@@ -1140,13 +1192,14 @@ mod tests {
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(Port::point("position", Point::new(100.0, 100.0)))
-                    .with_input(Port::float("width", 50.0))
-                    .with_input(Port::float("height", 50.0))
+                    .with_input(NodePort::point("position", Point::new(100.0, 100.0)))
+                    .with_input(NodePort::float("width", 50.0))
+                    .with_input(NodePort::float("height", 50.0))
             )
             .with_rendered_child("ellipse1");
 
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
 
         let bounds = paths[0].bounds().unwrap();
@@ -1161,22 +1214,23 @@ mod tests {
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(Port::point("position", Point::new(100.0, 100.0)))
-                    .with_input(Port::float("width", 50.0))
-                    .with_input(Port::float("height", 50.0))
+                    .with_input(NodePort::point("position", Point::new(100.0, 100.0)))
+                    .with_input(NodePort::float("width", 50.0))
+                    .with_input(NodePort::float("height", 50.0))
             )
             .with_child(
                 Node::new("colorize1")
                     .with_prototype("corevector.colorize")
-                    .with_input(Port::geometry("shape"))
-                    .with_input(Port::color("fill", Color::rgb(1.0, 0.0, 0.0)))
-                    .with_input(Port::color("stroke", Color::BLACK))
-                    .with_input(Port::float("strokeWidth", 2.0))
+                    .with_input(NodePort::geometry("shape"))
+                    .with_input(NodePort::color("fill", Color::rgb(1.0, 0.0, 0.0)))
+                    .with_input(NodePort::color("stroke", Color::BLACK))
+                    .with_input(NodePort::float("strokeWidth", 2.0))
             )
             .with_connection(Connection::new("ellipse1", "colorize1", "shape"))
             .with_rendered_child("colorize1");
 
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
 
         // Check that the colorize was applied
@@ -1194,27 +1248,28 @@ mod tests {
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(Port::point("position", Point::ZERO))
-                    .with_input(Port::float("width", 50.0))
-                    .with_input(Port::float("height", 50.0))
+                    .with_input(NodePort::point("position", Point::ZERO))
+                    .with_input(NodePort::float("width", 50.0))
+                    .with_input(NodePort::float("height", 50.0))
             )
             .with_child(
                 Node::new("rect1")
                     .with_prototype("corevector.rect")
-                    .with_input(Port::point("position", Point::new(100.0, 0.0)))
-                    .with_input(Port::float("width", 50.0))
-                    .with_input(Port::float("height", 50.0))
+                    .with_input(NodePort::point("position", Point::new(100.0, 0.0)))
+                    .with_input(NodePort::float("width", 50.0))
+                    .with_input(NodePort::float("height", 50.0))
             )
             .with_child(
                 Node::new("merge1")
                     .with_prototype("corevector.merge")
-                    .with_input(Port::geometry("shapes"))
+                    .with_input(NodePort::geometry("shapes"))
             )
             .with_connection(Connection::new("ellipse1", "merge1", "shapes"))
             .with_connection(Connection::new("rect1", "merge1", "shapes"))
             .with_rendered_child("merge1");
 
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
         // Merge collects all connected shapes
         assert_eq!(paths.len(), 2);
     }
@@ -1226,13 +1281,14 @@ mod tests {
             .with_child(
                 Node::new("rect1")
                     .with_prototype("corevector.rect")
-                    .with_input(Port::point("position", Point::ZERO))
-                    .with_input(Port::float("width", 80.0))
-                    .with_input(Port::float("height", 40.0))
+                    .with_input(NodePort::point("position", Point::ZERO))
+                    .with_input(NodePort::float("width", 80.0))
+                    .with_input(NodePort::float("height", 40.0))
             )
             .with_rendered_child("rect1");
 
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
 
         let bounds = paths[0].bounds().unwrap();
@@ -1247,13 +1303,14 @@ mod tests {
             .with_child(
                 Node::new("line1")
                     .with_prototype("corevector.line")
-                    .with_input(Port::point("point1", Point::new(0.0, 0.0)))
-                    .with_input(Port::point("point2", Point::new(100.0, 50.0)))
-                    .with_input(Port::int("points", 2))
+                    .with_input(NodePort::point("point1", Point::new(0.0, 0.0)))
+                    .with_input(NodePort::point("point2", Point::new(100.0, 50.0)))
+                    .with_input(NodePort::int("points", 2))
             )
             .with_rendered_child("line1");
 
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
 
         let bounds = paths[0].bounds().unwrap();
@@ -1268,14 +1325,15 @@ mod tests {
             .with_child(
                 Node::new("polygon1")
                     .with_prototype("corevector.polygon")
-                    .with_input(Port::point("position", Point::ZERO))
-                    .with_input(Port::float("radius", 50.0))
-                    .with_input(Port::int("sides", 6))
-                    .with_input(Port::boolean("align", true))
+                    .with_input(NodePort::point("position", Point::ZERO))
+                    .with_input(NodePort::float("radius", 50.0))
+                    .with_input(NodePort::int("sides", 6))
+                    .with_input(NodePort::boolean("align", true))
             )
             .with_rendered_child("polygon1");
 
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
 
         // Hexagon with radius 50 should have bounds approximately 100x86 (2*r x sqrt(3)*r)
@@ -1291,14 +1349,15 @@ mod tests {
             .with_child(
                 Node::new("star1")
                     .with_prototype("corevector.star")
-                    .with_input(Port::point("position", Point::ZERO))
-                    .with_input(Port::int("points", 5))
-                    .with_input(Port::float("outer", 50.0))
-                    .with_input(Port::float("inner", 25.0))
+                    .with_input(NodePort::point("position", Point::ZERO))
+                    .with_input(NodePort::int("points", 5))
+                    .with_input(NodePort::float("outer", 50.0))
+                    .with_input(NodePort::float("inner", 25.0))
             )
             .with_rendered_child("star1");
 
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
 
         // Star with outer radius 50 should have bounds approximately 100x100
@@ -1313,16 +1372,17 @@ mod tests {
             .with_child(
                 Node::new("arc1")
                     .with_prototype("corevector.arc")
-                    .with_input(Port::point("position", Point::ZERO))
-                    .with_input(Port::float("width", 100.0))
-                    .with_input(Port::float("height", 100.0))
-                    .with_input(Port::float("start_angle", 0.0))
-                    .with_input(Port::float("degrees", 180.0))
-                    .with_input(Port::string("type", "pie"))
+                    .with_input(NodePort::point("position", Point::ZERO))
+                    .with_input(NodePort::float("width", 100.0))
+                    .with_input(NodePort::float("height", 100.0))
+                    .with_input(NodePort::float("start_angle", 0.0))
+                    .with_input(NodePort::float("degrees", 180.0))
+                    .with_input(NodePort::string("type", "pie"))
             )
             .with_rendered_child("arc1");
 
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
     }
 
@@ -1333,20 +1393,21 @@ mod tests {
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(Port::point("position", Point::ZERO))
-                    .with_input(Port::float("width", 50.0))
-                    .with_input(Port::float("height", 50.0))
+                    .with_input(NodePort::point("position", Point::ZERO))
+                    .with_input(NodePort::float("width", 50.0))
+                    .with_input(NodePort::float("height", 50.0))
             )
             .with_child(
                 Node::new("translate1")
                     .with_prototype("corevector.translate")
-                    .with_input(Port::geometry("shape"))
-                    .with_input(Port::point("translate", Point::new(100.0, 50.0)))
+                    .with_input(NodePort::geometry("shape"))
+                    .with_input(NodePort::point("translate", Point::new(100.0, 50.0)))
             )
             .with_connection(Connection::new("ellipse1", "translate1", "shape"))
             .with_rendered_child("translate1");
 
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
 
         let bounds = paths[0].bounds().unwrap();
@@ -1365,21 +1426,22 @@ mod tests {
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(Port::point("position", Point::ZERO))
-                    .with_input(Port::float("width", 100.0))
-                    .with_input(Port::float("height", 100.0))
+                    .with_input(NodePort::point("position", Point::ZERO))
+                    .with_input(NodePort::float("width", 100.0))
+                    .with_input(NodePort::float("height", 100.0))
             )
             .with_child(
                 Node::new("scale1")
                     .with_prototype("corevector.scale")
-                    .with_input(Port::geometry("shape"))
-                    .with_input(Port::point("scale", Point::new(50.0, 200.0))) // 50% x, 200% y
-                    .with_input(Port::point("origin", Point::ZERO))
+                    .with_input(NodePort::geometry("shape"))
+                    .with_input(NodePort::point("scale", Point::new(50.0, 200.0))) // 50% x, 200% y
+                    .with_input(NodePort::point("origin", Point::ZERO))
             )
             .with_connection(Connection::new("ellipse1", "scale1", "shape"))
             .with_rendered_child("scale1");
 
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
 
         let bounds = paths[0].bounds().unwrap();
@@ -1395,24 +1457,25 @@ mod tests {
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(Port::point("position", Point::ZERO))
-                    .with_input(Port::float("width", 50.0))
-                    .with_input(Port::float("height", 50.0))
+                    .with_input(NodePort::point("position", Point::ZERO))
+                    .with_input(NodePort::float("width", 50.0))
+                    .with_input(NodePort::float("height", 50.0))
             )
             .with_child(
                 Node::new("copy1")
                     .with_prototype("corevector.copy")
-                    .with_input(Port::geometry("shape"))
-                    .with_input(Port::int("copies", 3))
-                    .with_input(Port::string("order", "tsr"))
-                    .with_input(Port::point("translate", Point::new(60.0, 0.0)))
-                    .with_input(Port::float("rotate", 0.0))
-                    .with_input(Port::point("scale", Point::new(100.0, 100.0)))
+                    .with_input(NodePort::geometry("shape"))
+                    .with_input(NodePort::int("copies", 3))
+                    .with_input(NodePort::string("order", "tsr"))
+                    .with_input(NodePort::point("translate", Point::new(60.0, 0.0)))
+                    .with_input(NodePort::float("rotate", 0.0))
+                    .with_input(NodePort::point("scale", Point::new(100.0, 100.0)))
             )
             .with_connection(Connection::new("ellipse1", "copy1", "shape"))
             .with_rendered_child("copy1");
 
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
         // Should have 3 copies
         assert_eq!(paths.len(), 3);
     }
@@ -1420,7 +1483,8 @@ mod tests {
     #[test]
     fn test_evaluate_empty_network() {
         let library = NodeLibrary::new("test");
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
         assert!(paths.is_empty());
     }
 
@@ -1431,13 +1495,14 @@ mod tests {
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(Port::point("position", Point::ZERO))
-                    .with_input(Port::float("width", 50.0))
-                    .with_input(Port::float("height", 50.0))
+                    .with_input(NodePort::point("position", Point::ZERO))
+                    .with_input(NodePort::float("width", 50.0))
+                    .with_input(NodePort::float("height", 50.0))
             );
         // No rendered_child set
 
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
         assert!(paths.is_empty());
     }
 
@@ -1448,15 +1513,16 @@ mod tests {
             .with_child(
                 Node::new("colorize1")
                     .with_prototype("corevector.colorize")
-                    .with_input(Port::geometry("shape"))
-                    .with_input(Port::color("fill", Color::rgb(1.0, 0.0, 0.0)))
-                    .with_input(Port::color("stroke", Color::BLACK))
-                    .with_input(Port::float("strokeWidth", 2.0))
+                    .with_input(NodePort::geometry("shape"))
+                    .with_input(NodePort::color("fill", Color::rgb(1.0, 0.0, 0.0)))
+                    .with_input(NodePort::color("stroke", Color::BLACK))
+                    .with_input(NodePort::float("strokeWidth", 2.0))
             )
             .with_rendered_child("colorize1");
 
         // Should handle missing input gracefully
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
         assert!(paths.is_empty());
     }
 
@@ -1471,7 +1537,8 @@ mod tests {
             .with_rendered_child("unknown1");
 
         // Should handle unknown node type gracefully
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
         assert!(paths.is_empty());
     }
 
@@ -1482,20 +1549,21 @@ mod tests {
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(Port::point("position", Point::ZERO))
-                    .with_input(Port::float("width", 100.0))
-                    .with_input(Port::float("height", 100.0))
+                    .with_input(NodePort::point("position", Point::ZERO))
+                    .with_input(NodePort::float("width", 100.0))
+                    .with_input(NodePort::float("height", 100.0))
             )
             .with_child(
                 Node::new("resample1")
                     .with_prototype("corevector.resample")
-                    .with_input(Port::geometry("shape"))
-                    .with_input(Port::int("points", 20))
+                    .with_input(NodePort::geometry("shape"))
+                    .with_input(NodePort::int("points", 20))
             )
             .with_connection(Connection::new("ellipse1", "resample1", "shape"))
             .with_rendered_child("resample1");
 
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
         // Resampled path should have the specified number of points
         // Note: exact point count depends on implementation
@@ -1508,23 +1576,24 @@ mod tests {
             .with_child(
                 Node::new("grid1")
                     .with_prototype("corevector.grid")
-                    .with_input(Port::int("columns", 3))
-                    .with_input(Port::int("rows", 3))
-                    .with_input(Port::float("width", 100.0))
-                    .with_input(Port::float("height", 100.0))
-                    .with_input(Port::point("position", Point::ZERO))
+                    .with_input(NodePort::int("columns", 3))
+                    .with_input(NodePort::int("rows", 3))
+                    .with_input(NodePort::float("width", 100.0))
+                    .with_input(NodePort::float("height", 100.0))
+                    .with_input(NodePort::point("position", Point::ZERO))
             )
             .with_child(
                 Node::new("connect1")
                     .with_prototype("corevector.connect")
                     // points port expects entire list, not individual values
-                    .with_input(Port::geometry("points").with_port_range(PortRange::List))
-                    .with_input(Port::boolean("closed", false))
+                    .with_input(NodePort::geometry("points").with_port_range(PortRange::List))
+                    .with_input(NodePort::boolean("closed", false))
             )
             .with_connection(Connection::new("grid1", "connect1", "points"))
             .with_rendered_child("connect1");
 
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
     }
 
@@ -1541,13 +1610,14 @@ mod tests {
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(Port::point("position", Point::new(100.0, 50.0)))
-                    .with_input(Port::float("width", 50.0))
-                    .with_input(Port::float("height", 50.0))
+                    .with_input(NodePort::point("position", Point::new(100.0, 50.0)))
+                    .with_input(NodePort::float("width", 50.0))
+                    .with_input(NodePort::float("height", 50.0))
             )
             .with_rendered_child("ellipse1");
 
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
 
         let bounds = paths[0].bounds().unwrap();
@@ -1567,13 +1637,14 @@ mod tests {
             .with_child(
                 Node::new("rect1")
                     .with_prototype("corevector.rect")
-                    .with_input(Port::point("position", Point::new(-50.0, 25.0)))
-                    .with_input(Port::float("width", 80.0))
-                    .with_input(Port::float("height", 40.0))
+                    .with_input(NodePort::point("position", Point::new(-50.0, 25.0)))
+                    .with_input(NodePort::float("width", 80.0))
+                    .with_input(NodePort::float("height", 40.0))
             )
             .with_rendered_child("rect1");
 
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
 
         let bounds = paths[0].bounds().unwrap();
@@ -1591,14 +1662,15 @@ mod tests {
             .with_child(
                 Node::new("rect1")
                     .with_prototype("corevector.rect")
-                    .with_input(Port::point("position", Point::new(0.0, 0.0)))
-                    .with_input(Port::float("width", 100.0))
-                    .with_input(Port::float("height", 100.0))
-                    .with_input(Port::point("roundness", Point::new(10.0, 10.0)))
+                    .with_input(NodePort::point("position", Point::new(0.0, 0.0)))
+                    .with_input(NodePort::float("width", 100.0))
+                    .with_input(NodePort::float("height", 100.0))
+                    .with_input(NodePort::point("roundness", Point::new(10.0, 10.0)))
             )
             .with_rendered_child("rect1");
 
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
         // If roundness is applied, the path should have more points than a simple rect
     }
@@ -1611,14 +1683,15 @@ mod tests {
             .with_child(
                 Node::new("polygon1")
                     .with_prototype("corevector.polygon")
-                    .with_input(Port::point("position", Point::new(200.0, -100.0)))
-                    .with_input(Port::float("radius", 50.0))
-                    .with_input(Port::int("sides", 6))
-                    .with_input(Port::boolean("align", true))
+                    .with_input(NodePort::point("position", Point::new(200.0, -100.0)))
+                    .with_input(NodePort::float("radius", 50.0))
+                    .with_input(NodePort::int("sides", 6))
+                    .with_input(NodePort::boolean("align", true))
             )
             .with_rendered_child("polygon1");
 
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
 
         let bounds = paths[0].bounds().unwrap();
@@ -1636,14 +1709,15 @@ mod tests {
             .with_child(
                 Node::new("star1")
                     .with_prototype("corevector.star")
-                    .with_input(Port::point("position", Point::new(75.0, 75.0)))
-                    .with_input(Port::int("points", 5))
-                    .with_input(Port::float("outer", 50.0))
-                    .with_input(Port::float("inner", 25.0))
+                    .with_input(NodePort::point("position", Point::new(75.0, 75.0)))
+                    .with_input(NodePort::int("points", 5))
+                    .with_input(NodePort::float("outer", 50.0))
+                    .with_input(NodePort::float("inner", 25.0))
             )
             .with_rendered_child("star1");
 
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
 
         let bounds = paths[0].bounds().unwrap();
@@ -1662,16 +1736,17 @@ mod tests {
             .with_child(
                 Node::new("arc1")
                     .with_prototype("corevector.arc")
-                    .with_input(Port::point("position", Point::new(50.0, -50.0)))
-                    .with_input(Port::float("width", 100.0))
-                    .with_input(Port::float("height", 100.0))
-                    .with_input(Port::float("start_angle", 0.0))
-                    .with_input(Port::float("degrees", 180.0))
-                    .with_input(Port::string("type", "pie"))
+                    .with_input(NodePort::point("position", Point::new(50.0, -50.0)))
+                    .with_input(NodePort::float("width", 100.0))
+                    .with_input(NodePort::float("height", 100.0))
+                    .with_input(NodePort::float("start_angle", 0.0))
+                    .with_input(NodePort::float("degrees", 180.0))
+                    .with_input(NodePort::string("type", "pie"))
             )
             .with_rendered_child("arc1");
 
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
 
         let bounds = paths[0].bounds().unwrap();
@@ -1689,24 +1764,25 @@ mod tests {
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(Port::point("position", Point::new(0.0, 0.0)))
-                    .with_input(Port::float("width", 50.0))
-                    .with_input(Port::float("height", 50.0))
+                    .with_input(NodePort::point("position", Point::new(0.0, 0.0)))
+                    .with_input(NodePort::float("width", 50.0))
+                    .with_input(NodePort::float("height", 50.0))
             )
             .with_child(
                 Node::new("copy1")
                     .with_prototype("corevector.copy")
-                    .with_input(Port::geometry("shape"))
-                    .with_input(Port::int("copies", 3))
-                    .with_input(Port::string("order", "tsr"))
-                    .with_input(Port::point("translate", Point::new(60.0, 0.0)))
-                    .with_input(Port::float("rotate", 0.0))
-                    .with_input(Port::point("scale", Point::new(100.0, 100.0)))
+                    .with_input(NodePort::geometry("shape"))
+                    .with_input(NodePort::int("copies", 3))
+                    .with_input(NodePort::string("order", "tsr"))
+                    .with_input(NodePort::point("translate", Point::new(60.0, 0.0)))
+                    .with_input(NodePort::float("rotate", 0.0))
+                    .with_input(NodePort::point("scale", Point::new(100.0, 100.0)))
             )
             .with_connection(Connection::new("ellipse1", "copy1", "shape"))
             .with_rendered_child("copy1");
 
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 3, "Should have 3 copies");
 
         // First copy at x=0, second at x=60, third at x=120
@@ -1727,23 +1803,24 @@ mod tests {
             .with_child(
                 Node::new("grid1")
                     .with_prototype("corevector.grid")
-                    .with_input(Port::int("columns", 3))
-                    .with_input(Port::int("rows", 3))
-                    .with_input(Port::float("width", 100.0))
-                    .with_input(Port::float("height", 100.0))
-                    .with_input(Port::point("position", Point::new(50.0, 50.0)))
+                    .with_input(NodePort::int("columns", 3))
+                    .with_input(NodePort::int("rows", 3))
+                    .with_input(NodePort::float("width", 100.0))
+                    .with_input(NodePort::float("height", 100.0))
+                    .with_input(NodePort::point("position", Point::new(50.0, 50.0)))
             )
             .with_child(
                 Node::new("connect1")
                     .with_prototype("corevector.connect")
                     // points port expects entire list, not individual values
-                    .with_input(Port::geometry("points").with_port_range(PortRange::List))
-                    .with_input(Port::boolean("closed", false))
+                    .with_input(NodePort::geometry("points").with_port_range(PortRange::List))
+                    .with_input(NodePort::boolean("closed", false))
             )
             .with_connection(Connection::new("grid1", "connect1", "points"))
             .with_rendered_child("connect1");
 
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
 
         let bounds = paths[0].bounds().unwrap();
@@ -1761,22 +1838,23 @@ mod tests {
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(Port::point("position", Point::new(0.0, 0.0)))
-                    .with_input(Port::float("width", 100.0))
-                    .with_input(Port::float("height", 100.0))
+                    .with_input(NodePort::point("position", Point::new(0.0, 0.0)))
+                    .with_input(NodePort::float("width", 100.0))
+                    .with_input(NodePort::float("height", 100.0))
             )
             .with_child(
                 Node::new("wiggle1")
                     .with_prototype("corevector.wiggle")
-                    .with_input(Port::geometry("shape"))
-                    .with_input(Port::string("scope", "points"))
-                    .with_input(Port::point("offset", Point::new(10.0, 10.0)))
-                    .with_input(Port::int("seed", 42))
+                    .with_input(NodePort::geometry("shape"))
+                    .with_input(NodePort::string("scope", "points"))
+                    .with_input(NodePort::point("offset", Point::new(10.0, 10.0)))
+                    .with_input(NodePort::int("seed", 42))
             )
             .with_connection(Connection::new("ellipse1", "wiggle1", "shape"))
             .with_rendered_child("wiggle1");
 
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
         assert!(!paths.is_empty(), "Wiggle should produce output");
     }
 
@@ -1789,23 +1867,24 @@ mod tests {
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(Port::point("position", Point::new(0.0, 0.0)))
-                    .with_input(Port::float("width", 200.0))
-                    .with_input(Port::float("height", 100.0))
+                    .with_input(NodePort::point("position", Point::new(0.0, 0.0)))
+                    .with_input(NodePort::float("width", 200.0))
+                    .with_input(NodePort::float("height", 100.0))
             )
             .with_child(
                 Node::new("fit1")
                     .with_prototype("corevector.fit")
-                    .with_input(Port::geometry("shape"))
-                    .with_input(Port::point("position", Point::new(100.0, 100.0)))
-                    .with_input(Port::float("width", 50.0))
-                    .with_input(Port::float("height", 50.0))
-                    .with_input(Port::boolean("keep_proportions", true))
+                    .with_input(NodePort::geometry("shape"))
+                    .with_input(NodePort::point("position", Point::new(100.0, 100.0)))
+                    .with_input(NodePort::float("width", 50.0))
+                    .with_input(NodePort::float("height", 50.0))
+                    .with_input(NodePort::boolean("keep_proportions", true))
             )
             .with_connection(Connection::new("ellipse1", "fit1", "shape"))
             .with_rendered_child("fit1");
 
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
 
         // Verify fit produced output - the shape should be constrained to max 50x50
@@ -1857,38 +1936,39 @@ mod tests {
             .with_child(
                 Node::new("rect1")
                     .with_prototype("corevector.rect")
-                    .with_input(Port::point("position", Point::new(-100.0, 0.0)))
-                    .with_input(Port::float("width", 50.0))
-                    .with_input(Port::float("height", 50.0)),
+                    .with_input(NodePort::point("position", Point::new(-100.0, 0.0)))
+                    .with_input(NodePort::float("width", 50.0))
+                    .with_input(NodePort::float("height", 50.0)),
             )
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(Port::point("position", Point::new(0.0, 0.0)))
-                    .with_input(Port::float("width", 50.0))
-                    .with_input(Port::float("height", 50.0)),
+                    .with_input(NodePort::point("position", Point::new(0.0, 0.0)))
+                    .with_input(NodePort::float("width", 50.0))
+                    .with_input(NodePort::float("height", 50.0)),
             )
             .with_child(
                 Node::new("polygon1")
                     .with_prototype("corevector.polygon")
-                    .with_input(Port::point("position", Point::new(100.0, 0.0)))
-                    .with_input(Port::float("radius", 25.0))
-                    .with_input(Port::int("sides", 6)),
+                    .with_input(NodePort::point("position", Point::new(100.0, 0.0)))
+                    .with_input(NodePort::float("radius", 25.0))
+                    .with_input(NodePort::int("sides", 6)),
             )
             .with_child(
                 Node::new("combine1")
                     .with_prototype("list.combine")
                     // Note: list.combine ports should accept lists, not iterate over them
-                    .with_input(Port::geometry("list1").with_port_range(PortRange::List))
-                    .with_input(Port::geometry("list2").with_port_range(PortRange::List))
-                    .with_input(Port::geometry("list3").with_port_range(PortRange::List)),
+                    .with_input(NodePort::geometry("list1").with_port_range(PortRange::List))
+                    .with_input(NodePort::geometry("list2").with_port_range(PortRange::List))
+                    .with_input(NodePort::geometry("list3").with_port_range(PortRange::List)),
             )
             .with_connection(Connection::new("rect1", "combine1", "list1"))
             .with_connection(Connection::new("ellipse1", "combine1", "list2"))
             .with_connection(Connection::new("polygon1", "combine1", "list3"))
             .with_rendered_child("combine1");
 
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
 
         assert_eq!(
             paths.len(),
@@ -1909,41 +1989,41 @@ mod tests {
             .with_child(
                 Node::new("rect1")
                     .with_prototype("corevector.rect")
-                    .with_input(Port::point("position", Point::new(-100.0, 0.0)))
-                    .with_input(Port::float("width", 50.0))
-                    .with_input(Port::float("height", 50.0)),
+                    .with_input(NodePort::point("position", Point::new(-100.0, 0.0)))
+                    .with_input(NodePort::float("width", 50.0))
+                    .with_input(NodePort::float("height", 50.0)),
             )
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(Port::point("position", Point::new(0.0, 0.0)))
-                    .with_input(Port::float("width", 50.0))
-                    .with_input(Port::float("height", 50.0)),
+                    .with_input(NodePort::point("position", Point::new(0.0, 0.0)))
+                    .with_input(NodePort::float("width", 50.0))
+                    .with_input(NodePort::float("height", 50.0)),
             )
             .with_child(
                 Node::new("polygon1")
                     .with_prototype("corevector.polygon")
-                    .with_input(Port::point("position", Point::new(100.0, 0.0)))
-                    .with_input(Port::float("radius", 25.0))
-                    .with_input(Port::int("sides", 6)),
+                    .with_input(NodePort::point("position", Point::new(100.0, 0.0)))
+                    .with_input(NodePort::float("radius", 25.0))
+                    .with_input(NodePort::int("sides", 6)),
             )
             .with_child(
                 Node::new("colorize1")
                     .with_prototype("corevector.colorize")
-                    .with_input(Port::geometry("shape"))
-                    .with_input(Port::color("fill", Color::rgb(1.0, 0.0, 0.0))),
+                    .with_input(NodePort::geometry("shape"))
+                    .with_input(NodePort::color("fill", Color::rgb(1.0, 0.0, 0.0))),
             )
             .with_child(
                 Node::new("colorize2")
                     .with_prototype("corevector.colorize")
-                    .with_input(Port::geometry("shape"))
-                    .with_input(Port::color("fill", Color::rgb(0.0, 1.0, 0.0))),
+                    .with_input(NodePort::geometry("shape"))
+                    .with_input(NodePort::color("fill", Color::rgb(0.0, 1.0, 0.0))),
             )
             .with_child(
                 Node::new("colorize3")
                     .with_prototype("corevector.colorize")
-                    .with_input(Port::geometry("shape"))
-                    .with_input(Port::color("fill", Color::rgb(0.0, 0.0, 1.0))),
+                    .with_input(NodePort::geometry("shape"))
+                    .with_input(NodePort::color("fill", Color::rgb(0.0, 0.0, 1.0))),
             )
             .with_child(
                 Node::new("combine1")
@@ -1958,7 +2038,8 @@ mod tests {
             .with_connection(Connection::new("colorize3", "combine1", "list3"))
             .with_rendered_child("combine1");
 
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
 
         assert_eq!(
             paths.len(),
@@ -1982,20 +2063,21 @@ mod tests {
             .with_child(
                 Node::new("rect1")
                     .with_prototype("corevector.rect")
-                    .with_input(Port::point("position", Point::ZERO))
-                    .with_input(Port::float("width", 50.0))
-                    .with_input(Port::float("height", 50.0)),
+                    .with_input(NodePort::point("position", Point::ZERO))
+                    .with_input(NodePort::float("width", 50.0))
+                    .with_input(NodePort::float("height", 50.0)),
             )
             .with_child(
                 Node::new("colorize1")
                     .with_prototype("corevector.colorize")
                     // Only fill is defined, NOT shape - mimics ndbx file
-                    .with_input(Port::color("fill", Color::rgb(1.0, 0.0, 0.0))),
+                    .with_input(NodePort::color("fill", Color::rgb(1.0, 0.0, 0.0))),
             )
             .with_connection(Connection::new("rect1", "colorize1", "shape"))
             .with_rendered_child("colorize1");
 
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
 
         assert_eq!(
             paths.len(),
@@ -2015,16 +2097,16 @@ mod tests {
             .with_child(
                 Node::new("rect1")
                     .with_prototype("corevector.rect")
-                    .with_input(Port::point("position", Point::new(-100.0, 0.0)))
-                    .with_input(Port::float("width", 50.0))
-                    .with_input(Port::float("height", 50.0)),
+                    .with_input(NodePort::point("position", Point::new(-100.0, 0.0)))
+                    .with_input(NodePort::float("width", 50.0))
+                    .with_input(NodePort::float("height", 50.0)),
             )
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(Port::point("position", Point::new(0.0, 0.0)))
-                    .with_input(Port::float("width", 50.0))
-                    .with_input(Port::float("height", 50.0)),
+                    .with_input(NodePort::point("position", Point::new(0.0, 0.0)))
+                    .with_input(NodePort::float("width", 50.0))
+                    .with_input(NodePort::float("height", 50.0)),
             )
             .with_child(
                 Node::new("combine1")
@@ -2035,7 +2117,8 @@ mod tests {
             .with_connection(Connection::new("ellipse1", "combine1", "list2"))
             .with_rendered_child("combine1");
 
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
 
         // With no port definitions, list matching treats inputs as VALUE range
         // Each input is a single path, so iteration count = 1
@@ -2056,24 +2139,25 @@ mod tests {
             .with_child(
                 Node::new("grid1")
                     .with_prototype("corevector.grid")
-                    .with_input(Port::int("columns", 10))
-                    .with_input(Port::int("rows", 10))
-                    .with_input(Port::float("width", 300.0))
-                    .with_input(Port::float("height", 300.0))
-                    .with_input(Port::point("position", Point::ZERO)),
+                    .with_input(NodePort::int("columns", 10))
+                    .with_input(NodePort::int("rows", 10))
+                    .with_input(NodePort::float("width", 300.0))
+                    .with_input(NodePort::float("height", 300.0))
+                    .with_input(NodePort::point("position", Point::ZERO)),
             )
             .with_child(
                 Node::new("rect1")
                     .with_prototype("corevector.rect")
-                    .with_input(Port::point("position", Point::ZERO))
-                    .with_input(Port::float("width", 20.0))
-                    .with_input(Port::float("height", 20.0))
-                    .with_input(Port::point("roundness", Point::ZERO)),
+                    .with_input(NodePort::point("position", Point::ZERO))
+                    .with_input(NodePort::float("width", 20.0))
+                    .with_input(NodePort::float("height", 20.0))
+                    .with_input(NodePort::point("roundness", Point::ZERO)),
             )
             .with_connection(Connection::new("grid1", "rect1", "position"))
             .with_rendered_child("rect1");
 
-        let (paths, _errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, _errors) = evaluate_network(&library, &port, &ctx);
 
         // THE KEY ASSERTION: Must produce 100 rectangles, not 1!
         assert_eq!(
@@ -2096,12 +2180,13 @@ mod tests {
             .with_child(
                 Node::new("colorize1")
                     .with_prototype("corevector.colorize")
-                    .with_input(Port::geometry("shape"))
-                    .with_input(Port::color("fill", Color::rgb(1.0, 0.0, 0.0)))
+                    .with_input(NodePort::geometry("shape"))
+                    .with_input(NodePort::color("fill", Color::rgb(1.0, 0.0, 0.0)))
             )
             .with_rendered_child("colorize1");
 
-        let (paths, errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, errors) = evaluate_network(&library, &port, &ctx);
 
         // Should have no paths output
         assert!(paths.is_empty(), "Should have no output on missing input, got {} paths", paths.len());
@@ -2124,18 +2209,19 @@ mod tests {
             .with_child(
                 Node::new("colorize1")
                     .with_prototype("corevector.colorize")
-                    .with_input(Port::geometry("shape"))
+                    .with_input(NodePort::geometry("shape"))
             )
             .with_child(
                 Node::new("translate1")
                     .with_prototype("corevector.translate")
-                    .with_input(Port::geometry("shape"))
-                    .with_input(Port::point("translate", Point::new(10.0, 10.0)))
+                    .with_input(NodePort::geometry("shape"))
+                    .with_input(NodePort::point("translate", Point::new(10.0, 10.0)))
             )
             .with_connection(Connection::new("colorize1", "translate1", "shape"))
             .with_rendered_child("translate1");
 
-        let (paths, errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, errors) = evaluate_network(&library, &port, &ctx);
 
         // Should have no output
         assert!(paths.is_empty(), "Should have no output when upstream has error");
@@ -2151,13 +2237,14 @@ mod tests {
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(Port::point("position", Point::ZERO))
-                    .with_input(Port::float("width", 100.0))
-                    .with_input(Port::float("height", 100.0))
+                    .with_input(NodePort::point("position", Point::ZERO))
+                    .with_input(NodePort::float("width", 100.0))
+                    .with_input(NodePort::float("height", 100.0))
             )
             .with_rendered_child("ellipse1");
 
-        let (paths, errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, errors) = evaluate_network(&library, &port, &ctx);
 
         // Should have output
         assert!(!paths.is_empty(), "Should have output for valid network");
@@ -2174,11 +2261,12 @@ mod tests {
             .with_child(
                 Node::new("my_colorize_node")
                     .with_prototype("corevector.colorize")
-                    .with_input(Port::geometry("shape"))
+                    .with_input(NodePort::geometry("shape"))
             )
             .with_rendered_child("my_colorize_node");
 
-        let (_paths, errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (_paths, errors) = evaluate_network(&library, &port, &ctx);
 
         assert!(!errors.is_empty(), "Should have an error");
         assert_eq!(
@@ -2200,7 +2288,8 @@ mod tests {
             )
             .with_rendered_child("ellipse1");
 
-        let (paths, errors) = evaluate_network(&library);
+        let (port, ctx) = test_port_and_context();
+        let (paths, errors) = evaluate_network(&library, &port, &ctx);
 
         assert!(!paths.is_empty(), "Generator should produce output with defaults");
         assert!(errors.is_empty(), "Generator should not produce errors");

--- a/crates/nodebox-gui/src/lib.rs
+++ b/crates/nodebox-gui/src/lib.rs
@@ -69,23 +69,25 @@ pub use vello_viewer::VelloViewer;
 mod native_menu;
 mod recent_files;
 
-use native_menu::NativeMenuHandle;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 /// Run the NodeBox GUI application.
+///
+/// This is a convenience function that creates a DesktopPort and runs the app.
+/// For more control, use `NodeBoxApp::new_with_port` directly.
 pub fn run() -> eframe::Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Initialize native menu bar (macOS)
-    // Must be done before eframe starts, and menu handle is passed to the app
-    let native_menu = NativeMenuHandle::new();
+    // Create the desktop port for file operations
+    let port: Arc<dyn nodebox_port::Port> = Arc::new(nodebox_port::DesktopPort::new());
 
     // Get initial file from command line arguments
     let initial_file: Option<PathBuf> = std::env::args()
         .nth(1)
         .map(PathBuf::from)
-        .filter(|p| p.extension().map_or(false, |ext| ext == "ndbx"));
+        .filter(|p| p.extension().is_some_and(|ext| ext == "ndbx"));
 
     // Native options
     let options = eframe::NativeOptions {
@@ -100,6 +102,6 @@ pub fn run() -> eframe::Result<()> {
     eframe::run_native(
         "NodeBox",
         options,
-        Box::new(move |cc| Ok(Box::new(NodeBoxApp::new_with_file(cc, initial_file, Some(native_menu))))),
+        Box::new(move |cc| Ok(Box::new(NodeBoxApp::new_with_port(cc, port.clone(), initial_file)))),
     )
 }

--- a/crates/nodebox-gui/src/panels.rs
+++ b/crates/nodebox-gui/src/panels.rs
@@ -3,6 +3,7 @@
 use eframe::egui::{self, Sense, TextStyle};
 use nodebox_core::node::{PortType, Widget};
 use nodebox_core::Value;
+use nodebox_port::{FileFilter, Port, PortError, ProjectContext};
 use crate::components;
 use crate::state::AppState;
 use crate::theme;
@@ -32,7 +33,13 @@ impl ParameterPanel {
     }
 
     /// Show the parameter panel.
-    pub fn show(&mut self, ui: &mut egui::Ui, state: &mut AppState) {
+    pub fn show(
+        &mut self,
+        ui: &mut egui::Ui,
+        state: &mut AppState,
+        port: &dyn Port,
+        project_context: &ProjectContext,
+    ) {
         // Apply minimal styling for the panel
         ui.style_mut().spacing.item_spacing = egui::vec2(8.0, 2.0);
 
@@ -93,9 +100,16 @@ impl ParameterPanel {
                             theme::PORT_VALUE_BACKGROUND,
                         );
 
-                        for port in &mut node.inputs {
-                            let is_connected = connected_ports.contains(&port.name);
-                            self.show_port_row(ui, port, is_connected, &node_name_clone);
+                        for node_port in &mut node.inputs {
+                            let is_connected = connected_ports.contains(&node_port.name);
+                            self.show_port_row(
+                                ui,
+                                node_port,
+                                is_connected,
+                                &node_name_clone,
+                                port,
+                                project_context,
+                            );
                         }
                     });
             } else {
@@ -114,6 +128,8 @@ impl ParameterPanel {
         port: &mut nodebox_core::node::Port,
         is_connected: bool,
         node_name: &str,
+        io_port: &dyn Port,
+        project_context: &ProjectContext,
     ) {
         ui.horizontal(|ui| {
             ui.set_height(theme::PARAMETER_ROW_HEIGHT);
@@ -151,13 +167,20 @@ impl ParameterPanel {
                 let pos = egui::pos2(rect.left(), rect.center().y - galley.size().y / 2.0);
                 ui.painter().galley(pos, galley, theme::TEXT_DISABLED);
             } else {
-                self.show_port_editor(ui, port, node_name);
+                self.show_port_editor(ui, port, node_name, io_port, project_context);
             }
         });
     }
 
     /// Show the editor widget for a port value - minimal style with no borders.
-    fn show_port_editor(&mut self, ui: &mut egui::Ui, port: &mut nodebox_core::node::Port, node_name: &str) {
+    fn show_port_editor(
+        &mut self,
+        ui: &mut egui::Ui,
+        port: &mut nodebox_core::node::Port,
+        node_name: &str,
+        io_port: &dyn Port,
+        project_context: &ProjectContext,
+    ) {
         let port_key = (node_name.to_string(), port.name.clone());
 
         // Check if we're editing this port
@@ -356,13 +379,37 @@ impl ParameterPanel {
                     }
 
                     if button_response.clicked() {
-                        // Open file dialog
-                        if let Some(picked_path) = rfd::FileDialog::new()
-                            .add_filter("SVG files", &["svg"])
-                            .add_filter("All files", &["*"])
-                            .pick_file()
-                        {
-                            *path = picked_path.to_string_lossy().to_string();
+                        // Check if project is saved first
+                        if !project_context.is_saved() {
+                            // Show message to save project first
+                            let _ = io_port.show_message_dialog(
+                                "Save Project First",
+                                "Please save your project before importing files.",
+                                &["OK"],
+                            );
+                        } else {
+                            // Use sandboxed file dialog through Port
+                            match io_port.show_open_file_dialog(
+                                project_context,
+                                &[FileFilter::svg()],
+                            ) {
+                                Ok(Some(relative_path)) => {
+                                    // Store the relative path
+                                    *path = relative_path.to_string();
+                                }
+                                Ok(None) => {} // User cancelled
+                                Err(PortError::SandboxViolation) => {
+                                    // File is outside project directory
+                                    let _ = io_port.show_message_dialog(
+                                        "File Outside Project",
+                                        "Please copy the file to your project folder first.",
+                                        &["OK"],
+                                    );
+                                }
+                                Err(e) => {
+                                    log::error!("File dialog error: {}", e);
+                                }
+                            }
                         }
                     }
                 }

--- a/crates/nodebox-gui/src/render_worker.rs
+++ b/crates/nodebox-gui/src/render_worker.rs
@@ -7,6 +7,7 @@ use std::thread;
 use std::time::Instant;
 use nodebox_core::geometry::Path as GeoPath;
 use nodebox_core::node::NodeLibrary;
+use nodebox_port::{Port, ProjectContext};
 use crate::eval::{NodeError, NodeOutput};
 
 /// Token for cooperative cancellation of render operations.
@@ -56,6 +57,8 @@ pub enum RenderRequest {
         id: RenderRequestId,
         library: NodeLibrary,
         cancel_token: CancellationToken,
+        port: Arc<dyn Port>,
+        project_context: ProjectContext,
     },
     /// Shut down the worker thread.
     Shutdown,
@@ -177,12 +180,16 @@ impl RenderWorkerHandle {
         id: RenderRequestId,
         library: NodeLibrary,
         cancel_token: CancellationToken,
+        port: Arc<dyn Port>,
+        project_context: ProjectContext,
     ) {
         if let Some(ref tx) = self.request_tx {
             let _ = tx.send(RenderRequest::Evaluate {
                 id,
                 library,
                 cancel_token,
+                port,
+                project_context,
             });
         }
     }
@@ -222,10 +229,10 @@ fn render_worker_loop(
 
     loop {
         match request_rx.recv() {
-            Ok(RenderRequest::Evaluate { id, library, cancel_token }) => {
+            Ok(RenderRequest::Evaluate { id, library, cancel_token, port, project_context }) => {
                 // Drain to the latest request (skip stale ones)
-                let (final_id, final_library, final_token) =
-                    drain_to_latest(id, library, cancel_token, &request_rx);
+                let (final_id, final_library, final_token, final_port, final_project_context) =
+                    drain_to_latest(id, library, cancel_token, port, project_context, &request_rx);
 
                 // Clear cache when library changes to ensure fresh evaluation.
                 // Future optimization: use hash-based cache keys so unchanged nodes stay cached.
@@ -236,6 +243,8 @@ fn render_worker_loop(
                     &final_library,
                     &final_token,
                     &mut node_cache,
+                    &final_port,
+                    &final_project_context,
                 );
 
                 match result {
@@ -263,21 +272,27 @@ fn drain_to_latest(
     mut id: RenderRequestId,
     mut library: NodeLibrary,
     mut cancel_token: CancellationToken,
+    mut port: Arc<dyn Port>,
+    mut project_context: ProjectContext,
     rx: &mpsc::Receiver<RenderRequest>,
-) -> (RenderRequestId, NodeLibrary, CancellationToken) {
+) -> (RenderRequestId, NodeLibrary, CancellationToken, Arc<dyn Port>, ProjectContext) {
     while let Ok(req) = rx.try_recv() {
         match req {
             RenderRequest::Evaluate {
                 id: new_id,
                 library: new_lib,
                 cancel_token: new_token,
+                port: new_port,
+                project_context: new_ctx,
             } => {
                 id = new_id;
                 library = new_lib;
                 cancel_token = new_token;
+                port = new_port;
+                project_context = new_ctx;
             }
             RenderRequest::Shutdown => break,
         }
     }
-    (id, library, cancel_token)
+    (id, library, cancel_token, port, project_context)
 }

--- a/crates/nodebox-gui/src/state.rs
+++ b/crates/nodebox-gui/src/state.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use nodebox_core::geometry::{Path as GeoPath, Color};
 use nodebox_core::node::{Node, NodeLibrary, Port, PortRange};
-use crate::eval;
 
 /// The main application state.
 pub struct AppState {
@@ -41,43 +40,21 @@ impl Default for AppState {
 
 impl AppState {
     /// Create a new application state with demo content.
+    ///
+    /// Note: Geometry starts empty - the render worker will evaluate with
+    /// the proper Port and populate it.
     pub fn new() -> Self {
-        // Create a demo node library
         let library = Self::create_demo_library();
-
-        // Evaluate the network to get the initial geometry
-        let (geometry, errors) = eval::evaluate_network(&library);
-        let node_errors: HashMap<String, String> = errors
-            .into_iter()
-            .map(|e| (e.node_name, e.message))
-            .collect();
 
         Self {
             current_file: None,
             dirty: false,
             show_about: false,
-            geometry,
+            geometry: Vec::new(), // Render worker will populate
             selected_node: None,
             background_color: Color::WHITE,
             library,
-            node_errors,
-        }
-    }
-
-    /// Re-evaluate the network and update the geometry.
-    #[allow(dead_code)]
-    pub fn evaluate(&mut self) {
-        let (geometry, errors) = eval::evaluate_network(&self.library);
-        if errors.is_empty() {
-            // Success: update geometry and clear errors
-            self.geometry = geometry;
-            self.node_errors.clear();
-        } else {
-            // Errors: keep last geometry, populate errors
-            self.node_errors = errors
-                .into_iter()
-                .map(|e| (e.node_name, e.message))
-                .collect();
+            node_errors: HashMap::new(),
         }
     }
 
@@ -112,6 +89,9 @@ impl AppState {
     }
 
     /// Load a file.
+    ///
+    /// Note: Geometry is cleared - the render worker will evaluate with
+    /// the proper Port and populate it.
     pub fn load_file(&mut self, path: &Path) -> Result<(), String> {
         // Parse the .ndbx file
         let mut library = nodebox_ndbx::parse_file(path).map_err(|e| e.to_string())?;
@@ -124,19 +104,8 @@ impl AppState {
         self.current_file = Some(path.to_path_buf());
         self.dirty = false;
         self.selected_node = None;
-
-        // Evaluate the network
-        let (geometry, errors) = eval::evaluate_network(&self.library);
-        if errors.is_empty() {
-            self.geometry = geometry;
-            self.node_errors.clear();
-        } else {
-            // Keep previous geometry on error, update error state
-            self.node_errors = errors
-                .into_iter()
-                .map(|e| (e.node_name, e.message))
-                .collect();
-        }
+        self.geometry.clear(); // Render worker will populate
+        self.node_errors.clear();
 
         Ok(())
     }

--- a/crates/nodebox-gui/tests/cancellation_tests.rs
+++ b/crates/nodebox-gui/tests/cancellation_tests.rs
@@ -1,12 +1,19 @@
 //! Integration tests for render cancellation.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 use nodebox_core::geometry::Point;
 use nodebox_core::node::{Node, NodeLibrary, Port};
 use nodebox_gui::eval::{EvalOutcome, NodeOutput, evaluate_network_cancellable};
 use nodebox_gui::render_worker::CancellationToken;
+use nodebox_port::{Port as PortTrait, ProjectContext, TestPort};
+
+/// Create a test port and project context for evaluation tests.
+fn test_port_and_context() -> (Arc<dyn PortTrait>, ProjectContext) {
+    (Arc::new(TestPort::new()), ProjectContext::new_unsaved())
+}
 
 /// Helper to create a library with a large grid that generates many iterations.
 fn create_large_grid_library(grid_size: i64) -> NodeLibrary {
@@ -64,7 +71,8 @@ fn test_evaluation_completes_without_cancellation() {
     let token = CancellationToken::new();
     let mut cache: HashMap<String, NodeOutput> = HashMap::new();
 
-    let outcome = evaluate_network_cancellable(&library, &token, &mut cache);
+    let (port, ctx) = test_port_and_context();
+    let outcome = evaluate_network_cancellable(&library, &token, &mut cache, &port, &ctx);
 
     match outcome {
         EvalOutcome::Completed { geometry, errors } => {
@@ -86,7 +94,8 @@ fn test_evaluation_cancelled_immediately() {
     // Cancel immediately
     token.cancel();
 
-    let outcome = evaluate_network_cancellable(&library, &token, &mut cache);
+    let (port, ctx) = test_port_and_context();
+    let outcome = evaluate_network_cancellable(&library, &token, &mut cache, &port, &ctx);
 
     match outcome {
         EvalOutcome::Completed { .. } => {
@@ -111,7 +120,8 @@ fn test_cache_preserved_after_cancellation() {
         token_clone.cancel();
     });
 
-    let outcome = evaluate_network_cancellable(&library, &token, &mut cache);
+    let (port, ctx) = test_port_and_context();
+    let outcome = evaluate_network_cancellable(&library, &token, &mut cache, &port, &ctx);
 
     // The outcome could be either cancelled or completed depending on timing
     // But the cache should have some entries
@@ -133,7 +143,8 @@ fn test_cache_reused_after_cancellation() {
 
     // First render - complete fully
     let token1 = CancellationToken::new();
-    let outcome1 = evaluate_network_cancellable(&library, &token1, &mut cache);
+    let (port, ctx) = test_port_and_context();
+    let outcome1 = evaluate_network_cancellable(&library, &token1, &mut cache, &port, &ctx);
 
     match outcome1 {
         EvalOutcome::Completed { geometry, errors } => {
@@ -149,7 +160,7 @@ fn test_cache_reused_after_cancellation() {
 
     // Second render - should reuse cache
     let token2 = CancellationToken::new();
-    let outcome2 = evaluate_network_cancellable(&library, &token2, &mut cache);
+    let outcome2 = evaluate_network_cancellable(&library, &token2, &mut cache, &port, &ctx);
 
     match outcome2 {
         EvalOutcome::Completed { geometry, errors } => {
@@ -174,7 +185,9 @@ fn test_cancellation_response_time() {
     let library_clone = library.clone();
     let handle = thread::spawn(move || {
         let mut thread_cache: HashMap<String, NodeOutput> = HashMap::new();
-        evaluate_network_cancellable(&library_clone, &token_for_thread, &mut thread_cache)
+        let port: Arc<dyn PortTrait> = Arc::new(TestPort::new());
+        let ctx = ProjectContext::new_unsaved();
+        evaluate_network_cancellable(&library_clone, &token_for_thread, &mut thread_cache, &port, &ctx)
     });
 
     // Wait a bit for evaluation to start, then cancel
@@ -207,7 +220,8 @@ fn test_multiple_rapid_cancellations() {
             token.cancel();
         }
 
-        let outcome = evaluate_network_cancellable(&library, &token, &mut cache);
+        let (port, ctx) = test_port_and_context();
+    let outcome = evaluate_network_cancellable(&library, &token, &mut cache, &port, &ctx);
 
         // Should not panic or hang regardless of timing
         match outcome {
@@ -226,7 +240,8 @@ fn test_empty_network_not_affected_by_cancellation() {
 
     token.cancel(); // Pre-cancel
 
-    let outcome = evaluate_network_cancellable(&library, &token, &mut cache);
+    let (port, ctx) = test_port_and_context();
+    let outcome = evaluate_network_cancellable(&library, &token, &mut cache, &port, &ctx);
 
     // Empty network should complete (nothing to cancel)
     match outcome {

--- a/crates/nodebox-gui/tests/file_tests.rs
+++ b/crates/nodebox-gui/tests/file_tests.rs
@@ -1,9 +1,16 @@
 //! Tests for loading and evaluating .ndbx files from the examples directory.
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use nodebox_gui::eval::evaluate_network;
 use nodebox_gui::{populate_default_ports, AppState};
+use nodebox_port::{Port, ProjectContext, TestPort};
+
+/// Create a test port and project context for evaluation tests.
+fn test_port_and_context() -> (Arc<dyn Port>, ProjectContext) {
+    (Arc::new(TestPort::new()), ProjectContext::new_unsaved())
+}
 
 /// Get the path to the examples directory.
 fn examples_dir() -> PathBuf {
@@ -117,17 +124,20 @@ fn test_evaluate_primitives() {
     test_library.root = library.root.clone();
     test_library.root.rendered_child = Some("rect1".to_string());
 
-    let (paths, _errors) = evaluate_network(&test_library);
+    let (port, ctx) = test_port_and_context();
+    let (paths, _errors) = evaluate_network(&test_library, &port, &ctx);
     assert_eq!(paths.len(), 1, "rect1 should produce one path");
 
     // Test ellipse
     test_library.root.rendered_child = Some("ellipse1".to_string());
-    let (paths, _errors) = evaluate_network(&test_library);
+    let (port, ctx) = test_port_and_context();
+    let (paths, _errors) = evaluate_network(&test_library, &port, &ctx);
     assert_eq!(paths.len(), 1, "ellipse1 should produce one path");
 
     // Test polygon
     test_library.root.rendered_child = Some("polygon1".to_string());
-    let (paths, _errors) = evaluate_network(&test_library);
+    let (port, ctx) = test_port_and_context();
+    let (paths, _errors) = evaluate_network(&test_library, &port, &ctx);
     assert_eq!(paths.len(), 1, "polygon1 should produce one path");
 }
 
@@ -137,7 +147,8 @@ fn test_evaluate_primitives_full() {
 
     // The rendered child is "combine1" which uses list.combine
     // Now that list.combine is implemented, we can evaluate the full network
-    let (paths, _errors) = evaluate_network(&library);
+    let (port, ctx) = test_port_and_context();
+    let (paths, _errors) = evaluate_network(&library, &port, &ctx);
 
     // Should have 3 shapes: rect, ellipse, polygon (each colorized)
     assert_eq!(paths.len(), 3, "combine1 should produce 3 colorized paths");
@@ -157,7 +168,8 @@ fn test_evaluate_colorized_primitives() {
 
     // Test colorized rect (colorize1 <- rect1)
     test_library.root.rendered_child = Some("colorize1".to_string());
-    let (paths, _errors) = evaluate_network(&test_library);
+    let (port, ctx) = test_port_and_context();
+    let (paths, _errors) = evaluate_network(&test_library, &port, &ctx);
 
     assert_eq!(paths.len(), 1, "colorize1 should produce one path");
     assert!(paths[0].fill.is_some(), "colorized path should have fill");
@@ -179,7 +191,8 @@ fn test_evaluate_copy() {
         test_library.root = library.root.clone();
         test_library.root.rendered_child = Some(copy.name.clone());
 
-        let (paths, _errors) = evaluate_network(&test_library);
+        let (port, ctx) = test_port_and_context();
+    let (paths, _errors) = evaluate_network(&test_library, &port, &ctx);
         // Copy should produce multiple paths
         assert!(
             !paths.is_empty(),
@@ -246,8 +259,11 @@ fn test_app_state_load_file() {
     assert!(state.library.root.child("ellipse1").is_some());
     assert!(state.library.root.child("polygon1").is_some());
 
-    // Verify geometry was evaluated (should have 3 shapes)
-    assert_eq!(state.geometry.len(), 3, "Should have 3 rendered shapes");
+    // Geometry is now evaluated by render worker, not load_file.
+    // Verify we can evaluate the loaded library (should have 3 shapes).
+    let (port, ctx) = test_port_and_context();
+    let (geometry, _errors) = evaluate_network(&state.library, &port, &ctx);
+    assert_eq!(geometry.len(), 3, "Should have 3 rendered shapes");
 }
 
 #[test]
@@ -278,21 +294,22 @@ fn test_primitives_shapes_at_different_positions() {
     let mut test_library = nodebox_core::node::NodeLibrary::new("test");
     test_library.root = library.root.clone();
     test_library.root.rendered_child = Some("rect1".to_string());
-    let (rect_paths, _errors) = evaluate_network(&test_library);
+    let (port, ctx) = test_port_and_context();
+    let (rect_paths, _errors) = evaluate_network(&test_library, &port, &ctx);
     assert_eq!(rect_paths.len(), 1, "rect1 should produce one path");
     let rect_bounds = rect_paths[0].bounds().unwrap();
     let rect_center_x = rect_bounds.x + rect_bounds.width / 2.0;
 
     // Evaluate ellipse1 alone
     test_library.root.rendered_child = Some("ellipse1".to_string());
-    let (ellipse_paths, _errors) = evaluate_network(&test_library);
+    let (ellipse_paths, _errors) = evaluate_network(&test_library, &port, &ctx);
     assert_eq!(ellipse_paths.len(), 1, "ellipse1 should produce one path");
     let ellipse_bounds = ellipse_paths[0].bounds().unwrap();
     let ellipse_center_x = ellipse_bounds.x + ellipse_bounds.width / 2.0;
 
     // Evaluate polygon1 alone
     test_library.root.rendered_child = Some("polygon1".to_string());
-    let (polygon_paths, _errors) = evaluate_network(&test_library);
+    let (polygon_paths, _errors) = evaluate_network(&test_library, &port, &ctx);
     assert_eq!(polygon_paths.len(), 1, "polygon1 should produce one path");
     let polygon_bounds = polygon_paths[0].bounds().unwrap();
     let polygon_center_x = polygon_bounds.x + polygon_bounds.width / 2.0;

--- a/crates/nodebox-ops/src/svg.rs
+++ b/crates/nodebox-ops/src/svg.rs
@@ -1,15 +1,21 @@
 //! SVG import functionality.
 //!
-//! This module provides functions to import SVG files and convert them to NodeBox geometry.
+//! This module provides functions to import SVG content and convert it to NodeBox geometry.
+//!
+//! File reading is NOT done by this module. Callers are responsible for reading
+//! SVG files through the Port system (for sandboxed file access) and passing
+//! the string content here.
 
 use nodebox_core::geometry::{Color, Contour, Geometry, Path, Point, Transform};
-use std::path::Path as StdPath;
 use usvg::{tiny_skia_path::PathSegment, Tree};
 
-/// Import an SVG file and convert it to NodeBox Geometry.
+/// Import SVG from string content and convert it to NodeBox Geometry.
+///
+/// This is the ONLY version - no file path version exists.
+/// Callers are responsible for reading the file through the Port system.
 ///
 /// # Arguments
-/// * `file_path` - Path to the SVG file
+/// * `svg_content` - SVG content as a string
 /// * `centered` - If true, center the geometry at the origin before applying position
 /// * `position` - Position offset to apply after optional centering
 ///
@@ -23,28 +29,19 @@ use usvg::{tiny_skia_path::PathSegment, Tree};
 /// use nodebox_core::geometry::Point;
 /// use nodebox_ops::import_svg;
 ///
-/// let geometry = import_svg("shape.svg", true, Point::ZERO)?;
+/// let svg_content = r#"<svg><rect width="100" height="100"/></svg>"#;
+/// let geometry = import_svg(svg_content, true, Point::ZERO)?;
 /// ```
-pub fn import_svg(file_path: &str, centered: bool, position: Point) -> Result<Geometry, String> {
-    // Empty path returns empty geometry
-    if file_path.is_empty() {
+pub fn import_svg(svg_content: &str, centered: bool, position: Point) -> Result<Geometry, String> {
+    // Empty content returns empty geometry
+    if svg_content.is_empty() {
         return Ok(Geometry::new());
     }
 
-    // Check if file exists
-    let path = StdPath::new(file_path);
-    if !path.exists() {
-        return Err(format!("SVG file not found: {}", file_path));
-    }
-
-    // Read and parse the SVG file
-    let svg_data =
-        std::fs::read(file_path).map_err(|e| format!("Failed to read SVG file: {}", e))?;
-
     // Parse SVG using usvg with default options
     let options = usvg::Options::default();
-    let tree =
-        Tree::from_data(&svg_data, &options).map_err(|e| format!("Failed to parse SVG: {}", e))?;
+    let tree = Tree::from_data(svg_content.as_bytes(), &options)
+        .map_err(|e| format!("Failed to parse SVG: {}", e))?;
 
     // Convert the usvg tree to NodeBox geometry
     let mut geometry = convert_tree_to_geometry(&tree);
@@ -238,17 +235,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_import_empty_path() {
+    fn test_import_empty_content() {
         let result = import_svg("", false, Point::ZERO);
         assert!(result.is_ok());
         assert!(result.unwrap().is_empty());
     }
 
     #[test]
-    fn test_import_missing_file() {
-        let result = import_svg("/nonexistent/path/to/file.svg", false, Point::ZERO);
+    fn test_import_invalid_svg() {
+        let result = import_svg("not valid svg content", false, Point::ZERO);
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("not found"));
+        assert!(result.unwrap_err().contains("Failed to parse SVG"));
     }
 
     #[test]
@@ -289,22 +286,14 @@ mod tests {
     }
 
     #[test]
-    fn test_import_svg_from_data() {
-        // Test importing from an in-memory SVG
-        use std::io::Write;
-        use tempfile::NamedTempFile;
-
+    fn test_import_svg_from_content() {
         let svg_content = r##"<?xml version="1.0" encoding="UTF-8"?>
             <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
                 <rect x="10" y="10" width="80" height="80" fill="#ff0000"/>
                 <circle cx="50" cy="50" r="25" fill="#00ff00"/>
             </svg>"##;
 
-        // Write to a temp file
-        let mut temp_file = NamedTempFile::new().unwrap();
-        temp_file.write_all(svg_content.as_bytes()).unwrap();
-
-        let result = import_svg(temp_file.path().to_str().unwrap(), false, Point::ZERO);
+        let result = import_svg(svg_content, false, Point::ZERO);
         assert!(result.is_ok(), "Failed to import SVG: {:?}", result);
 
         let geometry = result.unwrap();
@@ -320,24 +309,17 @@ mod tests {
 
     #[test]
     fn test_import_svg_centered() {
-        use std::io::Write;
-        use tempfile::NamedTempFile;
-
         let svg_content = r##"<?xml version="1.0" encoding="UTF-8"?>
             <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
                 <rect x="0" y="0" width="100" height="100" fill="#000000"/>
             </svg>"##;
 
-        let mut temp_file = NamedTempFile::new().unwrap();
-        temp_file.write_all(svg_content.as_bytes()).unwrap();
-        let path = temp_file.path().to_str().unwrap();
-
         // Import without centering
-        let not_centered = import_svg(path, false, Point::ZERO).unwrap();
+        let not_centered = import_svg(svg_content, false, Point::ZERO).unwrap();
         let bounds_not_centered = not_centered.bounds().unwrap();
 
         // Import with centering
-        let centered = import_svg(path, true, Point::ZERO).unwrap();
+        let centered = import_svg(svg_content, true, Point::ZERO).unwrap();
         let bounds_centered = centered.bounds().unwrap();
 
         // Centered version should have center at (0, 0)
@@ -364,19 +346,13 @@ mod tests {
 
     #[test]
     fn test_import_svg_with_position() {
-        use std::io::Write;
-        use tempfile::NamedTempFile;
-
         let svg_content = r##"<?xml version="1.0" encoding="UTF-8"?>
             <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
                 <rect x="0" y="0" width="100" height="100" fill="#000000"/>
             </svg>"##;
 
-        let mut temp_file = NamedTempFile::new().unwrap();
-        temp_file.write_all(svg_content.as_bytes()).unwrap();
-
         let offset = Point::new(200.0, 300.0);
-        let result = import_svg(temp_file.path().to_str().unwrap(), true, offset).unwrap();
+        let result = import_svg(svg_content, true, offset).unwrap();
         let bounds = result.bounds().unwrap();
 
         // Center should be at the offset position
@@ -395,18 +371,12 @@ mod tests {
 
     #[test]
     fn test_import_svg_colors() {
-        use std::io::Write;
-        use tempfile::NamedTempFile;
-
         let svg_content = r##"<?xml version="1.0" encoding="UTF-8"?>
             <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
                 <rect x="0" y="0" width="100" height="100" fill="#ff0000" stroke="#0000ff" stroke-width="2"/>
             </svg>"##;
 
-        let mut temp_file = NamedTempFile::new().unwrap();
-        temp_file.write_all(svg_content.as_bytes()).unwrap();
-
-        let result = import_svg(temp_file.path().to_str().unwrap(), false, Point::ZERO).unwrap();
+        let result = import_svg(svg_content, false, Point::ZERO).unwrap();
         assert!(!result.is_empty());
 
         let path = &result.paths[0];

--- a/crates/nodebox-port/Cargo.toml
+++ b/crates/nodebox-port/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "nodebox-port"
+description = "Platform abstraction layer for NodeBox"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[lib]
+name = "nodebox_port"
+path = "src/lib.rs"
+
+[dependencies]
+# Error handling
+thiserror.workspace = true
+
+# Logging
+log = "0.4"
+
+# File dialogs (desktop only)
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+rfd = "0.15"
+
+# Clipboard (desktop only)
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies.arboard]
+version = "3"
+
+# HTTP client (desktop only, blocking)
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies.ureq]
+version = "2"
+
+# Platform directories (desktop only)
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies.directories]
+version = "5"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/nodebox-port/src/desktop.rs
+++ b/crates/nodebox-port/src/desktop.rs
@@ -1,0 +1,851 @@
+//! Desktop (macOS, Windows, Linux) implementation of the Port trait.
+
+use crate::{
+    DirectoryEntry, FileFilter, LogLevel, PlatformInfo, Port, PortError, ProjectContext,
+    RelativePath,
+};
+use std::path::{Path, PathBuf};
+
+/// Desktop implementation of the Port trait.
+///
+/// Uses native filesystem, rfd for dialogs, arboard for clipboard, and ureq for HTTP.
+#[derive(Debug, Default)]
+pub struct DesktopPort;
+
+impl DesktopPort {
+    /// Create a new DesktopPort instance.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Get the library directory for the current platform.
+    fn library_dir(&self) -> Result<PathBuf, PortError> {
+        if let Some(proj_dirs) =
+            directories::ProjectDirs::from("net", "nodebox", "NodeBox")
+        {
+            Ok(proj_dirs.data_dir().join("libraries"))
+        } else {
+            Err(PortError::Other(
+                "Could not determine library directory".to_string(),
+            ))
+        }
+    }
+
+    /// Validate that a path is within the project directory and convert to RelativePath.
+    ///
+    /// This is a security function that ensures file access is sandboxed to the project.
+    fn validate_within_project(
+        ctx: &ProjectContext,
+        path: &Path,
+    ) -> Result<RelativePath, PortError> {
+        let root = ctx.root.as_ref().ok_or(PortError::Unsupported)?;
+
+        // Canonicalize both paths to resolve symlinks and normalize
+        let canonical_root = root.canonicalize().map_err(|e| {
+            PortError::IoError(format!("Failed to canonicalize project root: {}", e))
+        })?;
+        let canonical_path = path.canonicalize().map_err(|e| {
+            PortError::IoError(format!("Failed to canonicalize selected path: {}", e))
+        })?;
+
+        // Check if the selected path is within the project root
+        if canonical_path.starts_with(&canonical_root) {
+            let relative = canonical_path
+                .strip_prefix(&canonical_root)
+                .map_err(|_| PortError::SandboxViolation)?;
+            RelativePath::new(relative)
+        } else {
+            Err(PortError::SandboxViolation)
+        }
+    }
+
+    /// Validate that a path (which may not exist yet) would be within the project directory.
+    ///
+    /// This is used for save dialogs where the file doesn't exist yet, so we can't canonicalize it.
+    fn validate_save_path_within_project(
+        ctx: &ProjectContext,
+        path: &Path,
+    ) -> Result<RelativePath, PortError> {
+        let root = ctx.root.as_ref().ok_or(PortError::Unsupported)?;
+
+        // Canonicalize the project root
+        let canonical_root = root.canonicalize().map_err(|e| {
+            PortError::IoError(format!("Failed to canonicalize project root: {}", e))
+        })?;
+
+        // For the save path, canonicalize the parent directory (which should exist)
+        // and then append the filename
+        if let Some(parent) = path.parent() {
+            if let Some(file_name) = path.file_name() {
+                // Try to canonicalize the parent. If it doesn't exist, try its parent, etc.
+                let canonical_parent = if parent.exists() {
+                    parent.canonicalize().map_err(|e| {
+                        PortError::IoError(format!(
+                            "Failed to canonicalize parent directory: {}",
+                            e
+                        ))
+                    })?
+                } else {
+                    // Parent doesn't exist - this is a new nested directory
+                    // Check if any ancestor is within the project
+                    let mut ancestor = parent.to_path_buf();
+                    loop {
+                        if ancestor.exists() {
+                            break ancestor.canonicalize().map_err(|e| {
+                                PortError::IoError(format!(
+                                    "Failed to canonicalize ancestor: {}",
+                                    e
+                                ))
+                            })?;
+                        }
+                        if let Some(p) = ancestor.parent() {
+                            ancestor = p.to_path_buf();
+                        } else {
+                            return Err(PortError::SandboxViolation);
+                        }
+                    }
+                };
+
+                // Check if the canonical parent is within or equals the project root
+                if canonical_parent.starts_with(&canonical_root) {
+                    // Build the relative path from project root to the save location
+                    let relative_parent = if canonical_parent == canonical_root {
+                        PathBuf::new()
+                    } else {
+                        canonical_parent
+                            .strip_prefix(&canonical_root)
+                            .map_err(|_| PortError::SandboxViolation)?
+                            .to_path_buf()
+                    };
+
+                    // Append any non-existent directory components from the original path
+                    let original_parent = parent.to_path_buf();
+                    let existing_ancestor = if parent.exists() {
+                        parent.canonicalize().ok()
+                    } else {
+                        let mut a = parent.to_path_buf();
+                        while !a.exists() {
+                            if let Some(p) = a.parent() {
+                                a = p.to_path_buf();
+                            } else {
+                                break;
+                            }
+                        }
+                        a.canonicalize().ok()
+                    };
+
+                    let full_relative = if let Some(existing) = existing_ancestor {
+                        if let Ok(suffix) = original_parent.strip_prefix(
+                            existing
+                                .strip_prefix(&canonical_root)
+                                .map(|p| canonical_root.join(p))
+                                .unwrap_or(existing.clone()),
+                        ) {
+                            relative_parent.join(suffix).join(file_name)
+                        } else {
+                            relative_parent.join(file_name)
+                        }
+                    } else {
+                        relative_parent.join(file_name)
+                    };
+
+                    RelativePath::new(full_relative)
+                } else {
+                    Err(PortError::SandboxViolation)
+                }
+            } else {
+                Err(PortError::SandboxViolation)
+            }
+        } else {
+            // Path has no parent - just a filename, which is fine
+            RelativePath::new(path)
+        }
+    }
+}
+
+impl Port for DesktopPort {
+    fn platform_info(&self) -> PlatformInfo {
+        PlatformInfo::current()
+    }
+
+    fn read_file(&self, ctx: &ProjectContext, path: &RelativePath) -> Result<Vec<u8>, PortError> {
+        let root = ctx.root.as_ref().ok_or(PortError::Unsupported)?;
+        let full_path = root.join(path.as_path());
+        std::fs::read(&full_path).map_err(PortError::from)
+    }
+
+    fn write_file(
+        &self,
+        ctx: &ProjectContext,
+        path: &RelativePath,
+        data: &[u8],
+    ) -> Result<(), PortError> {
+        let root = ctx.root.as_ref().ok_or(PortError::Unsupported)?;
+        let full_path = root.join(path.as_path());
+
+        // Create parent directories if needed
+        if let Some(parent) = full_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        std::fs::write(&full_path, data).map_err(PortError::from)
+    }
+
+    fn list_directory(
+        &self,
+        ctx: &ProjectContext,
+        path: &RelativePath,
+    ) -> Result<Vec<DirectoryEntry>, PortError> {
+        let root = ctx.root.as_ref().ok_or(PortError::Unsupported)?;
+        let full_path = root.join(path.as_path());
+
+        let entries = std::fs::read_dir(&full_path)?
+            .filter_map(|entry| {
+                entry.ok().map(|e| {
+                    DirectoryEntry::new(
+                        e.file_name().to_string_lossy().to_string(),
+                        e.file_type().map(|ft| ft.is_dir()).unwrap_or(false),
+                    )
+                })
+            })
+            .collect();
+
+        Ok(entries)
+    }
+
+    fn read_text_file(&self, ctx: &ProjectContext, path: &str) -> Result<String, PortError> {
+        let root = ctx.root.as_ref().ok_or(PortError::Unsupported)?;
+        let relative = RelativePath::new(path)?;
+        let full_path = root.join(relative.as_path());
+        let bytes = std::fs::read(&full_path)?;
+        String::from_utf8(bytes).map_err(|_| PortError::IoError("Invalid UTF-8".to_string()))
+    }
+
+    fn read_binary_file(&self, ctx: &ProjectContext, path: &str) -> Result<Vec<u8>, PortError> {
+        let root = ctx.root.as_ref().ok_or(PortError::Unsupported)?;
+        let relative = RelativePath::new(path)?;
+        let full_path = root.join(relative.as_path());
+        std::fs::read(&full_path).map_err(PortError::from)
+    }
+
+    fn load_app_resource(&self, name: &str) -> Result<Vec<u8>, PortError> {
+        // Locate resources relative to executable or in standard location
+        let exe_dir = std::env::current_exe()
+            .ok()
+            .and_then(|p| p.parent().map(|p| p.to_path_buf()));
+
+        let resource_dirs = [
+            exe_dir.as_ref().map(|d| d.join("resources")),
+            exe_dir.as_ref().map(|d| d.join("../Resources")), // macOS app bundle
+            Some(PathBuf::from("resources")),                 // Development fallback
+        ];
+
+        for dir in resource_dirs.iter().flatten() {
+            let path = dir.join(name);
+            if path.exists() {
+                return std::fs::read(&path).map_err(PortError::from);
+            }
+        }
+
+        Err(PortError::NotFound)
+    }
+
+    fn read_project(&self, ctx: &ProjectContext) -> Result<Vec<u8>, PortError> {
+        let path = ctx.project_path().ok_or(PortError::Unsupported)?;
+        std::fs::read(&path).map_err(PortError::from)
+    }
+
+    fn write_project(&self, ctx: &ProjectContext, data: &[u8]) -> Result<(), PortError> {
+        let path = ctx.project_path().ok_or(PortError::Unsupported)?;
+
+        // Create parent directories if needed
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        std::fs::write(&path, data).map_err(PortError::from)
+    }
+
+    fn load_library(&self, name: &str) -> Result<Vec<u8>, PortError> {
+        let library_dir = self.library_dir()?;
+        let library_path = library_dir.join(format!("{}.ndbx", name));
+
+        if !library_path.exists() {
+            return Err(PortError::LibraryNotFound(name.to_string()));
+        }
+
+        std::fs::read(&library_path).map_err(PortError::from)
+    }
+
+    fn http_get(&self, url: &str) -> Result<Vec<u8>, PortError> {
+        let response = ureq::get(url)
+            .call()
+            .map_err(|e| PortError::NetworkError(e.to_string()))?;
+
+        let mut bytes = Vec::new();
+        response
+            .into_reader()
+            .read_to_end(&mut bytes)
+            .map_err(|e| PortError::NetworkError(e.to_string()))?;
+
+        Ok(bytes)
+    }
+
+    fn show_open_project_dialog(
+        &self,
+        filters: &[FileFilter],
+    ) -> Result<Option<PathBuf>, PortError> {
+        let mut dialog = rfd::FileDialog::new();
+
+        for filter in filters {
+            let extensions: Vec<&str> = filter.extensions.iter().map(|s| s.as_str()).collect();
+            dialog = dialog.add_filter(&filter.name, &extensions);
+        }
+
+        Ok(dialog.pick_file())
+    }
+
+    fn show_save_project_dialog(
+        &self,
+        filters: &[FileFilter],
+        default_name: Option<&str>,
+    ) -> Result<Option<PathBuf>, PortError> {
+        let mut dialog = rfd::FileDialog::new();
+
+        for filter in filters {
+            let extensions: Vec<&str> = filter.extensions.iter().map(|s| s.as_str()).collect();
+            dialog = dialog.add_filter(&filter.name, &extensions);
+        }
+
+        if let Some(name) = default_name {
+            dialog = dialog.set_file_name(name);
+        }
+
+        Ok(dialog.save_file())
+    }
+
+    fn show_open_file_dialog(
+        &self,
+        ctx: &ProjectContext,
+        filters: &[FileFilter],
+    ) -> Result<Option<RelativePath>, PortError> {
+        let root = ctx.root.as_ref().ok_or(PortError::Unsupported)?;
+        let mut dialog = rfd::FileDialog::new();
+
+        // Start in the project directory
+        dialog = dialog.set_directory(root);
+
+        for filter in filters {
+            let extensions: Vec<&str> = filter.extensions.iter().map(|s| s.as_str()).collect();
+            dialog = dialog.add_filter(&filter.name, &extensions);
+        }
+
+        match dialog.pick_file() {
+            Some(path) => {
+                // Validate that the selected file is within the project directory
+                let relative = Self::validate_within_project(ctx, &path)?;
+                Ok(Some(relative))
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn show_save_file_dialog(
+        &self,
+        ctx: &ProjectContext,
+        filters: &[FileFilter],
+        default_name: Option<&str>,
+    ) -> Result<Option<RelativePath>, PortError> {
+        let root = ctx.root.as_ref().ok_or(PortError::Unsupported)?;
+        let mut dialog = rfd::FileDialog::new();
+
+        // Start in the project directory
+        dialog = dialog.set_directory(root);
+
+        for filter in filters {
+            let extensions: Vec<&str> = filter.extensions.iter().map(|s| s.as_str()).collect();
+            dialog = dialog.add_filter(&filter.name, &extensions);
+        }
+
+        if let Some(name) = default_name {
+            dialog = dialog.set_file_name(name);
+        }
+
+        match dialog.save_file() {
+            Some(path) => {
+                // Validate that the selected location is within the project directory
+                let relative = Self::validate_save_path_within_project(ctx, &path)?;
+                Ok(Some(relative))
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn show_select_folder_dialog(
+        &self,
+        ctx: &ProjectContext,
+    ) -> Result<Option<RelativePath>, PortError> {
+        let root = ctx.root.as_ref().ok_or(PortError::Unsupported)?;
+        let mut dialog = rfd::FileDialog::new();
+
+        // Start in the project directory
+        dialog = dialog.set_directory(root);
+
+        match dialog.pick_folder() {
+            Some(path) => {
+                // Validate that the selected folder is within the project directory
+                let relative = Self::validate_within_project(ctx, &path)?;
+                Ok(Some(relative))
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn show_confirm_dialog(&self, title: &str, message: &str) -> Result<bool, PortError> {
+        let result = rfd::MessageDialog::new()
+            .set_title(title)
+            .set_description(message)
+            .set_buttons(rfd::MessageButtons::OkCancel)
+            .show();
+
+        Ok(result == rfd::MessageDialogResult::Ok)
+    }
+
+    fn show_message_dialog(
+        &self,
+        title: &str,
+        message: &str,
+        buttons: &[&str],
+    ) -> Result<Option<usize>, PortError> {
+        // rfd doesn't support custom button labels directly
+        // Map to available button types based on count
+        let button_type = match buttons.len() {
+            2 => rfd::MessageButtons::OkCancel,
+            3 => rfd::MessageButtons::YesNoCancel,
+            _ => rfd::MessageButtons::Ok,
+        };
+
+        let result = rfd::MessageDialog::new()
+            .set_title(title)
+            .set_description(message)
+            .set_buttons(button_type)
+            .show();
+
+        // Map result back to button index
+        let index = match result {
+            rfd::MessageDialogResult::Ok | rfd::MessageDialogResult::Yes => Some(0),
+            rfd::MessageDialogResult::No => Some(1),
+            rfd::MessageDialogResult::Cancel => {
+                if buttons.len() == 2 {
+                    Some(1)
+                } else {
+                    Some(2)
+                }
+            }
+            rfd::MessageDialogResult::Custom(_) => None,
+        };
+
+        Ok(index)
+    }
+
+    fn clipboard_read_text(&self) -> Result<Option<String>, PortError> {
+        let mut clipboard =
+            arboard::Clipboard::new().map_err(|e| PortError::Other(e.to_string()))?;
+
+        match clipboard.get_text() {
+            Ok(text) => Ok(Some(text)),
+            Err(arboard::Error::ContentNotAvailable) => Ok(None),
+            Err(e) => Err(PortError::Other(e.to_string())),
+        }
+    }
+
+    fn clipboard_write_text(&self, text: &str) -> Result<(), PortError> {
+        let mut clipboard =
+            arboard::Clipboard::new().map_err(|e| PortError::Other(e.to_string()))?;
+
+        clipboard
+            .set_text(text)
+            .map_err(|e| PortError::Other(e.to_string()))
+    }
+
+    fn log(&self, level: LogLevel, message: &str) {
+        match level {
+            LogLevel::Error => log::error!("{}", message),
+            LogLevel::Warn => log::warn!("{}", message),
+            LogLevel::Info => log::info!("{}", message),
+            LogLevel::Debug => log::debug!("{}", message),
+        }
+    }
+
+    fn performance_mark(&self, name: &str) {
+        log::trace!("[PERF] {}", name);
+    }
+
+    fn performance_mark_with_details(&self, name: &str, details: &str) {
+        log::trace!("[PERF] {} - {}", name, details);
+    }
+
+    fn get_config_dir(&self) -> Result<PathBuf, PortError> {
+        if let Some(proj_dirs) =
+            directories::ProjectDirs::from("net", "nodebox", "NodeBox")
+        {
+            Ok(proj_dirs.config_dir().to_path_buf())
+        } else {
+            Err(PortError::Other(
+                "Could not determine config directory".to_string(),
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn create_test_context() -> (TempDir, ProjectContext) {
+        let temp_dir = TempDir::new().unwrap();
+        let ctx = ProjectContext::new(temp_dir.path(), "test.ndbx");
+        (temp_dir, ctx)
+    }
+
+    #[test]
+    fn test_platform_info() {
+        let port = DesktopPort::new();
+        let info = port.platform_info();
+
+        assert!(info.has_filesystem);
+        assert!(info.has_native_dialogs);
+        assert!(!info.is_web);
+    }
+
+    #[test]
+    fn test_read_write_file() {
+        let (_temp_dir, ctx) = create_test_context();
+        let port = DesktopPort::new();
+
+        let path = RelativePath::new("test.txt").unwrap();
+        let data = b"Hello, World!";
+
+        // Write file
+        port.write_file(&ctx, &path, data).unwrap();
+
+        // Read file back
+        let read_data = port.read_file(&ctx, &path).unwrap();
+        assert_eq!(read_data, data);
+    }
+
+    #[test]
+    fn test_write_creates_directories() {
+        let (_temp_dir, ctx) = create_test_context();
+        let port = DesktopPort::new();
+
+        let path = RelativePath::new("subdir/nested/file.txt").unwrap();
+        let data = b"nested content";
+
+        port.write_file(&ctx, &path, data).unwrap();
+
+        let read_data = port.read_file(&ctx, &path).unwrap();
+        assert_eq!(read_data, data);
+    }
+
+    #[test]
+    fn test_read_nonexistent_file() {
+        let (_temp_dir, ctx) = create_test_context();
+        let port = DesktopPort::new();
+
+        let path = RelativePath::new("nonexistent.txt").unwrap();
+        let result = port.read_file(&ctx, &path);
+
+        assert!(matches!(result, Err(PortError::NotFound)));
+    }
+
+    #[test]
+    fn test_list_directory() {
+        let (_temp_dir, ctx) = create_test_context();
+        let port = DesktopPort::new();
+
+        // Create some files and directories
+        port.write_file(&ctx, &RelativePath::new("file1.txt").unwrap(), b"1")
+            .unwrap();
+        port.write_file(&ctx, &RelativePath::new("file2.txt").unwrap(), b"2")
+            .unwrap();
+        port.write_file(&ctx, &RelativePath::new("subdir/nested.txt").unwrap(), b"3")
+            .unwrap();
+
+        // List root directory
+        let root = RelativePath::new("").unwrap();
+        let entries = port.list_directory(&ctx, &root).unwrap();
+
+        let names: Vec<_> = entries.iter().map(|e| &e.name).collect();
+        assert!(names.contains(&&"file1.txt".to_string()));
+        assert!(names.contains(&&"file2.txt".to_string()));
+        assert!(names.contains(&&"subdir".to_string()));
+
+        // Check that subdir is marked as directory
+        let subdir = entries.iter().find(|e| e.name == "subdir").unwrap();
+        assert!(subdir.is_directory);
+    }
+
+    #[test]
+    fn test_read_write_project() {
+        let (_temp_dir, ctx) = create_test_context();
+        let port = DesktopPort::new();
+
+        let data = b"<ndbx>project content</ndbx>";
+
+        port.write_project(&ctx, data).unwrap();
+
+        let read_data = port.read_project(&ctx).unwrap();
+        assert_eq!(read_data, data);
+    }
+
+    #[test]
+    fn test_load_library_not_found() {
+        let port = DesktopPort::new();
+        let result = port.load_library("nonexistent_library_xyz");
+
+        assert!(matches!(result, Err(PortError::LibraryNotFound(_))));
+    }
+
+    #[test]
+    fn test_get_config_dir() {
+        let port = DesktopPort::new();
+        let result = port.get_config_dir();
+
+        assert!(result.is_ok());
+        let path = result.unwrap();
+        // Should end with nodebox or NodeBox
+        let path_str = path.to_string_lossy().to_lowercase();
+        assert!(path_str.contains("nodebox"));
+    }
+
+    #[test]
+    fn test_log_levels() {
+        let port = DesktopPort::new();
+
+        // Just verify these don't panic
+        port.log(LogLevel::Error, "test error");
+        port.log(LogLevel::Warn, "test warning");
+        port.log(LogLevel::Info, "test info");
+        port.log(LogLevel::Debug, "test debug");
+    }
+
+    #[test]
+    fn test_performance_marks() {
+        let port = DesktopPort::new();
+
+        // Just verify these don't panic
+        port.performance_mark("test-mark");
+        port.performance_mark_with_details("test-mark", r#"{"key": "value"}"#);
+    }
+
+    #[test]
+    fn test_validate_within_project_valid_path() {
+        let (_temp_dir, ctx) = create_test_context();
+
+        // Create a file inside the project
+        let file_path = ctx.root.as_ref().unwrap().join("test_file.txt");
+        std::fs::write(&file_path, "test content").unwrap();
+
+        // Validation should succeed
+        let result = DesktopPort::validate_within_project(&ctx, &file_path);
+        assert!(result.is_ok());
+        let relative = result.unwrap();
+        assert_eq!(relative.as_path(), Path::new("test_file.txt"));
+    }
+
+    #[test]
+    fn test_validate_within_project_nested_path() {
+        let (_temp_dir, ctx) = create_test_context();
+
+        // Create a nested file inside the project
+        let nested_dir = ctx.root.as_ref().unwrap().join("subdir");
+        std::fs::create_dir_all(&nested_dir).unwrap();
+        let file_path = nested_dir.join("nested_file.txt");
+        std::fs::write(&file_path, "nested content").unwrap();
+
+        // Validation should succeed
+        let result = DesktopPort::validate_within_project(&ctx, &file_path);
+        assert!(result.is_ok());
+        let relative = result.unwrap();
+        assert_eq!(relative.as_path(), Path::new("subdir/nested_file.txt"));
+    }
+
+    #[test]
+    fn test_validate_within_project_outside_path() {
+        let temp_dir = TempDir::new().unwrap();
+        let project_dir = temp_dir.path().join("project");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let ctx = ProjectContext::new(&project_dir, "test.ndbx");
+
+        // Create a file outside the project directory (sibling)
+        let outside_file = temp_dir.path().join("outside.txt");
+        std::fs::write(&outside_file, "outside content").unwrap();
+
+        // Validation should fail with SandboxViolation
+        let result = DesktopPort::validate_within_project(&ctx, &outside_file);
+        assert!(matches!(result, Err(PortError::SandboxViolation)));
+    }
+
+    #[test]
+    fn test_validate_within_project_parent_traversal() {
+        let temp_dir = TempDir::new().unwrap();
+        let project_dir = temp_dir.path().join("project");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let ctx = ProjectContext::new(&project_dir, "test.ndbx");
+
+        // Create a file at the parent level
+        let parent_file = temp_dir.path().join("parent.txt");
+        std::fs::write(&parent_file, "parent content").unwrap();
+
+        // Validation should fail
+        let result = DesktopPort::validate_within_project(&ctx, &parent_file);
+        assert!(matches!(result, Err(PortError::SandboxViolation)));
+    }
+
+    #[test]
+    fn test_validate_save_path_within_project_existing_file() {
+        let (_temp_dir, ctx) = create_test_context();
+
+        // Save path to an existing location (the file doesn't exist but parent does)
+        let save_path = ctx.root.as_ref().unwrap().join("new_file.txt");
+
+        let result = DesktopPort::validate_save_path_within_project(&ctx, &save_path);
+        assert!(result.is_ok());
+        let relative = result.unwrap();
+        assert_eq!(relative.as_path(), Path::new("new_file.txt"));
+    }
+
+    #[test]
+    fn test_validate_save_path_within_project_nested() {
+        let (_temp_dir, ctx) = create_test_context();
+
+        // Create a subdirectory
+        let subdir = ctx.root.as_ref().unwrap().join("assets");
+        std::fs::create_dir_all(&subdir).unwrap();
+
+        // Save path to the existing subdirectory
+        let save_path = subdir.join("new_image.png");
+
+        let result = DesktopPort::validate_save_path_within_project(&ctx, &save_path);
+        assert!(result.is_ok());
+        let relative = result.unwrap();
+        assert_eq!(relative.as_path(), Path::new("assets/new_image.png"));
+    }
+
+    #[test]
+    fn test_validate_save_path_outside_project() {
+        let temp_dir = TempDir::new().unwrap();
+        let project_dir = temp_dir.path().join("project");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let ctx = ProjectContext::new(&project_dir, "test.ndbx");
+
+        // Try to save outside the project
+        let outside_path = temp_dir.path().join("outside.txt");
+
+        let result = DesktopPort::validate_save_path_within_project(&ctx, &outside_path);
+        assert!(matches!(result, Err(PortError::SandboxViolation)));
+    }
+
+    #[test]
+    fn test_read_text_file() {
+        let (_temp_dir, ctx) = create_test_context();
+        let port = DesktopPort::new();
+
+        // Create a text file
+        let file_path = ctx.root.as_ref().unwrap().join("test.txt");
+        std::fs::write(&file_path, "Hello, World!").unwrap();
+
+        // Read it through the port
+        let content = port.read_text_file(&ctx, "test.txt").unwrap();
+        assert_eq!(content, "Hello, World!");
+    }
+
+    #[test]
+    fn test_read_text_file_nested() {
+        let (_temp_dir, ctx) = create_test_context();
+        let port = DesktopPort::new();
+
+        // Create a nested text file
+        let subdir = ctx.root.as_ref().unwrap().join("assets");
+        std::fs::create_dir_all(&subdir).unwrap();
+        std::fs::write(subdir.join("data.txt"), "nested content").unwrap();
+
+        // Read it through the port
+        let content = port.read_text_file(&ctx, "assets/data.txt").unwrap();
+        assert_eq!(content, "nested content");
+    }
+
+    #[test]
+    fn test_read_text_file_invalid_utf8() {
+        let (_temp_dir, ctx) = create_test_context();
+        let port = DesktopPort::new();
+
+        // Create a binary file (invalid UTF-8)
+        let file_path = ctx.root.as_ref().unwrap().join("binary.dat");
+        std::fs::write(&file_path, &[0xFF, 0xFE, 0x00, 0x01]).unwrap();
+
+        // Should fail with IoError for invalid UTF-8
+        let result = port.read_text_file(&ctx, "binary.dat");
+        assert!(matches!(result, Err(PortError::IoError(_))));
+    }
+
+    #[test]
+    fn test_read_text_file_rejects_sandbox_violation() {
+        let (_temp_dir, ctx) = create_test_context();
+        let port = DesktopPort::new();
+
+        // Try to read with ".." in path
+        let result = port.read_text_file(&ctx, "../escape.txt");
+        assert!(matches!(result, Err(PortError::SandboxViolation)));
+
+        // Try with absolute path
+        let result = port.read_text_file(&ctx, "/etc/passwd");
+        assert!(matches!(result, Err(PortError::SandboxViolation)));
+    }
+
+    #[test]
+    fn test_read_text_file_unsaved_project() {
+        let port = DesktopPort::new();
+        let ctx = ProjectContext::new_unsaved();
+
+        // Should fail because project is unsaved
+        let result = port.read_text_file(&ctx, "test.txt");
+        assert!(matches!(result, Err(PortError::Unsupported)));
+    }
+
+    #[test]
+    fn test_read_binary_file() {
+        let (_temp_dir, ctx) = create_test_context();
+        let port = DesktopPort::new();
+
+        // Create a binary file
+        let data = vec![0x89, 0x50, 0x4E, 0x47]; // PNG magic bytes
+        let file_path = ctx.root.as_ref().unwrap().join("image.png");
+        std::fs::write(&file_path, &data).unwrap();
+
+        // Read it through the port
+        let content = port.read_binary_file(&ctx, "image.png").unwrap();
+        assert_eq!(content, data);
+    }
+
+    #[test]
+    fn test_read_binary_file_rejects_sandbox_violation() {
+        let (_temp_dir, ctx) = create_test_context();
+        let port = DesktopPort::new();
+
+        // Try to read with ".." in path
+        let result = port.read_binary_file(&ctx, "../escape.bin");
+        assert!(matches!(result, Err(PortError::SandboxViolation)));
+    }
+
+    #[test]
+    fn test_load_app_resource_not_found() {
+        let port = DesktopPort::new();
+
+        // Resources that don't exist should return NotFound
+        let result = port.load_app_resource("nonexistent/icon.png");
+        assert!(matches!(result, Err(PortError::NotFound)));
+    }
+}

--- a/crates/nodebox-port/src/lib.rs
+++ b/crates/nodebox-port/src/lib.rs
@@ -1,0 +1,1096 @@
+//! Platform abstraction layer for NodeBox.
+//!
+//! The Port system provides a unified interface for platform-specific I/O operations,
+//! enabling the same core logic to run across desktop (macOS, Windows, Linux),
+//! web (WASM), and mobile (iOS, Android) platforms.
+//!
+//! # Design Principles
+//!
+//! 1. **Single trait with runtime capability checking** - One `Port` trait;
+//!    unsupported operations return `Err(PortError::Unsupported)`
+//! 2. **Synchronous API** - All operations are blocking
+//! 3. **Explicit context passing** - `ProjectContext` passed to operations; no global state
+//! 4. **Sandboxed file access** - Files accessible only within project directory,
+//!    its subdirectories, and explicit library paths
+//!
+//! # Example
+//!
+//! ```no_run
+//! use nodebox_port::{Port, ProjectContext, RelativePath, DesktopPort};
+//! use std::path::PathBuf;
+//!
+//! let port = DesktopPort::new();
+//! let ctx = ProjectContext::new("/path/to/project", "project.ndbx");
+//!
+//! // Read a file relative to project root using the convenience method
+//! let svg_content = port.read_text_file(&ctx, "assets/logo.svg");
+//!
+//! // Or use the lower-level API with RelativePath
+//! let path = RelativePath::new("assets/image.png").unwrap();
+//! let data = port.read_file(&ctx, &path);
+//! ```
+
+#[cfg(not(target_arch = "wasm32"))]
+mod desktop;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use desktop::DesktopPort;
+
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+/// Information about the current platform.
+#[derive(Debug, Clone)]
+pub struct PlatformInfo {
+    /// Operating system name: "macos", "windows", "linux", "web", "ios", "android"
+    pub os_name: String,
+    /// Whether running in a web browser (WASM)
+    pub is_web: bool,
+    /// Whether running on a mobile platform (iOS/Android)
+    pub is_mobile: bool,
+    /// Whether native filesystem access is available
+    pub has_filesystem: bool,
+    /// Whether OS-native dialogs are available
+    pub has_native_dialogs: bool,
+}
+
+impl PlatformInfo {
+    /// Create platform info for the current platform.
+    #[cfg(target_os = "macos")]
+    pub fn current() -> Self {
+        Self {
+            os_name: "macos".to_string(),
+            is_web: false,
+            is_mobile: false,
+            has_filesystem: true,
+            has_native_dialogs: true,
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    pub fn current() -> Self {
+        Self {
+            os_name: "windows".to_string(),
+            is_web: false,
+            is_mobile: false,
+            has_filesystem: true,
+            has_native_dialogs: true,
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    pub fn current() -> Self {
+        Self {
+            os_name: "linux".to_string(),
+            is_web: false,
+            is_mobile: false,
+            has_filesystem: true,
+            has_native_dialogs: true,
+        }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub fn current() -> Self {
+        Self {
+            os_name: "web".to_string(),
+            is_web: true,
+            is_mobile: false,
+            has_filesystem: false,
+            has_native_dialogs: false,
+        }
+    }
+
+    #[cfg(target_os = "ios")]
+    pub fn current() -> Self {
+        Self {
+            os_name: "ios".to_string(),
+            is_web: false,
+            is_mobile: true,
+            has_filesystem: true,
+            has_native_dialogs: true,
+        }
+    }
+
+    #[cfg(target_os = "android")]
+    pub fn current() -> Self {
+        Self {
+            os_name: "android".to_string(),
+            is_web: false,
+            is_mobile: true,
+            has_filesystem: true,
+            has_native_dialogs: true,
+        }
+    }
+
+    // Fallback for other platforms
+    #[cfg(not(any(
+        target_os = "macos",
+        target_os = "windows",
+        target_os = "linux",
+        target_os = "ios",
+        target_os = "android",
+        target_arch = "wasm32"
+    )))]
+    pub fn current() -> Self {
+        Self {
+            os_name: "unknown".to_string(),
+            is_web: false,
+            is_mobile: false,
+            has_filesystem: true,
+            has_native_dialogs: false,
+        }
+    }
+}
+
+/// Context for project-relative file operations.
+#[derive(Debug, Clone)]
+pub struct ProjectContext {
+    /// Root directory of the project (contains the .ndbx file).
+    /// None for unsaved projects.
+    pub root: Option<PathBuf>,
+    /// Name of the project file within root.
+    /// None for unsaved projects.
+    pub project_file: Option<String>,
+}
+
+impl ProjectContext {
+    /// Create context for a new unsaved project.
+    pub fn new_unsaved() -> Self {
+        Self {
+            root: None,
+            project_file: None,
+        }
+    }
+
+    /// Create context for a saved project.
+    pub fn new(root: impl Into<PathBuf>, project_file: impl Into<String>) -> Self {
+        Self {
+            root: Some(root.into()),
+            project_file: Some(project_file.into()),
+        }
+    }
+
+    /// Check if this project has been saved.
+    pub fn is_saved(&self) -> bool {
+        self.root.is_some()
+    }
+
+    /// Get the full path to the project file.
+    /// Returns None for unsaved projects.
+    pub fn project_path(&self) -> Option<PathBuf> {
+        match (&self.root, &self.project_file) {
+            (Some(root), Some(file)) => Some(root.join(file)),
+            _ => None,
+        }
+    }
+}
+
+/// A path relative to project root that cannot escape the project directory.
+///
+/// This type ensures that file access is sandboxed within the project directory.
+/// Paths containing ".." components or starting with "/" are rejected.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RelativePath {
+    path: PathBuf,
+}
+
+impl RelativePath {
+    /// Create a new relative path.
+    ///
+    /// # Errors
+    ///
+    /// Returns `PortError::SandboxViolation` if:
+    /// - The path contains ".." components
+    /// - The path starts with "/" (absolute path)
+    /// - The path starts with a Windows drive letter (e.g., "C:")
+    pub fn new(path: impl AsRef<Path>) -> Result<Self, PortError> {
+        let path = path.as_ref();
+
+        // Check for absolute paths
+        if path.is_absolute() {
+            return Err(PortError::SandboxViolation);
+        }
+
+        // Check for Windows-style absolute paths (C:\, D:\, etc.)
+        if let Some(s) = path.to_str() {
+            if s.len() >= 2 {
+                let chars: Vec<char> = s.chars().take(2).collect();
+                if chars[0].is_ascii_alphabetic() && chars[1] == ':' {
+                    return Err(PortError::SandboxViolation);
+                }
+            }
+        }
+
+        // Check for ".." components that could escape the sandbox
+        for component in path.components() {
+            if let std::path::Component::ParentDir = component {
+                return Err(PortError::SandboxViolation);
+            }
+        }
+
+        Ok(Self {
+            path: path.to_path_buf(),
+        })
+    }
+
+    /// Get the path as a `Path` reference.
+    pub fn as_path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Join this relative path with another path component.
+    ///
+    /// # Errors
+    ///
+    /// Returns `PortError::SandboxViolation` if the resulting path would escape the sandbox.
+    pub fn join(&self, path: impl AsRef<Path>) -> Result<Self, PortError> {
+        let joined = self.path.join(path);
+        Self::new(joined)
+    }
+}
+
+impl AsRef<Path> for RelativePath {
+    fn as_ref(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl std::fmt::Display for RelativePath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.path.display())
+    }
+}
+
+/// An entry in a directory listing.
+#[derive(Debug, Clone)]
+pub struct DirectoryEntry {
+    /// Name of the file or directory
+    pub name: String,
+    /// Whether this entry is a directory
+    pub is_directory: bool,
+}
+
+impl DirectoryEntry {
+    /// Create a new directory entry.
+    pub fn new(name: impl Into<String>, is_directory: bool) -> Self {
+        Self {
+            name: name.into(),
+            is_directory,
+        }
+    }
+}
+
+/// Filter for file dialogs.
+#[derive(Debug, Clone)]
+pub struct FileFilter {
+    /// Display name for the filter (e.g., "NodeBox Files")
+    pub name: String,
+    /// File extensions to filter (e.g., ["ndbx"])
+    pub extensions: Vec<String>,
+}
+
+impl FileFilter {
+    /// Create a new file filter.
+    pub fn new(name: impl Into<String>, extensions: Vec<String>) -> Self {
+        Self {
+            name: name.into(),
+            extensions,
+        }
+    }
+
+    /// Create a filter for NodeBox files.
+    pub fn nodebox() -> Self {
+        Self::new("NodeBox Files", vec!["ndbx".to_string()])
+    }
+
+    /// Create a filter for SVG files.
+    pub fn svg() -> Self {
+        Self::new("SVG Files", vec!["svg".to_string()])
+    }
+
+    /// Create a filter for PNG files.
+    pub fn png() -> Self {
+        Self::new("PNG Files", vec!["png".to_string()])
+    }
+}
+
+/// Log level for the `log` method.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogLevel {
+    /// Error messages
+    Error,
+    /// Warning messages
+    Warn,
+    /// Informational messages
+    Info,
+    /// Debug messages
+    Debug,
+}
+
+impl std::fmt::Display for LogLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LogLevel::Error => write!(f, "ERROR"),
+            LogLevel::Warn => write!(f, "WARN"),
+            LogLevel::Info => write!(f, "INFO"),
+            LogLevel::Debug => write!(f, "DEBUG"),
+        }
+    }
+}
+
+/// Errors that can occur during Port operations.
+#[derive(Debug, Error)]
+pub enum PortError {
+    /// Operation not supported on this platform
+    #[error("operation not supported on this platform")]
+    Unsupported,
+
+    /// File or directory not found
+    #[error("not found")]
+    NotFound,
+
+    /// Permission denied
+    #[error("permission denied")]
+    PermissionDenied,
+
+    /// Path escapes sandbox (tried to access outside project dir)
+    #[error("path escapes project sandbox")]
+    SandboxViolation,
+
+    /// Network request failed
+    #[error("network error: {0}")]
+    NetworkError(String),
+
+    /// I/O error
+    #[error("I/O error: {0}")]
+    IoError(String),
+
+    /// Library not found
+    #[error("library not found: {0}")]
+    LibraryNotFound(String),
+
+    /// Other error
+    #[error("{0}")]
+    Other(String),
+}
+
+impl From<std::io::Error> for PortError {
+    fn from(err: std::io::Error) -> Self {
+        match err.kind() {
+            std::io::ErrorKind::NotFound => PortError::NotFound,
+            std::io::ErrorKind::PermissionDenied => PortError::PermissionDenied,
+            _ => PortError::IoError(err.to_string()),
+        }
+    }
+}
+
+/// The main Port trait for platform abstraction.
+///
+/// Implementations of this trait provide platform-specific behavior for
+/// file I/O, dialogs, clipboard, network, and other operations.
+pub trait Port: Send + Sync {
+    // === Platform Info ===
+
+    /// Get information about the current platform.
+    fn platform_info(&self) -> PlatformInfo;
+
+    // === File Operations ===
+
+    /// Read a file from the project directory.
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx` - Project context containing the root directory
+    /// * `path` - Path relative to project root
+    ///
+    /// # Errors
+    ///
+    /// * `PortError::NotFound` - File does not exist
+    /// * `PortError::PermissionDenied` - No permission to read file
+    /// * `PortError::IoError` - Other I/O error
+    fn read_file(&self, ctx: &ProjectContext, path: &RelativePath) -> Result<Vec<u8>, PortError>;
+
+    /// Write a file to the project directory.
+    ///
+    /// Creates parent directories if they don't exist.
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx` - Project context containing the root directory
+    /// * `path` - Path relative to project root
+    /// * `data` - Data to write
+    ///
+    /// # Errors
+    ///
+    /// * `PortError::PermissionDenied` - No permission to write file
+    /// * `PortError::IoError` - Other I/O error
+    fn write_file(
+        &self,
+        ctx: &ProjectContext,
+        path: &RelativePath,
+        data: &[u8],
+    ) -> Result<(), PortError>;
+
+    /// List contents of a directory within the project.
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx` - Project context containing the root directory
+    /// * `path` - Path relative to project root
+    ///
+    /// # Errors
+    ///
+    /// * `PortError::NotFound` - Directory does not exist
+    /// * `PortError::PermissionDenied` - No permission to read directory
+    /// * `PortError::IoError` - Other I/O error
+    fn list_directory(
+        &self,
+        ctx: &ProjectContext,
+        path: &RelativePath,
+    ) -> Result<Vec<DirectoryEntry>, PortError>;
+
+    // === Convenience File Operations ===
+
+    /// Read a text file (UTF-8) from the project directory.
+    ///
+    /// This is a convenience method that validates the path is relative and within
+    /// the project sandbox, then reads the file as UTF-8 text.
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx` - Project context containing the root directory
+    /// * `path` - Path string relative to project root
+    ///
+    /// # Errors
+    ///
+    /// * `PortError::Unsupported` - Project has no root directory (unsaved project)
+    /// * `PortError::SandboxViolation` - Path contains "..", is absolute, etc.
+    /// * `PortError::NotFound` - File does not exist
+    /// * `PortError::IoError` - Other I/O error or invalid UTF-8
+    fn read_text_file(&self, ctx: &ProjectContext, path: &str) -> Result<String, PortError>;
+
+    /// Read a binary file from the project directory.
+    ///
+    /// This is a convenience method that validates the path is relative and within
+    /// the project sandbox, then reads the file as binary data.
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx` - Project context containing the root directory
+    /// * `path` - Path string relative to project root
+    ///
+    /// # Errors
+    ///
+    /// * `PortError::Unsupported` - Project has no root directory (unsaved project)
+    /// * `PortError::SandboxViolation` - Path contains "..", is absolute, etc.
+    /// * `PortError::NotFound` - File does not exist
+    /// * `PortError::IoError` - Other I/O error
+    fn read_binary_file(&self, ctx: &ProjectContext, path: &str) -> Result<Vec<u8>, PortError>;
+
+    /// Load an application resource (icons, fonts, etc.)
+    ///
+    /// These are bundled with the application, not project-specific.
+    /// Resources are located relative to the application executable or bundle.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Resource path relative to resources directory (e.g., "icons/add.png")
+    ///
+    /// # Errors
+    ///
+    /// * `PortError::NotFound` - Resource does not exist
+    /// * `PortError::IoError` - Other I/O error
+    fn load_app_resource(&self, name: &str) -> Result<Vec<u8>, PortError>;
+
+    // === Project File (special handling) ===
+
+    /// Read the project file.
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx` - Project context containing the root directory and project file name
+    ///
+    /// # Errors
+    ///
+    /// * `PortError::NotFound` - Project file does not exist
+    /// * `PortError::IoError` - Other I/O error
+    fn read_project(&self, ctx: &ProjectContext) -> Result<Vec<u8>, PortError>;
+
+    /// Write the project file.
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx` - Project context containing the root directory and project file name
+    /// * `data` - Project data to write
+    ///
+    /// # Errors
+    ///
+    /// * `PortError::PermissionDenied` - No permission to write file
+    /// * `PortError::IoError` - Other I/O error
+    fn write_project(&self, ctx: &ProjectContext, data: &[u8]) -> Result<(), PortError>;
+
+    // === Library Access ===
+
+    /// Load a library by name.
+    ///
+    /// Libraries are located in platform-specific directories:
+    /// - macOS: `~/Library/Application Support/net.nodebox.NodeBox/libraries/`
+    /// - Windows: `%APPDATA%\NodeBox\libraries\`
+    /// - Linux: `~/.local/share/nodebox/libraries/`
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Name of the library (without extension)
+    ///
+    /// # Errors
+    ///
+    /// * `PortError::LibraryNotFound` - Library does not exist
+    /// * `PortError::IoError` - Other I/O error
+    fn load_library(&self, name: &str) -> Result<Vec<u8>, PortError>;
+
+    // === Network ===
+
+    /// Perform an HTTP GET request.
+    ///
+    /// # Arguments
+    ///
+    /// * `url` - URL to fetch
+    ///
+    /// # Errors
+    ///
+    /// * `PortError::NetworkError` - Network request failed
+    /// * `PortError::Unsupported` - Network not available on this platform
+    fn http_get(&self, url: &str) -> Result<Vec<u8>, PortError>;
+
+    // === Dialogs (Project-level, return absolute paths) ===
+
+    /// Show dialog to open a project file (no sandbox restriction).
+    ///
+    /// This is for opening .ndbx project files and returns an absolute path.
+    /// Use this when the user wants to open an existing project.
+    ///
+    /// # Arguments
+    ///
+    /// * `filters` - File type filters to show
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(path))` - User selected a file
+    /// * `Ok(None)` - User cancelled
+    /// * `Err(PortError::Unsupported)` - Dialogs not available
+    fn show_open_project_dialog(
+        &self,
+        filters: &[FileFilter],
+    ) -> Result<Option<PathBuf>, PortError>;
+
+    /// Show dialog to choose where to save a new project.
+    ///
+    /// This is for "Save As" operations and returns an absolute path.
+    /// Use this to establish the project location for new/unsaved projects.
+    ///
+    /// # Arguments
+    ///
+    /// * `filters` - File type filters to show
+    /// * `default_name` - Optional default filename
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(path))` - User selected a save location
+    /// * `Ok(None)` - User cancelled
+    /// * `Err(PortError::Unsupported)` - Dialogs not available
+    fn show_save_project_dialog(
+        &self,
+        filters: &[FileFilter],
+        default_name: Option<&str>,
+    ) -> Result<Option<PathBuf>, PortError>;
+
+    // === Dialogs (Asset-level, sandboxed to project) ===
+
+    /// Show "Open File" dialog for importing assets.
+    ///
+    /// The selected file must be within the project directory. If the user
+    /// selects a file outside the project, returns `Err(PortError::SandboxViolation)`.
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx` - Project context (required for sandbox validation)
+    /// * `filters` - File type filters to show
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(path))` - User selected a valid file within project
+    /// * `Ok(None)` - User cancelled
+    /// * `Err(PortError::SandboxViolation)` - Selected file is outside project directory
+    /// * `Err(PortError::Unsupported)` - Dialogs not available
+    fn show_open_file_dialog(
+        &self,
+        ctx: &ProjectContext,
+        filters: &[FileFilter],
+    ) -> Result<Option<RelativePath>, PortError>;
+
+    /// Show "Save File" dialog for exporting assets.
+    ///
+    /// The selected location must be within the project directory. If the user
+    /// selects a location outside the project, returns `Err(PortError::SandboxViolation)`.
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx` - Project context (required for sandbox validation)
+    /// * `filters` - File type filters to show
+    /// * `default_name` - Optional default filename
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(path))` - User selected a valid location within project
+    /// * `Ok(None)` - User cancelled
+    /// * `Err(PortError::SandboxViolation)` - Selected location is outside project directory
+    /// * `Err(PortError::Unsupported)` - Dialogs not available
+    fn show_save_file_dialog(
+        &self,
+        ctx: &ProjectContext,
+        filters: &[FileFilter],
+        default_name: Option<&str>,
+    ) -> Result<Option<RelativePath>, PortError>;
+
+    /// Show a "Select Folder" dialog for selecting a directory within the project.
+    ///
+    /// The selected folder must be within the project directory. If the user
+    /// selects a folder outside the project, returns `Err(PortError::SandboxViolation)`.
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx` - Project context (required for sandbox validation)
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(path))` - User selected a valid folder within project
+    /// * `Ok(None)` - User cancelled
+    /// * `Err(PortError::SandboxViolation)` - Selected folder is outside project directory
+    /// * `Err(PortError::Unsupported)` - Dialogs not available
+    fn show_select_folder_dialog(
+        &self,
+        ctx: &ProjectContext,
+    ) -> Result<Option<RelativePath>, PortError>;
+
+    /// Show a confirmation dialog with OK and Cancel buttons.
+    ///
+    /// # Arguments
+    ///
+    /// * `title` - Dialog title
+    /// * `message` - Dialog message
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(true)` - User clicked OK
+    /// * `Ok(false)` - User clicked Cancel
+    /// * `Err(PortError::Unsupported)` - Dialogs not available
+    fn show_confirm_dialog(&self, title: &str, message: &str) -> Result<bool, PortError>;
+
+    /// Show a message dialog with custom buttons.
+    ///
+    /// # Arguments
+    ///
+    /// * `title` - Dialog title
+    /// * `message` - Dialog message
+    /// * `buttons` - Button labels (2-3 buttons)
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(index))` - User clicked button at index (0-based)
+    /// * `Ok(None)` - User dismissed without selection
+    /// * `Err(PortError::Unsupported)` - Dialogs not available
+    fn show_message_dialog(
+        &self,
+        title: &str,
+        message: &str,
+        buttons: &[&str],
+    ) -> Result<Option<usize>, PortError>;
+
+    // === Clipboard ===
+
+    /// Read text from the clipboard.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(text))` - Clipboard contains text
+    /// * `Ok(None)` - Clipboard is empty or doesn't contain text
+    /// * `Err(PortError::Unsupported)` - Clipboard not available
+    fn clipboard_read_text(&self) -> Result<Option<String>, PortError>;
+
+    /// Write text to the clipboard.
+    ///
+    /// # Arguments
+    ///
+    /// * `text` - Text to write to clipboard
+    ///
+    /// # Errors
+    ///
+    /// * `Err(PortError::Unsupported)` - Clipboard not available
+    /// * `Err(PortError::Other)` - Failed to write to clipboard
+    fn clipboard_write_text(&self, text: &str) -> Result<(), PortError>;
+
+    // === Logging ===
+
+    /// Log a message at the specified level.
+    ///
+    /// Messages are routed to the appropriate destination:
+    /// - Desktop: stderr or log file
+    /// - Web: console.log/console.error
+    /// - Mobile: NSLog/android.util.Log
+    fn log(&self, level: LogLevel, message: &str);
+
+    // === Performance ===
+
+    /// Create a performance mark.
+    ///
+    /// Used for profiling and performance analysis.
+    fn performance_mark(&self, name: &str);
+
+    /// Create a performance mark with additional details.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Mark name
+    /// * `details` - Additional details (JSON string)
+    fn performance_mark_with_details(&self, name: &str, details: &str);
+
+    // === Configuration ===
+
+    /// Get the configuration directory for storing app settings.
+    ///
+    /// Platform-specific locations:
+    /// - macOS: `~/Library/Application Support/net.nodebox.NodeBox/`
+    /// - Windows: `%APPDATA%\NodeBox\`
+    /// - Linux: `~/.config/nodebox/`
+    ///
+    /// # Errors
+    ///
+    /// * `Err(PortError::Unsupported)` - No config directory on this platform
+    fn get_config_dir(&self) -> Result<PathBuf, PortError>;
+}
+
+/// A minimal Port implementation for testing.
+///
+/// This port returns `Unsupported` for most operations, making it suitable
+/// for tests that don't need actual file or dialog operations.
+pub struct TestPort;
+
+impl TestPort {
+    /// Create a new TestPort.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for TestPort {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Port for TestPort {
+    fn platform_info(&self) -> PlatformInfo {
+        PlatformInfo {
+            os_name: "test".to_string(),
+            is_web: false,
+            is_mobile: false,
+            has_filesystem: false,
+            has_native_dialogs: false,
+        }
+    }
+
+    fn read_file(&self, _ctx: &ProjectContext, _path: &RelativePath) -> Result<Vec<u8>, PortError> {
+        Err(PortError::Unsupported)
+    }
+
+    fn write_file(
+        &self,
+        _ctx: &ProjectContext,
+        _path: &RelativePath,
+        _data: &[u8],
+    ) -> Result<(), PortError> {
+        Err(PortError::Unsupported)
+    }
+
+    fn list_directory(
+        &self,
+        _ctx: &ProjectContext,
+        _path: &RelativePath,
+    ) -> Result<Vec<DirectoryEntry>, PortError> {
+        Err(PortError::Unsupported)
+    }
+
+    fn read_text_file(&self, _ctx: &ProjectContext, _path: &str) -> Result<String, PortError> {
+        Err(PortError::Unsupported)
+    }
+
+    fn read_binary_file(&self, _ctx: &ProjectContext, _path: &str) -> Result<Vec<u8>, PortError> {
+        Err(PortError::Unsupported)
+    }
+
+    fn load_app_resource(&self, _name: &str) -> Result<Vec<u8>, PortError> {
+        Err(PortError::Unsupported)
+    }
+
+    fn read_project(&self, _ctx: &ProjectContext) -> Result<Vec<u8>, PortError> {
+        Err(PortError::Unsupported)
+    }
+
+    fn write_project(&self, _ctx: &ProjectContext, _data: &[u8]) -> Result<(), PortError> {
+        Err(PortError::Unsupported)
+    }
+
+    fn load_library(&self, _name: &str) -> Result<Vec<u8>, PortError> {
+        Err(PortError::Unsupported)
+    }
+
+    fn http_get(&self, _url: &str) -> Result<Vec<u8>, PortError> {
+        Err(PortError::Unsupported)
+    }
+
+    fn show_open_project_dialog(
+        &self,
+        _filters: &[FileFilter],
+    ) -> Result<Option<PathBuf>, PortError> {
+        Err(PortError::Unsupported)
+    }
+
+    fn show_save_project_dialog(
+        &self,
+        _filters: &[FileFilter],
+        _default_name: Option<&str>,
+    ) -> Result<Option<PathBuf>, PortError> {
+        Err(PortError::Unsupported)
+    }
+
+    fn show_open_file_dialog(
+        &self,
+        _ctx: &ProjectContext,
+        _filters: &[FileFilter],
+    ) -> Result<Option<RelativePath>, PortError> {
+        Err(PortError::Unsupported)
+    }
+
+    fn show_save_file_dialog(
+        &self,
+        _ctx: &ProjectContext,
+        _filters: &[FileFilter],
+        _default_name: Option<&str>,
+    ) -> Result<Option<RelativePath>, PortError> {
+        Err(PortError::Unsupported)
+    }
+
+    fn show_select_folder_dialog(
+        &self,
+        _ctx: &ProjectContext,
+    ) -> Result<Option<RelativePath>, PortError> {
+        Err(PortError::Unsupported)
+    }
+
+    fn show_confirm_dialog(&self, _title: &str, _message: &str) -> Result<bool, PortError> {
+        Err(PortError::Unsupported)
+    }
+
+    fn show_message_dialog(
+        &self,
+        _title: &str,
+        _message: &str,
+        _buttons: &[&str],
+    ) -> Result<Option<usize>, PortError> {
+        Err(PortError::Unsupported)
+    }
+
+    fn clipboard_read_text(&self) -> Result<Option<String>, PortError> {
+        Err(PortError::Unsupported)
+    }
+
+    fn clipboard_write_text(&self, _text: &str) -> Result<(), PortError> {
+        Err(PortError::Unsupported)
+    }
+
+    fn log(&self, _level: LogLevel, _message: &str) {}
+
+    fn performance_mark(&self, _name: &str) {}
+
+    fn performance_mark_with_details(&self, _name: &str, _details: &str) {}
+
+    fn get_config_dir(&self) -> Result<PathBuf, PortError> {
+        Err(PortError::Unsupported)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_relative_path_valid() {
+        // Simple paths should be valid
+        assert!(RelativePath::new("file.txt").is_ok());
+        assert!(RelativePath::new("subdir/file.txt").is_ok());
+        assert!(RelativePath::new("a/b/c/d.txt").is_ok());
+        assert!(RelativePath::new("").is_ok());
+    }
+
+    #[test]
+    fn test_relative_path_rejects_parent_dir() {
+        // Paths with ".." should be rejected
+        assert!(matches!(
+            RelativePath::new(".."),
+            Err(PortError::SandboxViolation)
+        ));
+        assert!(matches!(
+            RelativePath::new("../file.txt"),
+            Err(PortError::SandboxViolation)
+        ));
+        assert!(matches!(
+            RelativePath::new("subdir/../other.txt"),
+            Err(PortError::SandboxViolation)
+        ));
+        assert!(matches!(
+            RelativePath::new("a/b/../../c.txt"),
+            Err(PortError::SandboxViolation)
+        ));
+    }
+
+    #[test]
+    fn test_relative_path_rejects_absolute() {
+        // Absolute paths should be rejected
+        assert!(matches!(
+            RelativePath::new("/etc/passwd"),
+            Err(PortError::SandboxViolation)
+        ));
+        assert!(matches!(
+            RelativePath::new("/home/user/file.txt"),
+            Err(PortError::SandboxViolation)
+        ));
+    }
+
+    #[test]
+    fn test_relative_path_rejects_windows_absolute() {
+        // Windows-style absolute paths should be rejected
+        assert!(matches!(
+            RelativePath::new("C:/Users/file.txt"),
+            Err(PortError::SandboxViolation)
+        ));
+        assert!(matches!(
+            RelativePath::new("D:\\Documents\\file.txt"),
+            Err(PortError::SandboxViolation)
+        ));
+    }
+
+    #[test]
+    fn test_relative_path_join() {
+        let base = RelativePath::new("subdir").unwrap();
+
+        // Valid joins
+        let joined = base.join("file.txt").unwrap();
+        assert_eq!(joined.as_path(), Path::new("subdir/file.txt"));
+
+        // Invalid joins (with ..)
+        assert!(matches!(
+            base.join("../escape.txt"),
+            Err(PortError::SandboxViolation)
+        ));
+    }
+
+    #[test]
+    fn test_relative_path_display() {
+        let path = RelativePath::new("subdir/file.txt").unwrap();
+        assert_eq!(format!("{}", path), "subdir/file.txt");
+    }
+
+    #[test]
+    fn test_project_context() {
+        let ctx = ProjectContext::new("/home/user/project", "myproject.ndbx");
+        assert_eq!(ctx.root, Some(PathBuf::from("/home/user/project")));
+        assert_eq!(ctx.project_file, Some("myproject.ndbx".to_string()));
+        assert!(ctx.is_saved());
+        assert_eq!(
+            ctx.project_path(),
+            Some(PathBuf::from("/home/user/project/myproject.ndbx"))
+        );
+    }
+
+    #[test]
+    fn test_project_context_unsaved() {
+        let ctx = ProjectContext::new_unsaved();
+        assert_eq!(ctx.root, None);
+        assert_eq!(ctx.project_file, None);
+        assert!(!ctx.is_saved());
+        assert_eq!(ctx.project_path(), None);
+    }
+
+    #[test]
+    fn test_directory_entry() {
+        let file = DirectoryEntry::new("file.txt", false);
+        assert_eq!(file.name, "file.txt");
+        assert!(!file.is_directory);
+
+        let dir = DirectoryEntry::new("subdir", true);
+        assert_eq!(dir.name, "subdir");
+        assert!(dir.is_directory);
+    }
+
+    #[test]
+    fn test_file_filter() {
+        let filter = FileFilter::new("Images", vec!["png".to_string(), "jpg".to_string()]);
+        assert_eq!(filter.name, "Images");
+        assert_eq!(filter.extensions, vec!["png", "jpg"]);
+
+        let ndbx = FileFilter::nodebox();
+        assert_eq!(ndbx.extensions, vec!["ndbx"]);
+    }
+
+    #[test]
+    fn test_log_level_display() {
+        assert_eq!(format!("{}", LogLevel::Error), "ERROR");
+        assert_eq!(format!("{}", LogLevel::Warn), "WARN");
+        assert_eq!(format!("{}", LogLevel::Info), "INFO");
+        assert_eq!(format!("{}", LogLevel::Debug), "DEBUG");
+    }
+
+    #[test]
+    fn test_port_error_from_io_error() {
+        let not_found = std::io::Error::new(std::io::ErrorKind::NotFound, "not found");
+        assert!(matches!(PortError::from(not_found), PortError::NotFound));
+
+        let permission = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied");
+        assert!(matches!(
+            PortError::from(permission),
+            PortError::PermissionDenied
+        ));
+
+        let other = std::io::Error::new(std::io::ErrorKind::Other, "something else");
+        assert!(matches!(PortError::from(other), PortError::IoError(_)));
+    }
+
+    #[test]
+    fn test_port_error_display() {
+        assert_eq!(
+            format!("{}", PortError::Unsupported),
+            "operation not supported on this platform"
+        );
+        assert_eq!(format!("{}", PortError::NotFound), "not found");
+        assert_eq!(format!("{}", PortError::PermissionDenied), "permission denied");
+        assert_eq!(
+            format!("{}", PortError::SandboxViolation),
+            "path escapes project sandbox"
+        );
+        assert_eq!(
+            format!("{}", PortError::NetworkError("timeout".to_string())),
+            "network error: timeout"
+        );
+        assert_eq!(
+            format!("{}", PortError::LibraryNotFound("math".to_string())),
+            "library not found: math"
+        );
+    }
+
+    #[test]
+    fn test_platform_info_current() {
+        let info = PlatformInfo::current();
+        // Just verify it doesn't panic and returns something reasonable
+        assert!(!info.os_name.is_empty());
+    }
+}

--- a/scripts/build-linux-appimage.sh
+++ b/scripts/build-linux-appimage.sh
@@ -37,10 +37,10 @@ fi
 
 # Build the binary
 cd "$PROJECT_ROOT"
-cargo build $CARGO_FLAGS -p nodebox-gui
+cargo build $CARGO_FLAGS -p nodebox
 
 # Set up paths
-BINARY_PATH="$PROJECT_ROOT/target/$BUILD_TYPE/nodebox-gui"
+BINARY_PATH="$PROJECT_ROOT/target/$BUILD_TYPE/NodeBox"
 APPDIR="$PROJECT_ROOT/target/$BUILD_TYPE/NodeBox.AppDir"
 APPIMAGE_PATH="$PROJECT_ROOT/target/$BUILD_TYPE/NodeBox-$VERSION-$ARCH.AppImage"
 

--- a/scripts/build-mac-bundle.sh
+++ b/scripts/build-mac-bundle.sh
@@ -21,7 +21,7 @@ echo "Building NodeBox $VERSION ($BUILD_TYPE)..."
 
 # Build the binary
 cd "$PROJECT_ROOT"
-cargo build $CARGO_FLAGS
+cargo build $CARGO_FLAGS -p nodebox
 
 # Set up paths
 BINARY_PATH="$PROJECT_ROOT/target/$BUILD_TYPE/NodeBox"

--- a/scripts/build-windows-installer.ps1
+++ b/scripts/build-windows-installer.ps1
@@ -30,9 +30,9 @@ $CargoFlags = if ($Debug) { @() } else { @("--release") }
 
 # Build the binary
 Set-Location $ProjectRoot
-cargo build @CargoFlags -p nodebox-gui
+cargo build @CargoFlags -p nodebox
 
-$BinaryPath = "$ProjectRoot\target\$BuildType\nodebox-gui.exe"
+$BinaryPath = "$ProjectRoot\target\$BuildType\NodeBox.exe"
 $OutputDir = "$ProjectRoot\target\$BuildType\installer"
 
 # Create output directory
@@ -58,6 +58,6 @@ Write-Host ""
 Write-Host "To create an MSI installer:"
 Write-Host "  1. Install WiX Toolset: https://wixtoolset.org/"
 Write-Host "  2. Install cargo-wix: cargo install cargo-wix"
-Write-Host "  3. Run: cargo wix -p nodebox-gui"
+Write-Host "  3. Run: cargo wix -p nodebox"
 Write-Host ""
 Write-Host "Or use the portable executable directly: $OutputDir\NodeBox.exe"


### PR DESCRIPTION
## Summary
- Introduces `nodebox-port` crate with `Port` trait for platform-abstracted, sandboxed file I/O
- Integrates Port and ProjectContext throughout nodebox-gui evaluation pipeline
- Fixes critical bug where import_svg nodes bypassed sandbox and used direct filesystem access
- Removes TestPort from production code (was causing import_svg to silently fail)

## Changes

### New crate: `nodebox-port`
- `Port` trait: abstraction for file I/O with sandbox validation
- `ProjectContext`: tracks project save state (root directory, project file)
- `DesktopPort`: production implementation with `RelativePath` sandbox validation
- `TestPort`: minimal implementation for testing (returns `Unsupported` for all file ops)

### Updates to `nodebox-gui`
- `evaluate_network()` and related functions now accept `port` and `project_context` parameters
- `import_svg` handler reads SVG content through Port instead of direct filesystem access
- `AppState::new()` and `load_file()` no longer evaluate immediately; render worker handles it
- Removed TestPort usage from production state.rs

### Build changes
- Root `Cargo.toml` now builds the main binary directly (simplified from nodebox-desktop)
- Updated platform build scripts

## Test plan
- [x] `cargo build --workspace --exclude nodebox-python`
- [x] `cargo test --workspace --exclude nodebox-python`
- [x] `cargo run` launches the GUI correctly
- [x] Existing file_tests.rs pass with new Port-based evaluation

🤖 Generated with [Claude Code](https://claude.com/claude-code)