### PR TITLE
Always show points for point-output nodes in viewer

### DIFF
--- a/crates/nodebox-core/src/node/library.rs
+++ b/crates/nodebox-core/src/node/library.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use super::Node;
+use super::PortType;
 
 /// A library of nodes, typically loaded from an .ndbx file.
 ///
@@ -123,6 +124,14 @@ impl NodeLibrary {
 
         Some(current)
     }
+
+    /// Returns true if the currently rendered node outputs Point type.
+    pub fn is_rendered_output_point(&self) -> bool {
+        self.root.rendered_child.as_ref()
+            .and_then(|name| self.root.child(name))
+            .map(|node| node.output_type == PortType::Point)
+            .unwrap_or(false)
+    }
 }
 
 #[cfg(test)]
@@ -171,5 +180,25 @@ mod tests {
         let lib = NodeLibrary::new("test");
         assert_eq!(lib.width(), 1000.0);
         assert_eq!(lib.height(), 1000.0);
+    }
+
+    #[test]
+    fn test_is_rendered_output_point() {
+        let mut lib = NodeLibrary::new("test");
+
+        // No rendered child - should return false
+        assert!(!lib.is_rendered_output_point());
+
+        // Add a node with default Geometry output type
+        lib.root = Node::network("root")
+            .with_child(Node::new("rect1"))
+            .with_rendered_child("rect1");
+        assert!(!lib.is_rendered_output_point());
+
+        // Add a node with Point output type
+        lib.root = Node::network("root")
+            .with_child(Node::new("grid1").with_output_type(PortType::Point))
+            .with_rendered_child("grid1");
+        assert!(lib.is_rendered_output_point());
     }
 }

--- a/crates/nodebox-gui/src/eval.rs
+++ b/crates/nodebox-gui/src/eval.rs
@@ -142,6 +142,11 @@ impl NodeOutput {
             _ => 1,
         }
     }
+
+    /// Returns true if this output is a Point or Points type.
+    pub fn is_point_output(&self) -> bool {
+        matches!(self, NodeOutput::Point(_) | NodeOutput::Points(_))
+    }
 }
 
 /// Evaluate a node network and return the output of the rendered node along with any errors.
@@ -265,10 +270,12 @@ pub fn evaluate_network_cancellable(
     }
 
     match result {
-        Ok(output) => EvalOutcome::Completed {
-            geometry: output.to_paths(),
-            errors: Vec::new(),
-        },
+        Ok(output) => {
+            EvalOutcome::Completed {
+                geometry: output.to_paths(),
+                errors: Vec::new(),
+            }
+        }
         Err(EvalError::Cancelled) => EvalOutcome::Cancelled,
         Err(e) => {
             // Extract node name based on error type
@@ -1925,6 +1932,25 @@ mod tests {
 
         let output = NodeOutput::Float(1.0);
         assert!(output.as_paths().is_none());
+
+        // Test is_point_output()
+        let output = NodeOutput::Point(Point::ZERO);
+        assert!(output.is_point_output());
+
+        let output = NodeOutput::Points(vec![Point::ZERO, Point::new(1.0, 1.0)]);
+        assert!(output.is_point_output());
+
+        let output = NodeOutput::Path(path.clone());
+        assert!(!output.is_point_output());
+
+        let output = NodeOutput::Paths(vec![path.clone()]);
+        assert!(!output.is_point_output());
+
+        let output = NodeOutput::Float(1.0);
+        assert!(!output.is_point_output());
+
+        let output = NodeOutput::None;
+        assert!(!output.is_point_output());
     }
 
     #[test]

--- a/crates/nodebox-gui/src/viewer_pane.rs
+++ b/crates/nodebox-gui/src/viewer_pane.rs
@@ -695,8 +695,8 @@ impl ViewerPane {
                 geometry_hash,
             );
 
-            // Draw points overlay if enabled (still use egui for this)
-            if self.show_points {
+            // Draw points overlay if enabled or if output is from a Point-type node
+            if self.show_points || state.library.is_rendered_output_point() {
                 for path in &state.geometry {
                     self.draw_points(painter, path, center);
                 }
@@ -725,7 +725,7 @@ impl ViewerPane {
         for path in &state.geometry {
             self.draw_path(painter, path, center);
 
-            if self.show_points {
+            if self.show_points || state.library.is_rendered_output_point() {
                 self.draw_points(painter, path, center);
             }
         }


### PR DESCRIPTION
## Summary
- Nodes that output points (like `grid`, `scatter`, `makePoint`, `centroid`) now always display their points in the viewer, even when the global "Show Points" toggle is off
- Uses a simple approach: check the rendered node's `output_type` directly at render time via `NodeLibrary::is_rendered_output_point()`, rather than threading a flag through the evaluation pipeline

## Test plan
- [x] Create a `corevector.grid` node - points should display automatically
- [x] Toggle "Show Points" off - grid points should still display
- [x] Create a `corevector.rect` - points should NOT display when toggle is off
- [x] Toggle "Show Points" on for rect - points should now display

🤖 Generated with [Claude Code](https://claude.com/claude-code)