### PR TITLE
Fix viewer empty on startup until parameter change

### DIFF
--- a/crates/nodebox-gui/src/app.rs
+++ b/crates/nodebox-gui/src/app.rs
@@ -113,7 +113,7 @@ impl NodeBoxApp {
             previous_library_hash: hash,
             render_worker: RenderWorkerHandle::spawn(),
             render_state: RenderState::new(),
-            render_pending: false, // Initial geometry is already evaluated in AppState::new()
+            render_pending: true,
             native_menu,
             recent_files,
         }
@@ -193,7 +193,7 @@ impl NodeBoxApp {
             previous_library_hash: hash,
             render_worker: RenderWorkerHandle::spawn(),
             render_state: RenderState::new(),
-            render_pending: false, // Initial geometry is already evaluated in AppState::new()
+            render_pending: true,
             native_menu,
             recent_files,
         }


### PR DESCRIPTION
## Summary
- Set `render_pending` to `true` on app initialization so the render worker evaluates the node network on the first frame
- Previously the viewer was blank on startup because no render was dispatched until a user interaction triggered `check_for_changes()`
- Fix applied to both constructors in `app.rs`

## Test plan
- [x] Run `cargo run` — the rect should be visible immediately without any interaction
- [x] Run `cargo test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)