### PR TITLE
Fix for deleting rendered node

### DIFF
--- a/crates/nodebox-gui/src/network_view.rs
+++ b/crates/nodebox-gui/src/network_view.rs
@@ -450,6 +450,10 @@ impl NetworkView {
                 library.root.children.retain(|n| &n.name != name);
                 // Remove connections involving this node
                 library.root.connections.retain(|c| &c.output_node != name && &c.input_node != name);
+                // If the deleted node was the rendered node, clear the rendered child
+                if library.root.rendered_child.as_deref() == Some(name.as_str()) {
+                    library.root.rendered_child = None;
+                }
             }
             self.selected.clear();
         }


### PR DESCRIPTION
Deleting a node that was rendered before still tried to render the removed node. This now sets the rendered node to None. 