### PR TITLE
Add textpath node with font selector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3016,6 +3016,7 @@ version = "0.1.0"
 dependencies = [
  "arboard",
  "directories",
+ "font-kit",
  "log",
  "rfd",
  "tempfile",

--- a/crates/nodebox-gui/src/eval.rs
+++ b/crates/nodebox-gui/src/eval.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 use nodebox_core::geometry::{Path, Point, Color, Contour, PathPoint, PointType};
+use nodebox_core::geometry::font;
 use nodebox_core::node::{Node, NodeLibrary, EvalError};
 use nodebox_core::node::PortRange;
 use nodebox_core::Value;
@@ -979,6 +980,15 @@ fn execute_node(
             let degrees = get_float(inputs, "degrees", 90.0);
             let arc_type = get_string(inputs, "type", "pie");
             let path = nodebox_ops::arc(position, width, height, start_angle, degrees, &arc_type);
+            Ok(NodeOutput::Path(path))
+        }
+        "corevector.textpath" => {
+            let text = get_string(inputs, "text", "hello");
+            let font_name = get_string(inputs, "font_name", "Verdana");
+            let font_size = get_float(inputs, "font_size", 24.0);
+            let position = get_point(inputs, "position", Point::ZERO);
+            let path = font::text_to_path(&text, &font_name, font_size, position)
+                .map_err(|e| EvalError::ProcessingError(e.to_string()))?;
             Ok(NodeOutput::Path(path))
         }
 

--- a/crates/nodebox-gui/src/node_library.rs
+++ b/crates/nodebox-gui/src/node_library.rs
@@ -67,6 +67,12 @@ pub const NODE_TEMPLATES: &[NodeTemplate] = &[
         category: "geometry",
         description: "Create a grid of points",
     },
+    NodeTemplate {
+        name: "textpath",
+        prototype: "corevector.textpath",
+        category: "geometry",
+        description: "Convert text to a vector path",
+    },
     // Transform nodes
     NodeTemplate {
         name: "translate",
@@ -517,6 +523,20 @@ pub fn create_node_from_template(template: &NodeTemplate, library: &NodeLibrary,
                 ]))
                 .with_input(Port::point("offset", Point::new(10.0, 10.0)))
                 .with_input(Port::int("seed", 0));
+        }
+        "textpath" => {
+            node = node
+                .with_input(Port::string("text", "hello"))
+                .with_input(Port::string("font_name", "Verdana").with_widget(Widget::Font))
+                .with_input(Port::float("font_size", 24.0))
+                .with_input(Port::menu("align", "CENTER", vec![
+                    MenuItem::new("LEFT", "Left"),
+                    MenuItem::new("CENTER", "Center"),
+                    MenuItem::new("RIGHT", "Right"),
+                    MenuItem::new("JUSTIFY", "Justify"),
+                ]))
+                .with_input(Port::point("position", Point::ZERO))
+                .with_input(Port::float("width", 0.0));
         }
         "import_svg" => {
             node = node

--- a/crates/nodebox-gui/src/panels.rs
+++ b/crates/nodebox-gui/src/panels.rs
@@ -440,6 +440,24 @@ impl ParameterPanel {
                     }
                 }
             }
+            Widget::Font => {
+                if let Value::String(ref mut value) = port.value {
+                    let style = ui.style_mut();
+                    style.override_font_id = Some(egui::FontId::proportional(theme::FONT_SIZE_SMALL));
+
+                    let combo_id = ui.make_persistent_id((&port_key.0, &port_key.1));
+                    egui::ComboBox::from_id_salt(combo_id)
+                        .selected_text(value.as_str())
+                        .width(120.0)
+                        .show_ui(ui, |ui| {
+                            for family in io_port.list_fonts() {
+                                if ui.selectable_label(*value == family, &family).clicked() {
+                                    *value = family;
+                                }
+                            }
+                        });
+                }
+            }
             _ => {
                 // For geometry and other non-editable types, show type info (non-selectable)
                 let type_str = match port.port_type {

--- a/crates/nodebox-port/Cargo.toml
+++ b/crates/nodebox-port/Cargo.toml
@@ -34,5 +34,9 @@ version = "2"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.directories]
 version = "5"
 
+# Font enumeration (desktop only)
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies.font-kit]
+workspace = true
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/nodebox-port/src/desktop.rs
+++ b/crates/nodebox-port/src/desktop.rs
@@ -496,6 +496,13 @@ impl Port for DesktopPort {
             ))
         }
     }
+
+    fn list_fonts(&self) -> Vec<String> {
+        let source = font_kit::source::SystemSource::new();
+        let mut families = source.all_families().unwrap_or_default();
+        families.sort();
+        families
+    }
 }
 
 #[cfg(test)]

--- a/crates/nodebox-port/src/lib.rs
+++ b/crates/nodebox-port/src/lib.rs
@@ -771,6 +771,9 @@ pub trait Port: Send + Sync {
     ///
     /// * `Err(PortError::Unsupported)` - No config directory on this platform
     fn get_config_dir(&self) -> Result<PathBuf, PortError>;
+
+    /// List available font families on the system.
+    fn list_fonts(&self) -> Vec<String>;
 }
 
 /// A minimal Port implementation for testing.
@@ -920,6 +923,10 @@ impl Port for TestPort {
 
     fn get_config_dir(&self) -> Result<PathBuf, PortError> {
         Err(PortError::Unsupported)
+    }
+
+    fn list_fonts(&self) -> Vec<String> {
+        Vec::new()
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `textpath` node that converts text to vector paths using `font::text_to_path`
- Add `list_fonts()` method to the `Port` trait, implemented in `DesktopPort` via `font-kit` `SystemSource`
- Render `Widget::Font` as a combo box in the parameter panel, populated with system fonts

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes
- [ ] Open the app, create a `textpath` node, verify font dropdown shows system fonts
- [ ] Select a font, verify text renders with the chosen font

🤖 Generated with [Claude Code](https://claude.com/claude-code)