### PR TITLE
Add Colors variant to NodeOutput for list-matched color nodes

### DIFF
--- a/crates/nodebox-gui/src/eval.rs
+++ b/crates/nodebox-gui/src/eval.rs
@@ -70,6 +70,8 @@ pub enum NodeOutput {
     Strings(Vec<String>),
     /// A color value.
     Color(Color),
+    /// A list of color values.
+    Colors(Vec<Color>),
     /// A boolean value.
     Boolean(bool),
     /// A list of boolean values.
@@ -148,6 +150,7 @@ impl NodeOutput {
             NodeOutput::Boolean(b) => vec![format!("{}", b)],
             NodeOutput::Booleans(bs) => bs.iter().map(|b| format!("{}", b)).collect(),
             NodeOutput::Color(c) => vec![c.to_hex()],
+            NodeOutput::Colors(cs) => cs.iter().map(|c| c.to_hex()).collect(),
             NodeOutput::Point(p) => vec![format!("{:.2}, {:.2}", p.x, p.y)],
             NodeOutput::Points(pts) => pts.iter().map(|p| format!("{:.2}, {:.2}", p.x, p.y)).collect(),
             NodeOutput::Path(_) => vec!["[Path]".to_string()],
@@ -163,7 +166,7 @@ impl NodeOutput {
             NodeOutput::Int(_) | NodeOutput::Ints(_) => "int",
             NodeOutput::String(_) | NodeOutput::Strings(_) => "string",
             NodeOutput::Boolean(_) | NodeOutput::Booleans(_) => "boolean",
-            NodeOutput::Color(_) => "color",
+            NodeOutput::Color(_) | NodeOutput::Colors(_) => "color",
             NodeOutput::Point(_) | NodeOutput::Points(_) => "point",
             NodeOutput::Path(_) | NodeOutput::Paths(_) => "path",
         }
@@ -179,19 +182,21 @@ impl NodeOutput {
             NodeOutput::Ints(is) => is.len(),
             NodeOutput::Strings(ss) => ss.len(),
             NodeOutput::Booleans(bs) => bs.len(),
+            NodeOutput::Colors(cs) => cs.len(),
             _ => 1,
         }
     }
 
     /// Returns true if this output is a color type.
     pub fn is_color(&self) -> bool {
-        matches!(self, NodeOutput::Color(_))
+        matches!(self, NodeOutput::Color(_) | NodeOutput::Colors(_))
     }
 
     /// Returns the color at the given index, if this is a color output.
-    pub fn color_at(&self, _index: usize) -> Option<Color> {
+    pub fn color_at(&self, index: usize) -> Option<Color> {
         match self {
             NodeOutput::Color(c) => Some(*c),
+            NodeOutput::Colors(cs) => cs.get(index).copied(),
             _ => None,
         }
     }
@@ -208,6 +213,7 @@ impl NodeOutput {
             NodeOutput::Ints(is) => is.iter().map(|i| NodeOutput::Int(*i)).collect(),
             NodeOutput::Strings(ss) => ss.iter().map(|s| NodeOutput::String(s.clone())).collect(),
             NodeOutput::Booleans(bs) => bs.iter().map(|b| NodeOutput::Boolean(*b)).collect(),
+            NodeOutput::Colors(cs) => cs.iter().map(|c| NodeOutput::Color(*c)).collect(),
             v => vec![v.clone()], // Single values remain single
         }
     }
@@ -221,6 +227,7 @@ impl NodeOutput {
             NodeOutput::Ints(is) => is.len(),
             NodeOutput::Strings(ss) => ss.len(),
             NodeOutput::Booleans(bs) => bs.len(),
+            NodeOutput::Colors(cs) => cs.len(),
             NodeOutput::None => 0,
             _ => 1,
         }
@@ -510,6 +517,13 @@ fn collect_results(results: Vec<NodeOutput>) -> NodeOutput {
                 _ => None,
             }).collect();
             NodeOutput::Points(points)
+        }
+        Some(NodeOutput::Color(_)) => {
+            let colors: Vec<Color> = results.into_iter().filter_map(|r| match r {
+                NodeOutput::Color(c) => Some(c),
+                _ => None,
+            }).collect();
+            NodeOutput::Colors(colors)
         }
         _ => {
             // Default: collect as Paths (geometry operations)
@@ -3219,5 +3233,91 @@ mod tests {
 
         assert!(!paths.is_empty(), "Generator should produce output with defaults");
         assert!(errors.is_empty(), "Generator should not produce errors");
+    }
+
+    #[test]
+    fn test_collect_results_colors() {
+        let results = vec![
+            NodeOutput::Color(Color::rgb(1.0, 0.0, 0.0)),
+            NodeOutput::Color(Color::rgb(0.0, 1.0, 0.0)),
+            NodeOutput::Color(Color::rgb(0.0, 0.0, 1.0)),
+        ];
+        let collected = collect_results(results);
+        match &collected {
+            NodeOutput::Colors(cs) => {
+                assert_eq!(cs.len(), 3);
+                assert!((cs[0].r - 1.0).abs() < 0.01);
+                assert!((cs[1].g - 1.0).abs() < 0.01);
+                assert!((cs[2].b - 1.0).abs() < 0.01);
+            }
+            other => panic!("Expected Colors, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_sample_to_rgb_color_produces_colors() {
+        let mut library = NodeLibrary::new("test");
+        library.root = Node::network("root")
+            .with_child(
+                Node::new("sample1")
+                    .with_prototype("math.sample")
+                    .with_input(NodePort::int("amount", 3))
+                    .with_input(NodePort::float("start", 0.0))
+                    .with_input(NodePort::float("end", 255.0))
+                    .with_output_range(PortRange::List)
+            )
+            .with_child(
+                Node::new("rgb_color1")
+                    .with_prototype("color.rgb_color")
+                    .with_input(NodePort::float("red", 0.0))
+                    .with_input(NodePort::float("green", 0.0))
+                    .with_input(NodePort::float("blue", 0.0))
+                    .with_input(NodePort::float("alpha", 255.0))
+                    .with_input(NodePort::float("range", 255.0))
+                    .with_output_type(nodebox_core::node::PortType::Color)
+            )
+            .with_connection(Connection::new("sample1", "rgb_color1", "red"))
+            .with_rendered_child("rgb_color1");
+
+        let (port, ctx) = test_port_and_context();
+        let (_paths, output, errors) = evaluate_network(&library, &port, &ctx);
+        assert!(errors.is_empty(), "Should not produce errors: {:?}", errors);
+        match &output {
+            NodeOutput::Colors(cs) => {
+                assert_eq!(cs.len(), 3, "Should produce 3 colors");
+            }
+            other => panic!("Expected Colors, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_colors_item_count() {
+        let output = NodeOutput::Colors(vec![
+            Color::rgb(1.0, 0.0, 0.0),
+            Color::rgb(0.0, 1.0, 0.0),
+        ]);
+        assert_eq!(output.item_count(), 2);
+    }
+
+    #[test]
+    fn test_colors_is_color() {
+        let output = NodeOutput::Colors(vec![Color::rgb(1.0, 0.0, 0.0)]);
+        assert!(output.is_color());
+    }
+
+    #[test]
+    fn test_colors_color_at() {
+        let output = NodeOutput::Colors(vec![
+            Color::rgb(1.0, 0.0, 0.0),
+            Color::rgb(0.0, 1.0, 0.0),
+            Color::rgb(0.0, 0.0, 1.0),
+        ]);
+        let c0 = output.color_at(0).unwrap();
+        assert!((c0.r - 1.0).abs() < 0.01);
+        let c1 = output.color_at(1).unwrap();
+        assert!((c1.g - 1.0).abs() < 0.01);
+        let c2 = output.color_at(2).unwrap();
+        assert!((c2.b - 1.0).abs() < 0.01);
+        assert!(output.color_at(3).is_none());
     }
 }

--- a/crates/nodebox-gui/src/node_library.rs
+++ b/crates/nodebox-gui/src/node_library.rs
@@ -637,7 +637,8 @@ pub fn create_node_from_template(template: &NodeTemplate, library: &NodeLibrary,
                 .with_input(Port::float("green", 0.0))
                 .with_input(Port::float("blue", 0.0))
                 .with_input(Port::float("alpha", 255.0))
-                .with_input(Port::float("range", 255.0));
+                .with_input(Port::float("range", 255.0))
+                .with_output_type(PortType::Color);
         }
         "hsb_color" => {
             node = node
@@ -645,13 +646,15 @@ pub fn create_node_from_template(template: &NodeTemplate, library: &NodeLibrary,
                 .with_input(Port::float("saturation", 0.0))
                 .with_input(Port::float("brightness", 0.0))
                 .with_input(Port::float("alpha", 255.0))
-                .with_input(Port::float("range", 255.0));
+                .with_input(Port::float("range", 255.0))
+                .with_output_type(PortType::Color);
         }
         "gray_color" => {
             node = node
                 .with_input(Port::float("gray", 0.0))
                 .with_input(Port::float("alpha", 255.0))
-                .with_input(Port::float("range", 255.0));
+                .with_input(Port::float("range", 255.0))
+                .with_output_type(PortType::Color);
         }
         // Core nodes
         "frame" => {


### PR DESCRIPTION
## Summary
- Add missing `Colors(Vec<Color>)` variant to `NodeOutput` enum, matching the pattern of other plural variants (`Floats`, `Ints`, `Strings`, `Points`, `Booleans`)
- Update `collect_results()` to collect multiple `Color` outputs into `Colors`, fixing list-matched color nodes (e.g. `sample` → `rgb_color`) which previously produced `NodeOutput::None`
- Update all `NodeOutput` methods (`to_display_strings`, `type_label`, `item_count`, `is_color`, `color_at`, `to_value_list`, `list_len`) to handle the new variant
- Add `with_output_type(PortType::Color)` to `rgb_color`, `hsb_color`, and `gray_color` node templates so the evaluator correctly identifies their output type

## Test plan
- [x] `cargo test` — all 43 eval tests pass, including 5 new tests
- [ ] Run the app, create `sample` → `rgb_color` (connect to `red` port), double-click `rgb_color` — Data tab should show color swatches
- [ ] Repeat with `hsb_color` and `gray_color`
- [ ] Standalone color node (no list input) should still show a single color swatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)