### PR TITLE
Keep viewer tab when rendered node is deleted

### DIFF
--- a/crates/nodebox-gui/src/viewer_pane.rs
+++ b/crates/nodebox-gui/src/viewer_pane.rs
@@ -359,11 +359,19 @@ impl ViewerPane {
     /// Pass `render_state` for GPU-accelerated rendering when available.
     /// When `gpu-rendering` feature is disabled, pass `None`.
     pub fn show(&mut self, ui: &mut egui::Ui, state: &AppState, render_state: Option<&RenderState>) -> HandleResult {
-        // Auto-switch tab based on whether the rendered node outputs geometry
+        // Auto-switch tab based on whether the rendered node outputs geometry.
+        // When there's no rendered node at all, keep the current tab as-is
+        // so the user stays in Viewer mode (showing an empty canvas) if that
+        // was their preferred mode.
+        let has_rendered = state.library.root.rendered_child.is_some();
         let is_geometry = state.library.is_rendered_output_geometry();
         let was_available = self.visual_tab_available;
 
-        if is_geometry && !was_available {
+        if !has_rendered {
+            // No rendered node: keep current tab, but mark visual as available
+            // so the Viewer tab remains selectable (shows empty canvas).
+            self.visual_tab_available = true;
+        } else if is_geometry && !was_available {
             // Switching back to geometry: restore preferred tab
             self.visual_tab_available = true;
             self.current_tab = self.preferred_geometry_tab;


### PR DESCRIPTION
## Summary
- When deleting the rendered node, the viewer pane now stays on the current tab instead of forcing a switch to the Data tab
- If the user was in Viewer mode, they stay in Viewer mode (showing an empty canvas)
- If the user was in Data mode, they stay in Data mode
- The Visual tab remains selectable when there's no rendered node

## Test plan
- [ ] Create a geometry node (e.g. rect), render it, stay in Viewer tab, delete it — should stay in Viewer mode showing empty canvas
- [ ] Create a geometry node, render it, switch to Data tab, delete it — should stay in Data mode
- [ ] Create a non-geometry node, render it (forces Data), delete it — should stay in Data mode
- [ ] After deleting rendered node from Viewer mode, verify Visual tab is still clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)