### PR TITLE
Improve parameter panel input field design

### DIFF
--- a/crates/nodebox-gui/src/panels.rs
+++ b/crates/nodebox-gui/src/panels.rs
@@ -193,12 +193,12 @@ impl ParameterPanel {
         match port.widget {
             Widget::Float | Widget::Angle => {
                 if let Value::Float(ref mut value) = port.value {
-                    self.show_drag_value_float(ui, value, port.min, port.max, 1.0, &port_key, is_editing);
+                    self.show_drag_value_float(ui, value, port.min, port.max, 1.0, &port_key, is_editing, theme::PADDING);
                 }
             }
             Widget::Int => {
                 if let Value::Int(ref mut value) = port.value {
-                    self.show_drag_value_int(ui, value, &port_key, is_editing);
+                    self.show_drag_value_int(ui, value, &port_key, is_editing, theme::PADDING);
                 }
             }
             Widget::Toggle => {
@@ -326,15 +326,15 @@ impl ParameterPanel {
                     let is_editing_y = self.editing.as_ref()
                         .map(|(n, p, _, _)| n == &key_y.0 && p == &key_y.1)
                         .unwrap_or(false);
-                    let available = ui.available_width();
+                    let available = ui.available_width() - theme::PADDING;
                     let old_spacing = ui.spacing().item_spacing.x;
-                    ui.spacing_mut().item_spacing.x = 8.0;
-                    let field_width = (available - 8.0) / 2.0;
+                    ui.spacing_mut().item_spacing.x = 16.0;
+                    let field_width = (available - 16.0) / 2.0;
                     ui.allocate_ui(egui::Vec2::new(field_width, theme::PARAMETER_ROW_HEIGHT), |ui| {
-                        self.show_drag_value_float(ui, &mut point.x, None, None, 1.0, &key_x, is_editing_x);
+                        self.show_drag_value_float(ui, &mut point.x, None, None, 1.0, &key_x, is_editing_x, 0.0);
                     });
                     ui.allocate_ui(egui::Vec2::new(field_width, theme::PARAMETER_ROW_HEIGHT), |ui| {
-                        self.show_drag_value_float(ui, &mut point.y, None, None, 1.0, &key_y, is_editing_y);
+                        self.show_drag_value_float(ui, &mut point.y, None, None, 1.0, &key_y, is_editing_y, 0.0);
                     });
                     ui.spacing_mut().item_spacing.x = old_spacing;
                 }
@@ -469,6 +469,7 @@ impl ParameterPanel {
     }
 
     /// Show a minimal drag value for floats - non-selectable, draggable, click to edit.
+    /// `right_padding` is extra space to reserve on the right (e.g. PADDING for panel edge margin, 0.0 for Point widget fields).
     fn show_drag_value_float(
         &mut self,
         ui: &mut egui::Ui,
@@ -478,6 +479,7 @@ impl ParameterPanel {
         speed: f64,
         port_key: &(String, String),
         is_editing: bool,
+        right_padding: f32,
     ) {
         if is_editing {
             // Show text input for direct editing
@@ -494,7 +496,7 @@ impl ParameterPanel {
             let output = egui::TextEdit::singleline(&mut edit_text)
                 .font(egui::FontId::proportional(theme::FONT_SIZE_SMALL))
                 .text_color(egui::Color32::WHITE)
-                .desired_width(ui.available_width() - 2.0 * theme::PADDING)
+                .desired_width(ui.available_width() - theme::PADDING - right_padding)
                 .margin(egui::Margin::symmetric(4, 0))
                 .frame(false)
                 .show(ui);
@@ -558,7 +560,7 @@ impl ParameterPanel {
                 .interactive(false)
                 .frame(false)
                 .margin(egui::Margin::symmetric(4, 0))
-                .desired_width(ui.available_width() - 2.0 * theme::PADDING)
+                .desired_width(ui.available_width() - theme::PADDING - right_padding)
                 .show(ui);
 
             // Overlay click+drag sensing on the same rect
@@ -608,7 +610,7 @@ impl ParameterPanel {
     }
 
     /// Show a minimal drag value for ints - non-selectable, draggable, click to edit.
-    fn show_drag_value_int(&mut self, ui: &mut egui::Ui, value: &mut i64, port_key: &(String, String), is_editing: bool) {
+    fn show_drag_value_int(&mut self, ui: &mut egui::Ui, value: &mut i64, port_key: &(String, String), is_editing: bool, right_padding: f32) {
         if is_editing {
             // Show text input for direct editing
             let (mut edit_text, needs_select) = self.editing.as_ref()
@@ -624,7 +626,7 @@ impl ParameterPanel {
             let output = egui::TextEdit::singleline(&mut edit_text)
                 .font(egui::FontId::proportional(theme::FONT_SIZE_SMALL))
                 .text_color(egui::Color32::WHITE)
-                .desired_width(ui.available_width() - 2.0 * theme::PADDING)
+                .desired_width(ui.available_width() - theme::PADDING - right_padding)
                 .margin(egui::Margin::symmetric(4, 0))
                 .frame(false)
                 .show(ui);
@@ -679,7 +681,7 @@ impl ParameterPanel {
                 .interactive(false)
                 .frame(false)
                 .margin(egui::Margin::symmetric(4, 0))
-                .desired_width(ui.available_width() - 2.0 * theme::PADDING)
+                .desired_width(ui.available_width() - theme::PADDING - right_padding)
                 .show(ui);
 
             // Overlay click+drag sensing on the same rect
@@ -839,7 +841,7 @@ impl ParameterPanel {
             let is_editing = self.editing.as_ref()
                 .map(|(n, p, _, _)| n == &key.0 && p == &key.1)
                 .unwrap_or(false);
-            self.show_drag_value_float(ui, &mut width, Some(1.0), None, 1.0, &key, is_editing);
+            self.show_drag_value_float(ui, &mut width, Some(1.0), None, 1.0, &key, is_editing, theme::PADDING);
 
             // Update the property if changed
             if (state.library.width() - width).abs() > 0.001 {
@@ -877,7 +879,7 @@ impl ParameterPanel {
             let is_editing = self.editing.as_ref()
                 .map(|(n, p, _, _)| n == &key.0 && p == &key.1)
                 .unwrap_or(false);
-            self.show_drag_value_float(ui, &mut height, Some(1.0), None, 1.0, &key, is_editing);
+            self.show_drag_value_float(ui, &mut height, Some(1.0), None, 1.0, &key, is_editing, theme::PADDING);
 
             // Update the property if changed
             if (state.library.height() - height).abs() > 0.001 {

--- a/crates/nodebox-gui/src/panels.rs
+++ b/crates/nodebox-gui/src/panels.rs
@@ -100,6 +100,8 @@ impl ParameterPanel {
                             theme::PORT_VALUE_BACKGROUND,
                         );
 
+                        ui.add_space(theme::PADDING);
+
                         for node_port in &mut node.inputs {
                             let is_connected = connected_ports.contains(&node_port.name);
                             self.show_port_row(
@@ -324,9 +326,17 @@ impl ParameterPanel {
                     let is_editing_y = self.editing.as_ref()
                         .map(|(n, p, _, _)| n == &key_y.0 && p == &key_y.1)
                         .unwrap_or(false);
-                    self.show_drag_value_float(ui, &mut point.x, None, None, 1.0, &key_x, is_editing_x);
-                    ui.add_space(4.0);
-                    self.show_drag_value_float(ui, &mut point.y, None, None, 1.0, &key_y, is_editing_y);
+                    let available = ui.available_width() - theme::PADDING;
+                    let old_spacing = ui.spacing().item_spacing.x;
+                    ui.spacing_mut().item_spacing.x = 16.0;
+                    let field_width = (available - 16.0) / 2.0;
+                    ui.allocate_ui(egui::Vec2::new(field_width, theme::PARAMETER_ROW_HEIGHT), |ui| {
+                        self.show_drag_value_float(ui, &mut point.x, None, None, 1.0, &key_x, is_editing_x);
+                    });
+                    ui.allocate_ui(egui::Vec2::new(field_width, theme::PARAMETER_ROW_HEIGHT), |ui| {
+                        self.show_drag_value_float(ui, &mut point.y, None, None, 1.0, &key_y, is_editing_y);
+                    });
+                    ui.spacing_mut().item_spacing.x = old_spacing;
                 }
             }
             Widget::Menu => {
@@ -475,12 +485,29 @@ impl ParameterPanel {
                 .map(|(_, _, t, sel)| (t.clone(), *sel))
                 .unwrap_or_else(|| (format!("{:.2}", value), true));
 
+            // Style: no border, darker background, rounded corners, readable selection
+            let old_selection = ui.visuals().selection.clone();
+            let old_corner_radius = ui.visuals().widgets.active.corner_radius;
+            ui.visuals_mut().selection.stroke = egui::Stroke::new(0.0, egui::Color32::WHITE);
+            ui.visuals_mut().selection.bg_fill = theme::TEXT_EDIT_SELECTION_BG;
+            let rounding = egui::CornerRadius::same(theme::CORNER_RADIUS_SMALL as u8);
+            ui.visuals_mut().widgets.inactive.corner_radius = rounding;
+            ui.visuals_mut().widgets.active.corner_radius = rounding;
+            ui.visuals_mut().widgets.hovered.corner_radius = rounding;
+
             let output = egui::TextEdit::singleline(&mut edit_text)
-                .font(TextStyle::Body)
-                .text_color(theme::VALUE_TEXT)
-                .desired_width(60.0)
+                .font(egui::FontId::proportional(theme::FONT_SIZE_SMALL))
+                .text_color(egui::Color32::WHITE)
+                .desired_width(ui.available_width() - 2.0 * theme::PADDING)
+                .margin(egui::Margin { left: 4, top: 5, right: 4, bottom: 3 })
+                .background_color(theme::SLATE_800)
                 .frame(true)
                 .show(ui);
+
+            ui.visuals_mut().selection = old_selection;
+            ui.visuals_mut().widgets.inactive.corner_radius = old_corner_radius;
+            ui.visuals_mut().widgets.active.corner_radius = old_corner_radius;
+            ui.visuals_mut().widgets.hovered.corner_radius = old_corner_radius;
 
             // Select all on first frame
             if needs_select {
@@ -522,21 +549,22 @@ impl ParameterPanel {
 
             output.response.request_focus();
         } else {
-            // Show as draggable text (non-selectable)
+            // Show as draggable text (non-selectable) — fill available width for easy clicking
             let text = format!("{:.2}", value);
             let galley = ui.painter().layout_no_wrap(
                 text.clone(),
                 egui::FontId::proportional(11.0),
-                theme::VALUE_TEXT,
+                egui::Color32::WHITE,
             );
             let rect = ui.available_rect_before_wrap();
-            let text_rect = egui::Rect::from_min_size(
-                egui::pos2(rect.left(), rect.center().y - galley.size().y / 2.0),
-                galley.size(),
+            let interact_rect = egui::Rect::from_min_size(
+                rect.min,
+                egui::vec2(ui.available_width() - theme::PADDING, rect.height()),
             );
 
-            let response = ui.allocate_rect(text_rect, Sense::click_and_drag());
-            ui.painter().galley(text_rect.min, galley, theme::VALUE_TEXT);
+            let response = ui.allocate_rect(interact_rect, Sense::click_and_drag());
+            let text_pos = egui::pos2(rect.left() + 4.0, rect.center().y - galley.size().y / 2.0);
+            ui.painter().galley(text_pos, galley, egui::Color32::WHITE);
 
             if response.dragged() {
                 // Modifier keys: Shift = x10, Alt = /100
@@ -578,12 +606,29 @@ impl ParameterPanel {
                 .map(|(_, _, t, sel)| (t.clone(), *sel))
                 .unwrap_or_else(|| (format!("{}", value), true));
 
+            // Style: no border, darker background, rounded corners, readable selection
+            let old_selection = ui.visuals().selection.clone();
+            let old_corner_radius = ui.visuals().widgets.active.corner_radius;
+            ui.visuals_mut().selection.stroke = egui::Stroke::new(0.0, egui::Color32::WHITE);
+            ui.visuals_mut().selection.bg_fill = theme::TEXT_EDIT_SELECTION_BG;
+            let rounding = egui::CornerRadius::same(theme::CORNER_RADIUS_SMALL as u8);
+            ui.visuals_mut().widgets.inactive.corner_radius = rounding;
+            ui.visuals_mut().widgets.active.corner_radius = rounding;
+            ui.visuals_mut().widgets.hovered.corner_radius = rounding;
+
             let output = egui::TextEdit::singleline(&mut edit_text)
-                .font(TextStyle::Body)
-                .text_color(theme::VALUE_TEXT)
-                .desired_width(60.0)
+                .font(egui::FontId::proportional(theme::FONT_SIZE_SMALL))
+                .text_color(egui::Color32::WHITE)
+                .desired_width(ui.available_width() - 2.0 * theme::PADDING)
+                .margin(egui::Margin { left: 4, top: 5, right: 4, bottom: 3 })
+                .background_color(theme::SLATE_800)
                 .frame(true)
                 .show(ui);
+
+            ui.visuals_mut().selection = old_selection;
+            ui.visuals_mut().widgets.inactive.corner_radius = old_corner_radius;
+            ui.visuals_mut().widgets.active.corner_radius = old_corner_radius;
+            ui.visuals_mut().widgets.hovered.corner_radius = old_corner_radius;
 
             // Select all on first frame
             if needs_select {
@@ -620,16 +665,17 @@ impl ParameterPanel {
             let galley = ui.painter().layout_no_wrap(
                 text.clone(),
                 egui::FontId::proportional(11.0),
-                theme::VALUE_TEXT,
+                egui::Color32::WHITE,
             );
             let rect = ui.available_rect_before_wrap();
-            let text_rect = egui::Rect::from_min_size(
-                egui::pos2(rect.left(), rect.center().y - galley.size().y / 2.0),
-                galley.size(),
+            let interact_rect = egui::Rect::from_min_size(
+                rect.min,
+                egui::vec2(ui.available_width() - theme::PADDING, rect.height()),
             );
 
-            let response = ui.allocate_rect(text_rect, Sense::click_and_drag());
-            ui.painter().galley(text_rect.min, galley, theme::VALUE_TEXT);
+            let response = ui.allocate_rect(interact_rect, Sense::click_and_drag());
+            let text_pos = egui::pos2(rect.left() + 4.0, rect.center().y - galley.size().y / 2.0);
+            ui.painter().galley(text_pos, galley, egui::Color32::WHITE);
 
             if response.dragged() {
                 // Modifier keys: Shift = x10, Alt = /100
@@ -741,6 +787,8 @@ impl ParameterPanel {
             0.0,
             theme::PORT_VALUE_BACKGROUND,
         );
+
+        ui.add_space(theme::PADDING);
 
         // Width
         ui.horizontal(|ui| {

--- a/crates/nodebox-gui/src/panels.rs
+++ b/crates/nodebox-gui/src/panels.rs
@@ -326,7 +326,7 @@ impl ParameterPanel {
                     let is_editing_y = self.editing.as_ref()
                         .map(|(n, p, _, _)| n == &key_y.0 && p == &key_y.1)
                         .unwrap_or(false);
-                    let available = ui.available_width() - theme::PADDING;
+                    let available = ui.available_width();
                     let old_spacing = ui.spacing().item_spacing.x;
                     ui.spacing_mut().item_spacing.x = 16.0;
                     let field_width = (available - 16.0) / 2.0;
@@ -494,7 +494,7 @@ impl ParameterPanel {
             let output = egui::TextEdit::singleline(&mut edit_text)
                 .font(egui::FontId::proportional(theme::FONT_SIZE_SMALL))
                 .text_color(egui::Color32::WHITE)
-                .desired_width(ui.available_width() - theme::PADDING)
+                .desired_width(ui.available_width() - 2.0 * theme::PADDING)
                 .margin(egui::Margin::symmetric(4, 0))
                 .frame(false)
                 .show(ui);
@@ -551,18 +551,29 @@ impl ParameterPanel {
         } else {
             // Non-interactive TextEdit for pixel-perfect alignment with editing state
             let mut display_text = format!("{:.2}", value);
+            let bg_idx = ui.painter().add(egui::Shape::Noop);
             let te_output = egui::TextEdit::singleline(&mut display_text)
                 .font(egui::FontId::proportional(theme::FONT_SIZE_SMALL))
                 .text_color(egui::Color32::WHITE)
                 .interactive(false)
                 .frame(false)
                 .margin(egui::Margin::symmetric(4, 0))
-                .desired_width(ui.available_width() - theme::PADDING)
+                .desired_width(ui.available_width() - 2.0 * theme::PADDING)
                 .show(ui);
 
             // Overlay click+drag sensing on the same rect
             let interact_id = ui.id().with(port_key);
             let response = ui.interact(te_output.response.rect, interact_id, Sense::click_and_drag());
+
+            // Hover effect: subtle darkened background
+            if response.hovered() || response.dragged() {
+                let hover_rect = te_output.response.rect.expand2(egui::vec2(0.0, 4.0));
+                ui.painter().set(bg_idx, egui::Shape::rect_filled(
+                    hover_rect,
+                    egui::CornerRadius::same(theme::CORNER_RADIUS_SMALL as u8),
+                    theme::FIELD_HOVER_BG,
+                ));
+            }
 
             if response.dragged() {
                 // Modifier keys: Shift = x10, Alt = /100
@@ -613,7 +624,7 @@ impl ParameterPanel {
             let output = egui::TextEdit::singleline(&mut edit_text)
                 .font(egui::FontId::proportional(theme::FONT_SIZE_SMALL))
                 .text_color(egui::Color32::WHITE)
-                .desired_width(ui.available_width() - theme::PADDING)
+                .desired_width(ui.available_width() - 2.0 * theme::PADDING)
                 .margin(egui::Margin::symmetric(4, 0))
                 .frame(false)
                 .show(ui);
@@ -661,18 +672,29 @@ impl ParameterPanel {
         } else {
             // Non-interactive TextEdit for pixel-perfect alignment with editing state
             let mut display_text = format!("{}", value);
+            let bg_idx = ui.painter().add(egui::Shape::Noop);
             let te_output = egui::TextEdit::singleline(&mut display_text)
                 .font(egui::FontId::proportional(theme::FONT_SIZE_SMALL))
                 .text_color(egui::Color32::WHITE)
                 .interactive(false)
                 .frame(false)
                 .margin(egui::Margin::symmetric(4, 0))
-                .desired_width(ui.available_width() - theme::PADDING)
+                .desired_width(ui.available_width() - 2.0 * theme::PADDING)
                 .show(ui);
 
             // Overlay click+drag sensing on the same rect
             let interact_id = ui.id().with(port_key);
             let response = ui.interact(te_output.response.rect, interact_id, Sense::click_and_drag());
+
+            // Hover effect: subtle darkened background
+            if response.hovered() || response.dragged() {
+                let hover_rect = te_output.response.rect.expand2(egui::vec2(0.0, 4.0));
+                ui.painter().set(bg_idx, egui::Shape::rect_filled(
+                    hover_rect,
+                    egui::CornerRadius::same(theme::CORNER_RADIUS_SMALL as u8),
+                    theme::FIELD_HOVER_BG,
+                ));
+            }
 
             if response.dragged() {
                 // Modifier keys: Shift = x10, Alt = /100

--- a/crates/nodebox-gui/src/panels.rs
+++ b/crates/nodebox-gui/src/panels.rs
@@ -328,8 +328,8 @@ impl ParameterPanel {
                         .unwrap_or(false);
                     let available = ui.available_width();
                     let old_spacing = ui.spacing().item_spacing.x;
-                    ui.spacing_mut().item_spacing.x = 16.0;
-                    let field_width = (available - 16.0) / 2.0;
+                    ui.spacing_mut().item_spacing.x = 8.0;
+                    let field_width = (available - 8.0) / 2.0;
                     ui.allocate_ui(egui::Vec2::new(field_width, theme::PARAMETER_ROW_HEIGHT), |ui| {
                         self.show_drag_value_float(ui, &mut point.x, None, None, 1.0, &key_x, is_editing_x);
                     });

--- a/crates/nodebox-gui/src/panels.rs
+++ b/crates/nodebox-gui/src/panels.rs
@@ -485,29 +485,29 @@ impl ParameterPanel {
                 .map(|(_, _, t, sel)| (t.clone(), *sel))
                 .unwrap_or_else(|| (format!("{:.2}", value), true));
 
-            // Style: no border, darker background, rounded corners, readable selection
+            // Frameless TextEdit with manual background for pixel-perfect alignment
             let old_selection = ui.visuals().selection.clone();
-            let old_corner_radius = ui.visuals().widgets.active.corner_radius;
             ui.visuals_mut().selection.stroke = egui::Stroke::new(0.0, egui::Color32::WHITE);
             ui.visuals_mut().selection.bg_fill = theme::TEXT_EDIT_SELECTION_BG;
-            let rounding = egui::CornerRadius::same(theme::CORNER_RADIUS_SMALL as u8);
-            ui.visuals_mut().widgets.inactive.corner_radius = rounding;
-            ui.visuals_mut().widgets.active.corner_radius = rounding;
-            ui.visuals_mut().widgets.hovered.corner_radius = rounding;
 
+            let bg_idx = ui.painter().add(egui::Shape::Noop);
             let output = egui::TextEdit::singleline(&mut edit_text)
                 .font(egui::FontId::proportional(theme::FONT_SIZE_SMALL))
                 .text_color(egui::Color32::WHITE)
-                .desired_width(ui.available_width() - 2.0 * theme::PADDING)
-                .margin(egui::Margin { left: 4, top: 5, right: 4, bottom: 3 })
-                .background_color(theme::SLATE_800)
-                .frame(true)
+                .desired_width(ui.available_width() - theme::PADDING)
+                .margin(egui::Margin::symmetric(4, 0))
+                .frame(false)
                 .show(ui);
 
+            // Paint rounded background behind the text
+            let bg_rect = output.response.rect.expand2(egui::vec2(0.0, 4.0));
+            ui.painter().set(bg_idx, egui::Shape::rect_filled(
+                bg_rect,
+                egui::CornerRadius::same(theme::CORNER_RADIUS_SMALL as u8),
+                theme::SLATE_800,
+            ));
+
             ui.visuals_mut().selection = old_selection;
-            ui.visuals_mut().widgets.inactive.corner_radius = old_corner_radius;
-            ui.visuals_mut().widgets.active.corner_radius = old_corner_radius;
-            ui.visuals_mut().widgets.hovered.corner_radius = old_corner_radius;
 
             // Select all on first frame
             if needs_select {
@@ -549,22 +549,20 @@ impl ParameterPanel {
 
             output.response.request_focus();
         } else {
-            // Show as draggable text (non-selectable) — fill available width for easy clicking
-            let text = format!("{:.2}", value);
-            let galley = ui.painter().layout_no_wrap(
-                text.clone(),
-                egui::FontId::proportional(11.0),
-                egui::Color32::WHITE,
-            );
-            let rect = ui.available_rect_before_wrap();
-            let interact_rect = egui::Rect::from_min_size(
-                rect.min,
-                egui::vec2(ui.available_width() - theme::PADDING, rect.height()),
-            );
+            // Non-interactive TextEdit for pixel-perfect alignment with editing state
+            let mut display_text = format!("{:.2}", value);
+            let te_output = egui::TextEdit::singleline(&mut display_text)
+                .font(egui::FontId::proportional(theme::FONT_SIZE_SMALL))
+                .text_color(egui::Color32::WHITE)
+                .interactive(false)
+                .frame(false)
+                .margin(egui::Margin::symmetric(4, 0))
+                .desired_width(ui.available_width() - theme::PADDING)
+                .show(ui);
 
-            let response = ui.allocate_rect(interact_rect, Sense::click_and_drag());
-            let text_pos = egui::pos2(rect.left() + 4.0, rect.center().y - galley.size().y / 2.0);
-            ui.painter().galley(text_pos, galley, egui::Color32::WHITE);
+            // Overlay click+drag sensing on the same rect
+            let interact_id = ui.id().with(port_key);
+            let response = ui.interact(te_output.response.rect, interact_id, Sense::click_and_drag());
 
             if response.dragged() {
                 // Modifier keys: Shift = x10, Alt = /100
@@ -606,29 +604,29 @@ impl ParameterPanel {
                 .map(|(_, _, t, sel)| (t.clone(), *sel))
                 .unwrap_or_else(|| (format!("{}", value), true));
 
-            // Style: no border, darker background, rounded corners, readable selection
+            // Frameless TextEdit with manual background for pixel-perfect alignment
             let old_selection = ui.visuals().selection.clone();
-            let old_corner_radius = ui.visuals().widgets.active.corner_radius;
             ui.visuals_mut().selection.stroke = egui::Stroke::new(0.0, egui::Color32::WHITE);
             ui.visuals_mut().selection.bg_fill = theme::TEXT_EDIT_SELECTION_BG;
-            let rounding = egui::CornerRadius::same(theme::CORNER_RADIUS_SMALL as u8);
-            ui.visuals_mut().widgets.inactive.corner_radius = rounding;
-            ui.visuals_mut().widgets.active.corner_radius = rounding;
-            ui.visuals_mut().widgets.hovered.corner_radius = rounding;
 
+            let bg_idx = ui.painter().add(egui::Shape::Noop);
             let output = egui::TextEdit::singleline(&mut edit_text)
                 .font(egui::FontId::proportional(theme::FONT_SIZE_SMALL))
                 .text_color(egui::Color32::WHITE)
-                .desired_width(ui.available_width() - 2.0 * theme::PADDING)
-                .margin(egui::Margin { left: 4, top: 5, right: 4, bottom: 3 })
-                .background_color(theme::SLATE_800)
-                .frame(true)
+                .desired_width(ui.available_width() - theme::PADDING)
+                .margin(egui::Margin::symmetric(4, 0))
+                .frame(false)
                 .show(ui);
 
+            // Paint rounded background behind the text
+            let bg_rect = output.response.rect.expand2(egui::vec2(0.0, 4.0));
+            ui.painter().set(bg_idx, egui::Shape::rect_filled(
+                bg_rect,
+                egui::CornerRadius::same(theme::CORNER_RADIUS_SMALL as u8),
+                theme::SLATE_800,
+            ));
+
             ui.visuals_mut().selection = old_selection;
-            ui.visuals_mut().widgets.inactive.corner_radius = old_corner_radius;
-            ui.visuals_mut().widgets.active.corner_radius = old_corner_radius;
-            ui.visuals_mut().widgets.hovered.corner_radius = old_corner_radius;
 
             // Select all on first frame
             if needs_select {
@@ -661,21 +659,20 @@ impl ParameterPanel {
 
             output.response.request_focus();
         } else {
-            let text = format!("{}", value);
-            let galley = ui.painter().layout_no_wrap(
-                text.clone(),
-                egui::FontId::proportional(11.0),
-                egui::Color32::WHITE,
-            );
-            let rect = ui.available_rect_before_wrap();
-            let interact_rect = egui::Rect::from_min_size(
-                rect.min,
-                egui::vec2(ui.available_width() - theme::PADDING, rect.height()),
-            );
+            // Non-interactive TextEdit for pixel-perfect alignment with editing state
+            let mut display_text = format!("{}", value);
+            let te_output = egui::TextEdit::singleline(&mut display_text)
+                .font(egui::FontId::proportional(theme::FONT_SIZE_SMALL))
+                .text_color(egui::Color32::WHITE)
+                .interactive(false)
+                .frame(false)
+                .margin(egui::Margin::symmetric(4, 0))
+                .desired_width(ui.available_width() - theme::PADDING)
+                .show(ui);
 
-            let response = ui.allocate_rect(interact_rect, Sense::click_and_drag());
-            let text_pos = egui::pos2(rect.left() + 4.0, rect.center().y - galley.size().y / 2.0);
-            ui.painter().galley(text_pos, galley, egui::Color32::WHITE);
+            // Overlay click+drag sensing on the same rect
+            let interact_id = ui.id().with(port_key);
+            let response = ui.interact(te_output.response.rect, interact_id, Sense::click_and_drag());
 
             if response.dragged() {
                 // Modifier keys: Shift = x10, Alt = /100

--- a/crates/nodebox-gui/src/theme.rs
+++ b/crates/nodebox-gui/src/theme.rs
@@ -116,6 +116,8 @@ pub const TEXT_EDIT_BG: Color32 = SLATE_700;
 pub const HOVER_BG: Color32 = SLATE_600;
 /// Selection background (visible violet with good text contrast)
 pub const SELECTION_BG: Color32 = VIOLET_800;
+/// Text edit selection highlight (blue, readable with white text)
+pub const TEXT_EDIT_SELECTION_BG: Color32 = Color32::from_rgb(37, 99, 175);
 
 // =============================================================================
 // SEMANTIC COLORS - Text

--- a/crates/nodebox-gui/src/theme.rs
+++ b/crates/nodebox-gui/src/theme.rs
@@ -118,6 +118,8 @@ pub const HOVER_BG: Color32 = SLATE_600;
 pub const SELECTION_BG: Color32 = VIOLET_800;
 /// Text edit selection highlight (blue, readable with white text)
 pub const TEXT_EDIT_SELECTION_BG: Color32 = Color32::from_rgb(37, 99, 175);
+/// Field hover background (SLATE_800 at ~50% opacity over SLATE_700)
+pub const FIELD_HOVER_BG: Color32 = Color32::from_rgb(39, 53, 75);
 
 // =============================================================================
 // SEMANTIC COLORS - Text


### PR DESCRIPTION
## Summary
- Number fields (float/int) now fill available width for easier clicking and dragging
- Point widget fields share space equally with 16px gap between them
- White text color for value fields (was violet)
- Edit fields styled with SLATE_800 background, 4px rounded corners, no border
- Blue selection highlight for readable selected text in edit mode
- Text perfectly aligned between editing and non-editing states (no shift)
- Consistent 4px text inset and 8px right margin
- 8px top spacing before first parameter row (both node params and document properties)

## Test plan
- [ ] Select a node with number parameters — verify fields fill the value column width
- [ ] Click a number field to edit — verify text doesn't shift horizontally or vertically
- [ ] Select text in edit field — verify white text is readable on blue selection highlight
- [ ] Check a Point parameter (e.g. position) — verify two fields share space with 16px gap
- [ ] Verify the panel doesn't auto-grow when a Point parameter is visible
- [ ] Check Document properties (no node selected) — verify 8px top spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)