### PR TITLE
Switch theme from Tailwind Slate to Zinc color palette

### DIFF
--- a/crates/nodebox-gui/src/address_bar.rs
+++ b/crates/nodebox-gui/src/address_bar.rs
@@ -148,13 +148,13 @@ impl AddressBar {
         // Determine button color based on rendering state
         let button_color = if !self.is_rendering {
             // Not rendering: subtle (disabled appearance)
-            theme::SLATE_700
+            theme::ZINC_700
         } else if self.render_elapsed_secs < STOP_BUTTON_HIGHLIGHT_THRESHOLD_SECS {
             // Rendering but less than threshold: subtle
-            theme::SLATE_700
+            theme::ZINC_700
         } else {
             // Rendering and past threshold: prominent
-            theme::SLATE_300
+            theme::ZINC_300
         };
 
         // Draw the stop button (circle with square inside)

--- a/crates/nodebox-gui/src/animation_bar.rs
+++ b/crates/nodebox-gui/src/animation_bar.rs
@@ -293,36 +293,36 @@ impl AnimationBar {
     }
 
     /// Styled DragValue that follows the style guide.
-    /// Uses SLATE_800 for subtle elevation against SLATE_900 bar background.
+    /// Uses ZINC_800 for subtle elevation against ZINC_900 bar background.
     fn styled_drag_value(ui: &mut egui::Ui, value: &mut i32, range: std::ops::RangeInclusive<i32>, width: f32) -> egui::Response {
         // Override visuals and spacing for this widget
         let old_visuals = ui.visuals().clone();
         let old_spacing = ui.spacing().clone();
 
         // All states: no borders, sharp corners, appropriate fill
-        ui.visuals_mut().widgets.inactive.bg_fill = theme::SLATE_800;
-        ui.visuals_mut().widgets.inactive.weak_bg_fill = theme::SLATE_800;
+        ui.visuals_mut().widgets.inactive.bg_fill = theme::ZINC_800;
+        ui.visuals_mut().widgets.inactive.weak_bg_fill = theme::ZINC_800;
         ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::NONE;
         ui.visuals_mut().widgets.inactive.fg_stroke = egui::Stroke::new(1.0, theme::TEXT_DEFAULT);
         ui.visuals_mut().widgets.inactive.corner_radius = egui::CornerRadius::ZERO;
         ui.visuals_mut().widgets.inactive.expansion = 0.0;
 
-        ui.visuals_mut().widgets.hovered.bg_fill = theme::SLATE_700;
-        ui.visuals_mut().widgets.hovered.weak_bg_fill = theme::SLATE_700;
+        ui.visuals_mut().widgets.hovered.bg_fill = theme::ZINC_700;
+        ui.visuals_mut().widgets.hovered.weak_bg_fill = theme::ZINC_700;
         ui.visuals_mut().widgets.hovered.bg_stroke = egui::Stroke::NONE;
         ui.visuals_mut().widgets.hovered.fg_stroke = egui::Stroke::new(1.0, theme::TEXT_STRONG);
         ui.visuals_mut().widgets.hovered.corner_radius = egui::CornerRadius::ZERO;
         ui.visuals_mut().widgets.hovered.expansion = 0.0;
 
-        ui.visuals_mut().widgets.active.bg_fill = theme::SLATE_700;
-        ui.visuals_mut().widgets.active.weak_bg_fill = theme::SLATE_700;
+        ui.visuals_mut().widgets.active.bg_fill = theme::ZINC_700;
+        ui.visuals_mut().widgets.active.weak_bg_fill = theme::ZINC_700;
         ui.visuals_mut().widgets.active.bg_stroke = egui::Stroke::NONE;
         ui.visuals_mut().widgets.active.fg_stroke = egui::Stroke::new(1.0, theme::TEXT_STRONG);
         ui.visuals_mut().widgets.active.corner_radius = egui::CornerRadius::ZERO;
         ui.visuals_mut().widgets.active.expansion = 0.0;
 
-        ui.visuals_mut().widgets.noninteractive.bg_fill = theme::SLATE_800;
-        ui.visuals_mut().widgets.noninteractive.weak_bg_fill = theme::SLATE_800;
+        ui.visuals_mut().widgets.noninteractive.bg_fill = theme::ZINC_800;
+        ui.visuals_mut().widgets.noninteractive.weak_bg_fill = theme::ZINC_800;
         ui.visuals_mut().widgets.noninteractive.bg_stroke = egui::Stroke::NONE;
         ui.visuals_mut().widgets.noninteractive.corner_radius = egui::CornerRadius::ZERO;
         ui.visuals_mut().widgets.noninteractive.expansion = 0.0;
@@ -354,23 +354,23 @@ impl AnimationBar {
         // Override visuals for this widget
         let old_visuals = ui.visuals().clone();
 
-        ui.visuals_mut().widgets.inactive.bg_fill = theme::SLATE_800;
-        ui.visuals_mut().widgets.inactive.weak_bg_fill = theme::SLATE_800;
+        ui.visuals_mut().widgets.inactive.bg_fill = theme::ZINC_800;
+        ui.visuals_mut().widgets.inactive.weak_bg_fill = theme::ZINC_800;
         ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::NONE;
         ui.visuals_mut().widgets.inactive.corner_radius = egui::CornerRadius::ZERO;
 
-        ui.visuals_mut().widgets.hovered.bg_fill = theme::SLATE_700;
-        ui.visuals_mut().widgets.hovered.weak_bg_fill = theme::SLATE_700;
+        ui.visuals_mut().widgets.hovered.bg_fill = theme::ZINC_700;
+        ui.visuals_mut().widgets.hovered.weak_bg_fill = theme::ZINC_700;
         ui.visuals_mut().widgets.hovered.bg_stroke = egui::Stroke::NONE;
         ui.visuals_mut().widgets.hovered.corner_radius = egui::CornerRadius::ZERO;
 
-        ui.visuals_mut().widgets.active.bg_fill = theme::SLATE_700;
-        ui.visuals_mut().widgets.active.weak_bg_fill = theme::SLATE_700;
+        ui.visuals_mut().widgets.active.bg_fill = theme::ZINC_700;
+        ui.visuals_mut().widgets.active.weak_bg_fill = theme::ZINC_700;
         ui.visuals_mut().widgets.active.bg_stroke = egui::Stroke::NONE;
         ui.visuals_mut().widgets.active.corner_radius = egui::CornerRadius::ZERO;
 
-        ui.visuals_mut().widgets.noninteractive.bg_fill = theme::SLATE_800;
-        ui.visuals_mut().widgets.noninteractive.weak_bg_fill = theme::SLATE_800;
+        ui.visuals_mut().widgets.noninteractive.bg_fill = theme::ZINC_800;
+        ui.visuals_mut().widgets.noninteractive.weak_bg_fill = theme::ZINC_800;
         ui.visuals_mut().widgets.noninteractive.bg_stroke = egui::Stroke::NONE;
         ui.visuals_mut().widgets.noninteractive.corner_radius = egui::CornerRadius::ZERO;
 
@@ -391,7 +391,7 @@ impl AnimationBar {
         if ui.is_rect_visible(rect) {
             // Transparent background, lighter on hover
             let bg_color = if response.hovered() {
-                theme::SLATE_800
+                theme::ZINC_800
             } else {
                 egui::Color32::TRANSPARENT
             };

--- a/crates/nodebox-gui/src/components.rs
+++ b/crates/nodebox-gui/src/components.rs
@@ -45,7 +45,7 @@ pub fn draw_pane_header_with_title(
             egui::pos2(aligned_rect.left(), aligned_rect.top() + 0.5),
             egui::pos2(aligned_rect.right(), aligned_rect.top() + 0.5),
         ],
-        egui::Stroke::new(1.0, theme::SLATE_700),
+        egui::Stroke::new(1.0, theme::ZINC_700),
     );
 
     // Title on left (UPPERCASE)
@@ -78,7 +78,7 @@ pub fn draw_pane_header_with_title(
             egui::pos2(aligned_rect.left(), aligned_rect.bottom() - 0.5),
             egui::pos2(aligned_rect.right(), aligned_rect.bottom() - 0.5),
         ],
-        egui::Stroke::new(1.0, theme::SLATE_950),
+        egui::Stroke::new(1.0, theme::ZINC_950),
     );
 
     // Return header rect and x position after separator (8px margin)
@@ -287,7 +287,7 @@ pub fn header_segmented_control(
         ui.painter().rect_filled(
             selected_rect,
             0.0,
-            theme::SLATE_700,
+            theme::ZINC_700,
         );
     }
 
@@ -374,29 +374,29 @@ pub fn header_zoom_control(
     let old_spacing = ui.spacing().clone();
 
     // All states: no borders, sharp corners, appropriate fill
-    ui.visuals_mut().widgets.inactive.bg_fill = theme::SLATE_800;
-    ui.visuals_mut().widgets.inactive.weak_bg_fill = theme::SLATE_800;
+    ui.visuals_mut().widgets.inactive.bg_fill = theme::ZINC_800;
+    ui.visuals_mut().widgets.inactive.weak_bg_fill = theme::ZINC_800;
     ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::NONE;
     ui.visuals_mut().widgets.inactive.fg_stroke = egui::Stroke::new(1.0, theme::TEXT_DEFAULT);
     ui.visuals_mut().widgets.inactive.corner_radius = egui::CornerRadius::ZERO;
     ui.visuals_mut().widgets.inactive.expansion = 0.0;
 
-    ui.visuals_mut().widgets.hovered.bg_fill = theme::SLATE_700;
-    ui.visuals_mut().widgets.hovered.weak_bg_fill = theme::SLATE_700;
+    ui.visuals_mut().widgets.hovered.bg_fill = theme::ZINC_700;
+    ui.visuals_mut().widgets.hovered.weak_bg_fill = theme::ZINC_700;
     ui.visuals_mut().widgets.hovered.bg_stroke = egui::Stroke::NONE;
     ui.visuals_mut().widgets.hovered.fg_stroke = egui::Stroke::new(1.0, theme::TEXT_STRONG);
     ui.visuals_mut().widgets.hovered.corner_radius = egui::CornerRadius::ZERO;
     ui.visuals_mut().widgets.hovered.expansion = 0.0;
 
-    ui.visuals_mut().widgets.active.bg_fill = theme::SLATE_700;
-    ui.visuals_mut().widgets.active.weak_bg_fill = theme::SLATE_700;
+    ui.visuals_mut().widgets.active.bg_fill = theme::ZINC_700;
+    ui.visuals_mut().widgets.active.weak_bg_fill = theme::ZINC_700;
     ui.visuals_mut().widgets.active.bg_stroke = egui::Stroke::NONE;
     ui.visuals_mut().widgets.active.fg_stroke = egui::Stroke::new(1.0, theme::TEXT_STRONG);
     ui.visuals_mut().widgets.active.corner_radius = egui::CornerRadius::ZERO;
     ui.visuals_mut().widgets.active.expansion = 0.0;
 
-    ui.visuals_mut().widgets.noninteractive.bg_fill = theme::SLATE_800;
-    ui.visuals_mut().widgets.noninteractive.weak_bg_fill = theme::SLATE_800;
+    ui.visuals_mut().widgets.noninteractive.bg_fill = theme::ZINC_800;
+    ui.visuals_mut().widgets.noninteractive.weak_bg_fill = theme::ZINC_800;
     ui.visuals_mut().widgets.noninteractive.bg_stroke = egui::Stroke::NONE;
     ui.visuals_mut().widgets.noninteractive.corner_radius = egui::CornerRadius::ZERO;
     ui.visuals_mut().widgets.noninteractive.expansion = 0.0;
@@ -462,7 +462,7 @@ pub fn header_icon_button(
         ui.painter().rect_filled(
             button_rect,
             0.0,
-            theme::SLATE_700,
+            theme::ZINC_700,
         );
     }
 

--- a/crates/nodebox-gui/src/theme.rs
+++ b/crates/nodebox-gui/src/theme.rs
@@ -1,7 +1,7 @@
-//! Centralized theme constants based on Tailwind's Slate color palette.
+//! Centralized theme constants based on Tailwind's Zinc color palette.
 //!
 //! Design principles:
-//! - Cool blue-gray tones from Tailwind's Slate palette
+//! - Neutral gray tones from Tailwind's Zinc palette
 //! - Purple/violet accent color for selections and highlights
 //! - Sharp corners (0px) for a modern, precise feel
 //! - Minimal borders - use background color differentiation instead
@@ -14,56 +14,56 @@
 use eframe::egui::{self, Color32, CornerRadius, FontId, Stroke, Style, Visuals};
 
 // =============================================================================
-// SLATE SCALE (Tailwind v4 Slate Palette)
+// ZINC SCALE (Tailwind v4 Zinc Palette)
 // =============================================================================
-// Cool blue-gray tones with good contrast
+// Neutral gray tones with good contrast
 
-/// Lightest - near white with cool tint
-pub const SLATE_50: Color32 = Color32::from_rgb(248, 250, 252);
+/// Lightest - near white
+pub const ZINC_50: Color32 = Color32::from_rgb(250, 250, 250);
 /// Very light
-pub const SLATE_100: Color32 = Color32::from_rgb(241, 245, 249);
+pub const ZINC_100: Color32 = Color32::from_rgb(244, 244, 245);
 /// Light
-pub const SLATE_200: Color32 = Color32::from_rgb(226, 232, 240);
+pub const ZINC_200: Color32 = Color32::from_rgb(228, 228, 231);
 /// Light-medium
-pub const SLATE_300: Color32 = Color32::from_rgb(202, 213, 226);
+pub const ZINC_300: Color32 = Color32::from_rgb(212, 212, 216);
 /// Medium - good for muted text
-pub const SLATE_400: Color32 = Color32::from_rgb(144, 161, 185);
+pub const ZINC_400: Color32 = Color32::from_rgb(161, 161, 170);
 /// Medium-dark - node fills, secondary elements
-pub const SLATE_500: Color32 = Color32::from_rgb(98, 116, 142);
+pub const ZINC_500: Color32 = Color32::from_rgb(113, 113, 122);
 /// Dark - node fills, interactive elements
-pub const SLATE_600: Color32 = Color32::from_rgb(69, 85, 108);
+pub const ZINC_600: Color32 = Color32::from_rgb(82, 82, 91);
 /// Darker - elevated surfaces
-pub const SLATE_700: Color32 = Color32::from_rgb(49, 65, 88);
+pub const ZINC_700: Color32 = Color32::from_rgb(63, 63, 70);
 /// Very dark - panel backgrounds
-pub const SLATE_800: Color32 = Color32::from_rgb(29, 41, 61);
+pub const ZINC_800: Color32 = Color32::from_rgb(39, 39, 42);
 /// Near black - main backgrounds
-pub const SLATE_900: Color32 = Color32::from_rgb(15, 23, 43);
+pub const ZINC_900: Color32 = Color32::from_rgb(24, 24, 27);
 /// Deepest - true dark background
-pub const SLATE_950: Color32 = Color32::from_rgb(2, 6, 24);
+pub const ZINC_950: Color32 = Color32::from_rgb(9, 9, 11);
 
 // =============================================================================
-// LEGACY GRAY ALIASES (map to Slate for backward compatibility)
+// LEGACY GRAY ALIASES (map to Zinc for backward compatibility)
 // =============================================================================
 
 pub const GRAY_0: Color32 = Color32::from_rgb(0, 0, 0);
-pub const GRAY_50: Color32 = SLATE_950;
-pub const GRAY_100: Color32 = SLATE_900;
-pub const GRAY_150: Color32 = SLATE_800;
-pub const GRAY_200: Color32 = SLATE_700;
-pub const GRAY_250: Color32 = SLATE_600;
-pub const GRAY_300: Color32 = SLATE_600;
-pub const GRAY_350: Color32 = SLATE_500;
-pub const GRAY_400: Color32 = SLATE_500;
-pub const GRAY_500: Color32 = SLATE_400;
-pub const GRAY_600: Color32 = SLATE_300;
-pub const GRAY_700: Color32 = SLATE_200;
-pub const GRAY_800: Color32 = SLATE_100;
-pub const GRAY_900: Color32 = SLATE_50;
+pub const GRAY_50: Color32 = ZINC_950;
+pub const GRAY_100: Color32 = ZINC_900;
+pub const GRAY_150: Color32 = ZINC_800;
+pub const GRAY_200: Color32 = ZINC_700;
+pub const GRAY_250: Color32 = ZINC_600;
+pub const GRAY_300: Color32 = ZINC_600;
+pub const GRAY_350: Color32 = ZINC_500;
+pub const GRAY_400: Color32 = ZINC_500;
+pub const GRAY_500: Color32 = ZINC_400;
+pub const GRAY_600: Color32 = ZINC_300;
+pub const GRAY_700: Color32 = ZINC_200;
+pub const GRAY_800: Color32 = ZINC_100;
+pub const GRAY_900: Color32 = ZINC_50;
 pub const GRAY_1000: Color32 = Color32::from_rgb(255, 255, 255);
 
-pub const GRAY_325: Color32 = SLATE_500;
-pub const GRAY_550: Color32 = SLATE_400;
-pub const GRAY_775: Color32 = SLATE_100;
+pub const GRAY_325: Color32 = ZINC_500;
+pub const GRAY_550: Color32 = ZINC_400;
+pub const GRAY_775: Color32 = ZINC_100;
 
 // =============================================================================
 // ACCENT COLORS (Purple/Violet - Linear-inspired)
@@ -91,7 +91,7 @@ pub const BLUE_500: Color32 = VIOLET_400;
 
 pub const SUCCESS_GREEN: Color32 = Color32::from_rgb(34, 197, 94);
 pub const WARNING_YELLOW: Color32 = Color32::from_rgb(234, 179, 8);
-pub const ERROR_RED: Color32 = Color32::from_rgb(255, 100, 103);  // #ff6467
+pub const ERROR_RED: Color32 = Color32::from_rgb(255, 100, 103); // #ff6467
 
 // Legacy alias
 pub const WARNING_ORANGE: Color32 = WARNING_YELLOW;
@@ -101,19 +101,19 @@ pub const WARNING_ORANGE: Color32 = WARNING_YELLOW;
 // =============================================================================
 
 /// Main panel background (dark)
-pub const PANEL_BG: Color32 = SLATE_900;
+pub const PANEL_BG: Color32 = ZINC_900;
 /// Top bar / title bar background
-pub const TOP_BAR_BG: Color32 = SLATE_900;
+pub const TOP_BAR_BG: Color32 = ZINC_900;
 /// Tab bar background
-pub const TAB_BAR_BG: Color32 = SLATE_800;
+pub const TAB_BAR_BG: Color32 = ZINC_800;
 /// Bottom bar / footer background
-pub const BOTTOM_BAR_BG: Color32 = SLATE_900;
+pub const BOTTOM_BAR_BG: Color32 = ZINC_900;
 /// Elevated surface (cards, dialogs, popups)
-pub const SURFACE_ELEVATED: Color32 = SLATE_700;
+pub const SURFACE_ELEVATED: Color32 = ZINC_700;
 /// Text edit / input field background
-pub const TEXT_EDIT_BG: Color32 = SLATE_700;
+pub const TEXT_EDIT_BG: Color32 = ZINC_700;
 /// Hover state background
-pub const HOVER_BG: Color32 = SLATE_600;
+pub const HOVER_BG: Color32 = ZINC_600;
 /// Selection background (visible violet with good text contrast)
 pub const SELECTION_BG: Color32 = VIOLET_800;
 
@@ -122,30 +122,30 @@ pub const SELECTION_BG: Color32 = VIOLET_800;
 // =============================================================================
 
 /// Strong/active text (brightest)
-pub const TEXT_STRONG: Color32 = SLATE_50;
+pub const TEXT_STRONG: Color32 = ZINC_50;
 /// Default body text
-pub const TEXT_DEFAULT: Color32 = SLATE_200;
+pub const TEXT_DEFAULT: Color32 = ZINC_200;
 /// Secondary/muted text
-pub const TEXT_SUBDUED: Color32 = SLATE_400;
+pub const TEXT_SUBDUED: Color32 = ZINC_400;
 /// Disabled/non-interactive text
-pub const TEXT_DISABLED: Color32 = SLATE_500;
+pub const TEXT_DISABLED: Color32 = ZINC_500;
 
 // =============================================================================
 // SEMANTIC COLORS - Widgets & Borders
 // =============================================================================
 
 /// Widget inactive background
-pub const WIDGET_INACTIVE_BG: Color32 = SLATE_700;
+pub const WIDGET_INACTIVE_BG: Color32 = ZINC_700;
 /// Widget hovered background
-pub const WIDGET_HOVERED_BG: Color32 = SLATE_600;
+pub const WIDGET_HOVERED_BG: Color32 = ZINC_600;
 /// Widget active/pressed background
-pub const WIDGET_ACTIVE_BG: Color32 = SLATE_400;
+pub const WIDGET_ACTIVE_BG: Color32 = ZINC_400;
 /// Non-interactive widget background
-pub const WIDGET_NONINTERACTIVE_BG: Color32 = SLATE_800;
+pub const WIDGET_NONINTERACTIVE_BG: Color32 = ZINC_800;
 /// Border color (use sparingly - prefer no borders)
-pub const BORDER_COLOR: Color32 = SLATE_600;
+pub const BORDER_COLOR: Color32 = ZINC_600;
 /// Secondary border color
-pub const BORDER_SECONDARY: Color32 = SLATE_500;
+pub const BORDER_SECONDARY: Color32 = ZINC_500;
 
 // =============================================================================
 // LAYOUT CONSTANTS - Heights
@@ -175,26 +175,26 @@ pub const LABEL_WIDTH: f32 = 112.0;
 // =============================================================================
 
 /// Zebra stripe: even row background (matches panel bg)
-pub const TABLE_ROW_EVEN: Color32 = SLATE_900;
-/// Zebra stripe: odd row alternating background (between SLATE_900 and SLATE_800)
-pub const TABLE_ROW_ODD: Color32 = Color32::from_rgb(19, 29, 50);
+pub const TABLE_ROW_EVEN: Color32 = ZINC_900;
+/// Zebra stripe: odd row alternating background (between ZINC_900 and ZINC_800)
+pub const TABLE_ROW_ODD: Color32 = Color32::from_rgb(30, 30, 33);
 /// Table header background
-pub const TABLE_HEADER_BG: Color32 = SLATE_800;
+pub const TABLE_HEADER_BG: Color32 = ZINC_800;
 /// Table header text color
-pub const TABLE_HEADER_TEXT: Color32 = SLATE_300;
+pub const TABLE_HEADER_TEXT: Color32 = ZINC_300;
 /// Table cell text color
-pub const TABLE_CELL_TEXT: Color32 = SLATE_200;
+pub const TABLE_CELL_TEXT: Color32 = ZINC_200;
 /// Index column text color (subdued)
-pub const TABLE_INDEX_TEXT: Color32 = SLATE_400;
+pub const TABLE_INDEX_TEXT: Color32 = ZINC_400;
 
 // =============================================================================
 // PANE HEADER COLORS
 // =============================================================================
 
 /// Pane header background color (same as panel for seamless look)
-pub const PANE_HEADER_BACKGROUND_COLOR: Color32 = SLATE_800;
+pub const PANE_HEADER_BACKGROUND_COLOR: Color32 = ZINC_800;
 /// Pane header foreground/text color
-pub const PANE_HEADER_FOREGROUND_COLOR: Color32 = SLATE_300;
+pub const PANE_HEADER_FOREGROUND_COLOR: Color32 = ZINC_300;
 pub const PARAMETER_PANEL_WIDTH: f32 = 280.0;
 pub const PARAMETER_ROW_HEIGHT: f32 = ROW_HEIGHT;
 
@@ -260,34 +260,34 @@ pub const VALUE_TEXT: Color32 = VIOLET_400;
 pub const VALUE_TEXT_HOVER: Color32 = VIOLET_500;
 
 // Background colors
-pub const BACKGROUND_COLOR: Color32 = SLATE_800;
-pub const HEADER_BACKGROUND: Color32 = SLATE_800;
-pub const DARK_BACKGROUND: Color32 = SLATE_900;
+pub const BACKGROUND_COLOR: Color32 = ZINC_800;
+pub const HEADER_BACKGROUND: Color32 = ZINC_800;
+pub const DARK_BACKGROUND: Color32 = ZINC_900;
 
 // Text colors
 pub const TEXT_NORMAL: Color32 = TEXT_DEFAULT;
 pub const TEXT_BRIGHT: Color32 = TEXT_STRONG;
 
 // Port/parameter colors (labels on left are darker)
-pub const PORT_LABEL_BACKGROUND: Color32 = SLATE_800;
-pub const PORT_VALUE_BACKGROUND: Color32 = SLATE_700;
+pub const PORT_LABEL_BACKGROUND: Color32 = ZINC_800;
+pub const PORT_VALUE_BACKGROUND: Color32 = ZINC_700;
 
 // Tab colors
-pub const SELECTED_TAB_BACKGROUND: Color32 = SLATE_700;
-pub const UNSELECTED_TAB_BACKGROUND: Color32 = SLATE_800;
+pub const SELECTED_TAB_BACKGROUND: Color32 = ZINC_700;
+pub const UNSELECTED_TAB_BACKGROUND: Color32 = ZINC_800;
 
 // Address bar colors
-pub const ADDRESS_BAR_BACKGROUND: Color32 = SLATE_800;
-pub const ADDRESS_SEGMENT_HOVER: Color32 = SLATE_600;
-pub const ADDRESS_SEPARATOR_COLOR: Color32 = SLATE_500;
+pub const ADDRESS_BAR_BACKGROUND: Color32 = ZINC_800;
+pub const ADDRESS_SEGMENT_HOVER: Color32 = ZINC_600;
+pub const ADDRESS_SEPARATOR_COLOR: Color32 = ZINC_500;
 
 // Animation bar colors
-pub const ANIMATION_BAR_BACKGROUND: Color32 = SLATE_900;
+pub const ANIMATION_BAR_BACKGROUND: Color32 = ZINC_900;
 
 // Network view colors
-pub const NETWORK_BACKGROUND: Color32 = SLATE_900;
-/// Grid lines - subtle contrast against slate-900 background
-pub const NETWORK_GRID: Color32 = SLATE_800;
+pub const NETWORK_BACKGROUND: Color32 = ZINC_900;
+/// Grid lines - subtle contrast against zinc-900 background
+pub const NETWORK_GRID: Color32 = ZINC_800;
 
 // Network View - Tooltips
 pub const TOOLTIP_BG: Color32 = SURFACE_ELEVATED;
@@ -298,17 +298,17 @@ pub const CONNECTION_HOVER: Color32 = ERROR_RED; // Red indicates deletable
 pub const PORT_HOVER: Color32 = VIOLET_400; // Accent for interactive
 
 // Node body fill colors - muted tints based on output type
-// Base: SLATE_600 (69, 85, 108) - all variants stay dark and professional
-pub const NODE_BODY_GEOMETRY: Color32 = SLATE_600;                          // Standard slate
-pub const NODE_BODY_INT: Color32 = Color32::from_rgb(65, 78, 108);          // Subtle blue tint
-pub const NODE_BODY_FLOAT: Color32 = Color32::from_rgb(65, 78, 108);        // Subtle blue tint
-pub const NODE_BODY_STRING: Color32 = Color32::from_rgb(62, 88, 82);        // Subtle green tint
-pub const NODE_BODY_BOOLEAN: Color32 = Color32::from_rgb(90, 82, 65);       // Subtle amber tint
-pub const NODE_BODY_POINT: Color32 = Color32::from_rgb(58, 85, 95);         // Subtle cyan tint
-pub const NODE_BODY_COLOR: Color32 = Color32::from_rgb(85, 70, 90);         // Subtle pink tint
-pub const NODE_BODY_LIST: Color32 = Color32::from_rgb(58, 88, 88);          // Subtle teal tint
-pub const NODE_BODY_DATA: Color32 = Color32::from_rgb(92, 78, 62);          // Subtle orange tint
-pub const NODE_BODY_DEFAULT: Color32 = SLATE_600;                           // Fallback
+// Base: ZINC_600 (82, 82, 91) - all variants stay dark and professional
+pub const NODE_BODY_GEOMETRY: Color32 = ZINC_600;
+pub const NODE_BODY_INT: Color32 = Color32::from_rgb(65, 78, 108); // Subtle blue tint
+pub const NODE_BODY_FLOAT: Color32 = Color32::from_rgb(65, 78, 108); // Subtle blue tint
+pub const NODE_BODY_STRING: Color32 = Color32::from_rgb(62, 88, 82); // Subtle green tint
+pub const NODE_BODY_BOOLEAN: Color32 = Color32::from_rgb(90, 82, 65); // Subtle amber tint
+pub const NODE_BODY_POINT: Color32 = Color32::from_rgb(58, 85, 95); // Subtle cyan tint
+pub const NODE_BODY_COLOR: Color32 = Color32::from_rgb(85, 70, 90); // Subtle pink tint
+pub const NODE_BODY_LIST: Color32 = Color32::from_rgb(58, 88, 88); // Subtle teal tint
+pub const NODE_BODY_DATA: Color32 = Color32::from_rgb(92, 78, 62); // Subtle orange tint
+pub const NODE_BODY_DEFAULT: Color32 = ZINC_600;
 
 // Node Category Colors (for node icons/identity)
 pub const CATEGORY_GEOMETRY: Color32 = Color32::from_rgb(80, 120, 200);
@@ -318,16 +318,16 @@ pub const CATEGORY_MATH: Color32 = Color32::from_rgb(120, 200, 80);
 pub const CATEGORY_LIST: Color32 = Color32::from_rgb(200, 200, 80);
 pub const CATEGORY_STRING: Color32 = Color32::from_rgb(180, 80, 200);
 pub const CATEGORY_DATA: Color32 = Color32::from_rgb(80, 200, 200);
-pub const CATEGORY_DEFAULT: Color32 = SLATE_500;
+pub const CATEGORY_DEFAULT: Color32 = ZINC_500;
 
 // Handle Colors (violet-based to match accent)
 pub const HANDLE_PRIMARY: Color32 = VIOLET_500;
 
 // Canvas/Viewer grid (uses alpha, so defined as function)
 pub fn viewer_grid() -> Color32 {
-    Color32::from_rgba_unmultiplied(144, 161, 185, 40) // slate-400 with alpha
+    Color32::from_rgba_unmultiplied(161, 161, 170, 40) // zinc-400 with alpha
 }
-pub const VIEWER_CROSSHAIR: Color32 = SLATE_400;
+pub const VIEWER_CROSSHAIR: Color32 = ZINC_400;
 
 // Point Type Visualization
 pub const POINT_LINE_TO: Color32 = Color32::from_rgb(100, 200, 100);
@@ -335,31 +335,31 @@ pub const POINT_CURVE_TO: Color32 = Color32::from_rgb(200, 100, 100);
 pub const POINT_CURVE_DATA: Color32 = Color32::from_rgb(100, 100, 200);
 
 // Timeline
-pub const TIMELINE_BG: Color32 = SLATE_800;
-pub const TIMELINE_MARKER: Color32 = SLATE_600;
+pub const TIMELINE_BG: Color32 = ZINC_800;
+pub const TIMELINE_MARKER: Color32 = ZINC_600;
 pub const TIMELINE_PLAYHEAD: Color32 = ERROR_RED;
 
 // Port type colors (semantic colors for data types)
-pub const PORT_COLOR_INT: Color32 = Color32::from_rgb(99, 102, 241);    // Indigo
-pub const PORT_COLOR_FLOAT: Color32 = Color32::from_rgb(99, 102, 241);  // Indigo
+pub const PORT_COLOR_INT: Color32 = Color32::from_rgb(99, 102, 241); // Indigo
+pub const PORT_COLOR_FLOAT: Color32 = Color32::from_rgb(99, 102, 241); // Indigo
 pub const PORT_COLOR_STRING: Color32 = Color32::from_rgb(34, 197, 94); // Green
 pub const PORT_COLOR_BOOLEAN: Color32 = Color32::from_rgb(234, 179, 8); // Yellow
-pub const PORT_COLOR_POINT: Color32 = Color32::from_rgb(56, 189, 248);  // Sky blue
-pub const PORT_COLOR_COLOR: Color32 = Color32::from_rgb(236, 72, 153);  // Pink
-pub const PORT_COLOR_GEOMETRY: Color32 = SLATE_600; // Same as node body
-pub const PORT_COLOR_LIST: Color32 = Color32::from_rgb(20, 184, 166);   // Teal
-pub const PORT_COLOR_DATA: Color32 = Color32::from_rgb(249, 115, 22);   // Orange
+pub const PORT_COLOR_POINT: Color32 = Color32::from_rgb(56, 189, 248); // Sky blue
+pub const PORT_COLOR_COLOR: Color32 = Color32::from_rgb(236, 72, 153); // Pink
+pub const PORT_COLOR_GEOMETRY: Color32 = ZINC_600; // Same as node body
+pub const PORT_COLOR_LIST: Color32 = Color32::from_rgb(20, 184, 166); // Teal
+pub const PORT_COLOR_DATA: Color32 = Color32::from_rgb(249, 115, 22); // Orange
 
 // Node selection dialog colors
-pub const DIALOG_BACKGROUND: Color32 = SLATE_800;
-pub const DIALOG_BORDER: Color32 = SLATE_600;
+pub const DIALOG_BACKGROUND: Color32 = ZINC_800;
+pub const DIALOG_BORDER: Color32 = ZINC_600;
 pub const SELECTED_ITEM: Color32 = SELECTION_BG;
-pub const HOVERED_ITEM: Color32 = SLATE_700;
+pub const HOVERED_ITEM: Color32 = ZINC_700;
 
 // Button colors
-pub const BUTTON_NORMAL: Color32 = SLATE_600;
-pub const BUTTON_HOVER: Color32 = SLATE_500;
-pub const BUTTON_ACTIVE: Color32 = SLATE_400;
+pub const BUTTON_NORMAL: Color32 = ZINC_600;
+pub const BUTTON_HOVER: Color32 = ZINC_500;
+pub const BUTTON_ACTIVE: Color32 = ZINC_400;
 
 // =============================================================================
 // STYLE CONFIGURATION
@@ -371,10 +371,9 @@ pub fn configure_style(ctx: &egui::Context) {
     let mut visuals = Visuals::dark();
 
     // Text styles
-    style.text_styles.insert(
-        egui::TextStyle::Body,
-        FontId::proportional(FONT_SIZE_BASE),
-    );
+    style
+        .text_styles
+        .insert(egui::TextStyle::Body, FontId::proportional(FONT_SIZE_BASE));
     style.text_styles.insert(
         egui::TextStyle::Small,
         FontId::proportional(FONT_SIZE_SMALL),
@@ -406,7 +405,7 @@ pub fn configure_style(ctx: &egui::Context) {
 
     // Visuals - Window (sharp corners, subtle border)
     visuals.window_fill = SURFACE_ELEVATED;
-    visuals.window_stroke = Stroke::new(1.0, SLATE_600); // Very subtle border
+    visuals.window_stroke = Stroke::new(1.0, ZINC_600); // Very subtle border
     visuals.window_corner_radius = CornerRadius::ZERO; // Sharp 90° corners
     visuals.window_shadow = egui::Shadow::NONE;
 
@@ -416,39 +415,39 @@ pub fn configure_style(ctx: &egui::Context) {
 
     // Visuals - Panel (no borders, use background differentiation)
     visuals.panel_fill = PANEL_BG;
-    visuals.faint_bg_color = SLATE_800;
-    visuals.extreme_bg_color = SLATE_950;
+    visuals.faint_bg_color = ZINC_800;
+    visuals.extreme_bg_color = ZINC_950;
 
     // Visuals - Widgets (sharp corners, minimal borders)
-    visuals.widgets.noninteractive.bg_fill = SLATE_800;
-    visuals.widgets.noninteractive.weak_bg_fill = SLATE_800;
+    visuals.widgets.noninteractive.bg_fill = ZINC_800;
+    visuals.widgets.noninteractive.weak_bg_fill = ZINC_800;
     visuals.widgets.noninteractive.fg_stroke = Stroke::new(1.0, TEXT_SUBDUED);
     visuals.widgets.noninteractive.corner_radius = CornerRadius::ZERO;
     visuals.widgets.noninteractive.bg_stroke = Stroke::NONE;
 
-    visuals.widgets.inactive.bg_fill = SLATE_700;
-    visuals.widgets.inactive.weak_bg_fill = SLATE_700;
-    visuals.widgets.inactive.fg_stroke = Stroke::new(1.0, SLATE_200);
+    visuals.widgets.inactive.bg_fill = ZINC_700;
+    visuals.widgets.inactive.weak_bg_fill = ZINC_700;
+    visuals.widgets.inactive.fg_stroke = Stroke::new(1.0, ZINC_200);
     visuals.widgets.inactive.corner_radius = CornerRadius::ZERO;
     visuals.widgets.inactive.bg_stroke = Stroke::NONE;
 
-    visuals.widgets.hovered.bg_fill = SLATE_600;
-    visuals.widgets.hovered.weak_bg_fill = SLATE_600;
-    visuals.widgets.hovered.fg_stroke = Stroke::new(1.0, SLATE_100);
+    visuals.widgets.hovered.bg_fill = ZINC_600;
+    visuals.widgets.hovered.weak_bg_fill = ZINC_600;
+    visuals.widgets.hovered.fg_stroke = Stroke::new(1.0, ZINC_100);
     visuals.widgets.hovered.corner_radius = CornerRadius::ZERO;
     visuals.widgets.hovered.expansion = 0.0; // No expansion, just color change
     visuals.widgets.hovered.bg_stroke = Stroke::NONE;
 
-    visuals.widgets.active.bg_fill = SLATE_600;
-    visuals.widgets.active.weak_bg_fill = SLATE_600;
-    visuals.widgets.active.fg_stroke = Stroke::new(1.0, SLATE_100);
+    visuals.widgets.active.bg_fill = ZINC_600;
+    visuals.widgets.active.weak_bg_fill = ZINC_600;
+    visuals.widgets.active.fg_stroke = Stroke::new(1.0, ZINC_100);
     visuals.widgets.active.corner_radius = CornerRadius::ZERO;
     visuals.widgets.active.expansion = 0.0;
     visuals.widgets.active.bg_stroke = Stroke::NONE;
 
-    visuals.widgets.open.bg_fill = SLATE_600;
-    visuals.widgets.open.weak_bg_fill = SLATE_600;
-    visuals.widgets.open.fg_stroke = Stroke::new(1.0, SLATE_200);
+    visuals.widgets.open.bg_fill = ZINC_600;
+    visuals.widgets.open.weak_bg_fill = ZINC_600;
+    visuals.widgets.open.fg_stroke = Stroke::new(1.0, ZINC_200);
     visuals.widgets.open.corner_radius = CornerRadius::ZERO;
 
     // Selection (violet tint with visible text)

--- a/crates/nodebox-gui/src/viewer_pane.rs
+++ b/crates/nodebox-gui/src/viewer_pane.rs
@@ -936,7 +936,7 @@ impl ViewerPane {
                                 ui.painter().rect_stroke(
                                     swatch_rect,
                                     0.0,
-                                    Stroke::new(1.0, theme::SLATE_600),
+                                    Stroke::new(1.0, theme::ZINC_600),
                                     egui::StrokeKind::Inside,
                                 );
                             }
@@ -1257,7 +1257,7 @@ impl ViewerPane {
                 ui.painter().rect_stroke(
                     swatch_rect,
                     0.0,
-                    Stroke::new(1.0, theme::SLATE_600),
+                    Stroke::new(1.0, theme::ZINC_600),
                     egui::StrokeKind::Inside,
                 );
 


### PR DESCRIPTION
Replaces the Tailwind Slate color palette with Zinc across the GUI theme.

**What changed:**
- Renamed all `SLATE_*` constants to `ZINC_*` and updated RGB values to match Tailwind's Zinc palette
- Updated all references in `theme.rs`, `address_bar.rs`, `animation_bar.rs`, `components.rs`, and `viewer_pane.rs`
- Updated `TABLE_ROW_ODD` and `viewer_grid()` to use Zinc-appropriate colors
- Updated comments and documentation strings

**Visual difference:** The UI shifts from cool blue-gray tones (Slate has noticeable blue undertones in darker shades) to neutral grays (Zinc is nearly pure gray with very subtle cool undertones). This gives the interface a more neutral, less blue-tinted appearance.

**Verification:** `cargo build --workspace --exclude nodebox-python` passes.