### PR TITLE
Fix canvas border not visible over Vello GPU texture

### DIFF
--- a/crates/nodebox-gui/src/viewer_pane.rs
+++ b/crates/nodebox-gui/src/viewer_pane.rs
@@ -601,13 +601,14 @@ impl ViewerPane {
         // Draw a subtle grid
         self.draw_grid(&painter, rect);
 
+        // Draw all geometry (using GPU or CPU rendering)
+        self.render_geometry(ui, &painter, state, render_state, rect, center);
+
         // Draw canvas border (uses document width/height)
+        // Drawn after geometry so it's visible on top of the Vello GPU texture.
         if self.show_canvas_border {
             self.draw_canvas_border(&painter, center, state.library.width(), state.library.height());
         }
-
-        // Draw all geometry (using GPU or CPU rendering)
-        self.render_geometry(ui, &painter, state, render_state, rect, center);
 
         // Draw origin crosshair
         if self.show_origin {


### PR DESCRIPTION
## Summary
- Move canvas border drawing to after geometry rendering so it appears on top of the Vello GPU texture instead of being hidden beneath it
- Previously the border was drawn before `render_geometry()`, and the Vello renderer painted a full-viewport texture that covered it

## Test plan
- [x] `cargo build --workspace --exclude nodebox-python`
- [x] `cargo test --workspace --exclude nodebox-python`
- [x] Run the app, verify the canvas border rectangle is visible in the viewer
- [x] Toggle the "Canvas" button in the viewer header to confirm it toggles on/off
- [x] Zoom in/out to verify the border stays at constant 1px screen-space width

🤖 Generated with [Claude Code](https://claude.com/claude-code)