### PR TITLE
Fix spacebar typing into parameter fields after editing

### DIFF
--- a/crates/nodebox-gui/src/panels.rs
+++ b/crates/nodebox-gui/src/panels.rs
@@ -272,7 +272,9 @@ impl ParameterPanel {
                         }
 
                         // Request focus on first frame
-                        output.response.request_focus();
+                        if self.editing.is_some() {
+                            output.response.request_focus();
+                        }
                     } else {
                         // Show as clickable text
                         let display = if value.is_empty() { "\"\"" } else { value.as_str() };
@@ -539,7 +541,9 @@ impl ParameterPanel {
                 }
             }
 
-            output.response.request_focus();
+            if self.editing.is_some() {
+                output.response.request_focus();
+            }
         } else {
             // Show as draggable text (non-selectable)
             let text = format!("{:.2}", value);
@@ -633,7 +637,9 @@ impl ParameterPanel {
                 }
             }
 
-            output.response.request_focus();
+            if self.editing.is_some() {
+                output.response.request_focus();
+            }
         } else {
             let text = format!("{}", value);
             let galley = ui.painter().layout_no_wrap(


### PR DESCRIPTION
## Summary
- Fix bug where pressing spacebar to pan after editing a parameter field would re-activate the field and type a space character instead of panning
- Root cause: `request_focus()` was called unconditionally in the editing block, so after `self.editing` was set to `None` (on Enter/Tab), focus remained on the widget ID — causing egui's `FAKE_PRIMARY_CLICKED` to re-trigger editing on spacebar press
- Made `request_focus()` conditional on `self.editing.is_some()` for string, float, and int parameter widgets

## Test plan
- [x] `cargo build --workspace --exclude nodebox-python` compiles
- [x] `cargo test --workspace --exclude nodebox-python` passes
- [x] Edit a float parameter, press Enter, move mouse to viewer, press spacebar → should pan, NOT re-activate the field
- [x] Edit a string parameter, press Enter, press spacebar over network → should pan
- [x] While actively editing a field, spacebar should still type normally
- [x] Spacebar + drag on viewer/network → should pan as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)