### PR TITLE
Fix header lines drawing over dialogs and make node dialog modal

### DIFF
--- a/crates/nodebox-gui/src/components.rs
+++ b/crates/nodebox-gui/src/components.rs
@@ -72,13 +72,8 @@ pub fn draw_pane_header_with_title(
         egui::Stroke::new(1.0, theme::TEXT_DISABLED),
     );
 
-    // Bottom border (1px dark line) - painted on foreground layer so content
-    // below (canvas, table headers) cannot paint over it.
-    let fg_painter = ui.ctx().layer_painter(egui::LayerId::new(
-        egui::Order::Foreground,
-        ui.id().with("header_border"),
-    ));
-    fg_painter.line_segment(
+    // Bottom border (1px dark line)
+    ui.painter().line_segment(
         [
             egui::pos2(aligned_rect.left(), aligned_rect.bottom() - 0.5),
             egui::pos2(aligned_rect.right(), aligned_rect.bottom() - 0.5),

--- a/crates/nodebox-gui/src/node_selection_dialog.rs
+++ b/crates/nodebox-gui/src/node_selection_dialog.rs
@@ -1,6 +1,6 @@
 //! Modal node selection dialog with search and category filtering.
 
-use eframe::egui::{self, Color32, Id, Key, Vec2};
+use eframe::egui::{self, Color32, Key, Vec2};
 use nodebox_core::geometry::Point;
 use nodebox_core::node::{Node, NodeLibrary};
 use crate::icon_cache::IconCache;
@@ -160,19 +160,6 @@ impl NodeSelectionDialog {
                 }
             }
         });
-
-        // Full-screen modal backdrop: absorbs all pointer events so panels
-        // behind the dialog don't respond to clicks or scroll wheel.
-        let screen = ctx.content_rect();
-        egui::Area::new(Id::new("node_dialog_backdrop"))
-            .order(egui::Order::Middle)
-            .fixed_pos(screen.min)
-            .show(ctx, |ui| {
-                let response = ui.allocate_response(screen.size(), egui::Sense::click_and_drag());
-                if response.clicked() {
-                    should_close = true;
-                }
-            });
 
         // Modal window - clean Figma-like styling
         let dialog_frame = egui::Frame::NONE

--- a/crates/nodebox-gui/src/node_selection_dialog.rs
+++ b/crates/nodebox-gui/src/node_selection_dialog.rs
@@ -1,6 +1,6 @@
 //! Modal node selection dialog with search and category filtering.
 
-use eframe::egui::{self, Color32, Key, Vec2};
+use eframe::egui::{self, Color32, Id, Key, Vec2};
 use nodebox_core::geometry::Point;
 use nodebox_core::node::{Node, NodeLibrary};
 use crate::icon_cache::IconCache;
@@ -160,6 +160,19 @@ impl NodeSelectionDialog {
                 }
             }
         });
+
+        // Full-screen modal backdrop: absorbs all pointer events so panels
+        // behind the dialog don't respond to clicks or scroll wheel.
+        let screen = ctx.content_rect();
+        egui::Area::new(Id::new("node_dialog_backdrop"))
+            .order(egui::Order::Middle)
+            .fixed_pos(screen.min)
+            .show(ctx, |ui| {
+                let response = ui.allocate_response(screen.size(), egui::Sense::click_and_drag());
+                if response.clicked() {
+                    should_close = true;
+                }
+            });
 
         // Modal window - clean Figma-like styling
         let dialog_frame = egui::Frame::NONE

--- a/crates/nodebox-gui/src/pan_zoom.rs
+++ b/crates/nodebox-gui/src/pan_zoom.rs
@@ -57,7 +57,8 @@ impl PanZoom {
     /// Returns true if zoom changed.
     pub fn handle_scroll_zoom(&mut self, rect: Rect, ui: &egui::Ui, origin: Vec2) -> bool {
         if let Some(mouse_pos) = ui.input(|i| i.pointer.hover_pos()) {
-            if rect.contains(mouse_pos) {
+            // Use layer-aware check so overlapping windows/dialogs block scroll.
+            if ui.rect_contains_pointer(rect) {
                 let scroll = ui.input(|i| i.raw_scroll_delta.y);
                 if scroll != 0.0 {
                     let zoom_factor = 1.0 + scroll * 0.001;


### PR DESCRIPTION
## Summary
- Draw pane header bottom border on the panel's own layer instead of `Order::Foreground`, so it no longer renders on top of popups (color picker) and windows (Add Node dialog)
- Add a full-screen modal backdrop behind the node selection dialog that captures pointer events and closes on click-outside
- Switch `pan_zoom` scroll-zoom check from raw `rect.contains(mouse_pos)` to layer-aware `ui.rect_contains_pointer(rect)` so overlapping dialogs block background zoom

## Test plan
- [x] Open Add Node dialog — header bottom border line should not draw through it
- [x] Open color picker — header bottom border line should not draw through it
- [x] Scroll inside Add Node dialog — viewer/network should not zoom
- [ ] Click outside Add Node dialog — dialog should close

🤖 Generated with [Claude Code](https://claude.com/claude-code)