### PR TITLE
Add generic list type support for polymorphic list operations

### DIFF
--- a/crates/nodebox-core/src/node/port.rs
+++ b/crates/nodebox-core/src/node/port.rs
@@ -79,6 +79,16 @@ impl PortType {
             return true;
         }
 
+        // PortType::List is a generic type — list inputs accept any output type
+        if matches!(input_type, PortType::List) {
+            return true;
+        }
+
+        // PortType::List output can connect to any input (runtime type determined by actual data)
+        if matches!(output_type, PortType::List) {
+            return true;
+        }
+
         // Everything can be converted to a string
         if matches!(input_type, PortType::String) {
             return true;
@@ -387,6 +397,21 @@ mod tests {
         // Number -> Point
         assert!(PortType::is_compatible(&PortType::Int, &PortType::Point));
         assert!(PortType::is_compatible(&PortType::Float, &PortType::Point));
+
+        // List input accepts any type (generic list nodes)
+        assert!(PortType::is_compatible(&PortType::Geometry, &PortType::List));
+        assert!(PortType::is_compatible(&PortType::Color, &PortType::List));
+        assert!(PortType::is_compatible(&PortType::Point, &PortType::List));
+        assert!(PortType::is_compatible(&PortType::Float, &PortType::List));
+        assert!(PortType::is_compatible(&PortType::Int, &PortType::List));
+        assert!(PortType::is_compatible(&PortType::String, &PortType::List));
+
+        // List output connects to any type (runtime type determined by data)
+        assert!(PortType::is_compatible(&PortType::List, &PortType::Geometry));
+        assert!(PortType::is_compatible(&PortType::List, &PortType::Color));
+        assert!(PortType::is_compatible(&PortType::List, &PortType::Point));
+        assert!(PortType::is_compatible(&PortType::List, &PortType::Float));
+        assert!(PortType::is_compatible(&PortType::List, &PortType::Int));
 
         // Incompatible
         assert!(!PortType::is_compatible(&PortType::String, &PortType::Int));

--- a/crates/nodebox-gui/src/eval.rs
+++ b/crates/nodebox-gui/src/eval.rs
@@ -1724,6 +1724,7 @@ fn execute_node(
                 Some(NodeOutput::Ints(v)) => Ok(NodeOutput::Int(v.len() as i64)),
                 Some(NodeOutput::Strings(v)) => Ok(NodeOutput::Int(v.len() as i64)),
                 Some(NodeOutput::Booleans(v)) => Ok(NodeOutput::Int(v.len() as i64)),
+                Some(NodeOutput::Colors(v)) => Ok(NodeOutput::Int(v.len() as i64)),
                 _ => Ok(NodeOutput::Int(0)),
             }
         }
@@ -1736,6 +1737,7 @@ fn execute_node(
                 Some(NodeOutput::Ints(v)) => Ok(v.first().map(|i| NodeOutput::Int(*i)).unwrap_or(NodeOutput::None)),
                 Some(NodeOutput::Strings(v)) => Ok(v.first().map(|s| NodeOutput::String(s.clone())).unwrap_or(NodeOutput::None)),
                 Some(NodeOutput::Booleans(v)) => Ok(v.first().map(|b| NodeOutput::Boolean(*b)).unwrap_or(NodeOutput::None)),
+                Some(NodeOutput::Colors(v)) => Ok(v.first().map(|c| NodeOutput::Color(*c)).unwrap_or(NodeOutput::None)),
                 _ => Ok(NodeOutput::None),
             }
         }
@@ -1748,6 +1750,7 @@ fn execute_node(
                 Some(NodeOutput::Ints(v)) => Ok(v.get(1).map(|i| NodeOutput::Int(*i)).unwrap_or(NodeOutput::None)),
                 Some(NodeOutput::Strings(v)) => Ok(v.get(1).map(|s| NodeOutput::String(s.clone())).unwrap_or(NodeOutput::None)),
                 Some(NodeOutput::Booleans(v)) => Ok(v.get(1).map(|b| NodeOutput::Boolean(*b)).unwrap_or(NodeOutput::None)),
+                Some(NodeOutput::Colors(v)) => Ok(v.get(1).map(|c| NodeOutput::Color(*c)).unwrap_or(NodeOutput::None)),
                 _ => Ok(NodeOutput::None),
             }
         }
@@ -1760,6 +1763,7 @@ fn execute_node(
                 Some(NodeOutput::Ints(v)) => Ok(v.last().map(|i| NodeOutput::Int(*i)).unwrap_or(NodeOutput::None)),
                 Some(NodeOutput::Strings(v)) => Ok(v.last().map(|s| NodeOutput::String(s.clone())).unwrap_or(NodeOutput::None)),
                 Some(NodeOutput::Booleans(v)) => Ok(v.last().map(|b| NodeOutput::Boolean(*b)).unwrap_or(NodeOutput::None)),
+                Some(NodeOutput::Colors(v)) => Ok(v.last().map(|c| NodeOutput::Color(*c)).unwrap_or(NodeOutput::None)),
                 _ => Ok(NodeOutput::None),
             }
         }
@@ -1772,6 +1776,7 @@ fn execute_node(
                 Some(NodeOutput::Ints(v)) => Ok(NodeOutput::Ints(nodebox_ops::list::rest(v))),
                 Some(NodeOutput::Strings(v)) => Ok(NodeOutput::Strings(nodebox_ops::list::rest(v))),
                 Some(NodeOutput::Booleans(v)) => Ok(NodeOutput::Booleans(nodebox_ops::list::rest(v))),
+                Some(NodeOutput::Colors(v)) => Ok(NodeOutput::Colors(nodebox_ops::list::rest(v))),
                 _ => Ok(NodeOutput::None),
             }
         }
@@ -1784,6 +1789,7 @@ fn execute_node(
                 Some(NodeOutput::Ints(v)) => Ok(NodeOutput::Ints(nodebox_ops::list::reverse(v))),
                 Some(NodeOutput::Strings(v)) => Ok(NodeOutput::Strings(nodebox_ops::list::reverse(v))),
                 Some(NodeOutput::Booleans(v)) => Ok(NodeOutput::Booleans(nodebox_ops::list::reverse(v))),
+                Some(NodeOutput::Colors(v)) => Ok(NodeOutput::Colors(nodebox_ops::list::reverse(v))),
                 _ => Ok(NodeOutput::None),
             }
         }
@@ -1799,6 +1805,7 @@ fn execute_node(
                 Some(NodeOutput::Ints(v)) => Ok(NodeOutput::Ints(nodebox_ops::list::slice(v, start_index, size, invert))),
                 Some(NodeOutput::Strings(v)) => Ok(NodeOutput::Strings(nodebox_ops::list::slice(v, start_index, size, invert))),
                 Some(NodeOutput::Booleans(v)) => Ok(NodeOutput::Booleans(nodebox_ops::list::slice(v, start_index, size, invert))),
+                Some(NodeOutput::Colors(v)) => Ok(NodeOutput::Colors(nodebox_ops::list::slice(v, start_index, size, invert))),
                 _ => Ok(NodeOutput::None),
             }
         }
@@ -1812,6 +1819,7 @@ fn execute_node(
                 Some(NodeOutput::Ints(v)) => Ok(NodeOutput::Ints(nodebox_ops::list::shift(v, amount))),
                 Some(NodeOutput::Strings(v)) => Ok(NodeOutput::Strings(nodebox_ops::list::shift(v, amount))),
                 Some(NodeOutput::Booleans(v)) => Ok(NodeOutput::Booleans(nodebox_ops::list::shift(v, amount))),
+                Some(NodeOutput::Colors(v)) => Ok(NodeOutput::Colors(nodebox_ops::list::shift(v, amount))),
                 _ => Ok(NodeOutput::None),
             }
         }
@@ -1826,6 +1834,7 @@ fn execute_node(
                 Some(NodeOutput::Ints(v)) => Ok(NodeOutput::Ints(nodebox_ops::list::repeat(v, amount, per_item))),
                 Some(NodeOutput::Strings(v)) => Ok(NodeOutput::Strings(nodebox_ops::list::repeat(v, amount, per_item))),
                 Some(NodeOutput::Booleans(v)) => Ok(NodeOutput::Booleans(nodebox_ops::list::repeat(v, amount, per_item))),
+                Some(NodeOutput::Colors(v)) => Ok(NodeOutput::Colors(nodebox_ops::list::repeat(v, amount, per_item))),
                 _ => Ok(NodeOutput::None),
             }
         }
@@ -1849,6 +1858,7 @@ fn execute_node(
                 Some(NodeOutput::Ints(v)) => Ok(NodeOutput::Ints(nodebox_ops::list::shuffle(v, seed))),
                 Some(NodeOutput::Strings(v)) => Ok(NodeOutput::Strings(nodebox_ops::list::shuffle(v, seed))),
                 Some(NodeOutput::Booleans(v)) => Ok(NodeOutput::Booleans(nodebox_ops::list::shuffle(v, seed))),
+                Some(NodeOutput::Colors(v)) => Ok(NodeOutput::Colors(nodebox_ops::list::shuffle(v, seed))),
                 _ => Ok(NodeOutput::None),
             }
         }
@@ -1863,6 +1873,7 @@ fn execute_node(
                 Some(NodeOutput::Ints(v)) => Ok(NodeOutput::Ints(nodebox_ops::list::pick(v, amount, seed))),
                 Some(NodeOutput::Strings(v)) => Ok(NodeOutput::Strings(nodebox_ops::list::pick(v, amount, seed))),
                 Some(NodeOutput::Booleans(v)) => Ok(NodeOutput::Booleans(nodebox_ops::list::pick(v, amount, seed))),
+                Some(NodeOutput::Colors(v)) => Ok(NodeOutput::Colors(nodebox_ops::list::pick(v, amount, seed))),
                 _ => Ok(NodeOutput::None),
             }
         }
@@ -1876,6 +1887,7 @@ fn execute_node(
                 Some(NodeOutput::Ints(v)) => Ok(NodeOutput::Ints(nodebox_ops::list::cull(v, &booleans))),
                 Some(NodeOutput::Strings(v)) => Ok(NodeOutput::Strings(nodebox_ops::list::cull(v, &booleans))),
                 Some(NodeOutput::Booleans(v)) => Ok(NodeOutput::Booleans(nodebox_ops::list::cull(v, &booleans))),
+                Some(NodeOutput::Colors(v)) => Ok(NodeOutput::Colors(nodebox_ops::list::cull(v, &booleans))),
                 _ => Ok(NodeOutput::None),
             }
         }
@@ -1889,6 +1901,7 @@ fn execute_node(
                 Some(NodeOutput::Ints(v)) => Ok(NodeOutput::Ints(nodebox_ops::list::take_every(v, n))),
                 Some(NodeOutput::Strings(v)) => Ok(NodeOutput::Strings(nodebox_ops::list::take_every(v, n))),
                 Some(NodeOutput::Booleans(v)) => Ok(NodeOutput::Booleans(nodebox_ops::list::take_every(v, n))),
+                Some(NodeOutput::Colors(v)) => Ok(NodeOutput::Colors(nodebox_ops::list::take_every(v, n))),
                 _ => Ok(NodeOutput::None),
             }
         }

--- a/crates/nodebox-gui/src/node_library.rs
+++ b/crates/nodebox-gui/src/node_library.rs
@@ -637,16 +637,34 @@ pub fn create_node_from_template(template: &NodeTemplate, library: &NodeLibrary,
                 .with_output_type(PortType::String)
                 .with_output_range(PortRange::List);
         }
-        // List nodes
+        // List nodes — accept any list type via PortType::List
         "count" | "first" | "reverse" | "shuffle" | "slice" => {
-            node = node.with_input(Port::geometry("list").with_port_range(PortRange::List));
+            node = node.with_input(Port::new("list", PortType::List).with_port_range(PortRange::List));
             match template.name {
-                "shuffle" => { node = node.with_input(Port::int("seed", 0)); }
+                "count" => {
+                    node = node.with_output_type(PortType::Int);
+                }
+                "first" => {
+                    node = node.with_output_type(PortType::List);
+                }
+                "reverse" => {
+                    node = node
+                        .with_output_type(PortType::List)
+                        .with_output_range(PortRange::List);
+                }
+                "shuffle" => {
+                    node = node
+                        .with_input(Port::int("seed", 0))
+                        .with_output_type(PortType::List)
+                        .with_output_range(PortRange::List);
+                }
                 "slice" => {
                     node = node
                         .with_input(Port::int("start_index", 0))
                         .with_input(Port::int("size", 10))
-                        .with_input(Port::boolean("invert", false));
+                        .with_input(Port::boolean("invert", false))
+                        .with_output_type(PortType::List)
+                        .with_output_range(PortRange::List);
                 }
                 _ => {}
             }


### PR DESCRIPTION
## Summary
This PR introduces a generic `PortType::List` that enables list operation nodes to work with any list type (Geometry, Color, Point, Float, Int, String, Boolean). Previously, list nodes were hardcoded to work only with specific types. This change makes list operations truly polymorphic.

## Key Changes

- **Port type compatibility rules**: Updated `PortType::is_compatible()` to treat `PortType::List` as a generic type that accepts any input type and can connect to any output type, with runtime type determined by actual data.

- **List node input ports**: Changed list operation nodes (`count`, `first`, `reverse`, `shuffle`, `slice`) to use generic `PortType::List` instead of `PortType::Geometry`, allowing them to accept lists of any element type.

- **List node output types**: Added explicit output type declarations for all list operation nodes:
  - `count`: returns `Int`
  - `first`: returns `List` (preserves element type)
  - `reverse`: returns `List` with `PortRange::List`
  - `shuffle`: returns `List` with `PortRange::List`
  - `slice`: returns `List` with `PortRange::List`

- **Color list support in evaluator**: Extended all list operation implementations in `execute_node()` to handle `NodeOutput::Colors` variant, ensuring color lists are properly processed through all list operations (count, first, rest, reverse, slice, shift, repeat, shuffle, pick, cull, take_every).

- **Comprehensive test coverage**: Added tests validating that `PortType::List` inputs accept all concrete types and that `PortType::List` outputs connect to all concrete input types.

## Implementation Details
The generic list type works by deferring type resolution to runtime—the actual element type is determined by the data flowing through the list port, not by static type checking. This allows a single set of list operation nodes to work with any list type without duplication.

https://claude.ai/code/session_01NoFFq96einUnh1inhLHGAr