### PR TITLE
Expand node selection dialog categories

### DIFF
--- a/crates/nodebox-gui/src/node_selection_dialog.rs
+++ b/crates/nodebox-gui/src/node_selection_dialog.rs
@@ -247,7 +247,7 @@ impl NodeSelectionDialog {
                             egui::Label::new(
                                 egui::RichText::new(cat).color(text_color).size(10.0),
                             ).sense(egui::Sense::click())
-                        );
+                        ).on_hover_cursor(egui::CursorIcon::PointingHand);
 
                         if response.clicked() {
                             if cat == "All" {

--- a/crates/nodebox-gui/src/node_selection_dialog.rs
+++ b/crates/nodebox-gui/src/node_selection_dialog.rs
@@ -8,7 +8,7 @@ use crate::node_library::{NodeTemplate, NODE_TEMPLATES, create_node_from_templat
 use crate::theme;
 
 /// Categories for filtering nodes.
-const CATEGORIES: &[&str] = &["All", "geometry", "transform", "color"];
+const CATEGORIES: &[&str] = &["All", "geometry", "transform", "color", "math", "string", "list", "core"];
 
 /// The modal node selection dialog.
 pub struct NodeSelectionDialog {


### PR DESCRIPTION
## Summary
Extended the available node categories in the node selection dialog to provide better organization and filtering options for users.

## Changes
- Added four new node categories to the `CATEGORIES` constant: "math", "string", "list", and "core"
- Updated the category filter list from 4 categories to 8 total categories, maintaining "All" as the first option followed by the original categories (geometry, transform, color) and the new ones

## Details
This change improves the node library organization by allowing nodes to be grouped into additional logical categories beyond the existing geometry, transform, and color classifications. The new categories support mathematical operations, string manipulation, list operations, and core functionality nodes.

https://claude.ai/code/session_01VmHyqEPs7QCd6HM9D2iJSV