### PR TITLE
Always append index to unique child names for consistency

### DIFF
--- a/crates/nodebox-core/src/node/node.rs
+++ b/crates/nodebox-core/src/node/node.rs
@@ -218,13 +218,10 @@ impl Node {
     }
 
     /// Generates a unique name for a new child based on a prefix.
+    /// Always appends an index (e.g. "rect1", "rect2") so names can be used as identifiers.
     pub fn unique_child_name(&self, prefix: &str) -> String {
         let existing: std::collections::HashSet<_> =
             self.children.iter().map(|c| c.name.as_str()).collect();
-
-        if !existing.contains(prefix) {
-            return prefix.to_string();
-        }
 
         for i in 1..1000 {
             let name = format!("{}{}", prefix, i);
@@ -378,7 +375,9 @@ mod tests {
             .with_child(Node::new("rect"))
             .with_child(Node::new("rect1"));
 
-        assert_eq!(node.unique_child_name("ellipse"), "ellipse");
+        // Always appends an index, even for new prefixes
+        assert_eq!(node.unique_child_name("ellipse"), "ellipse1");
+        // Skips existing "rect1", returns "rect2"
         assert_eq!(node.unique_child_name("rect"), "rect2");
     }
 }


### PR DESCRIPTION
## Summary
Modified the `unique_child_name` method to always append a numeric index to generated names, even when the prefix itself doesn't exist as a child. This ensures consistent naming behavior where all generated names follow the pattern `prefix + index` (e.g., "rect1", "rect2").

## Key Changes
- Removed the early return that would skip index appending when the prefix didn't already exist
- Updated the logic to always start from index 1 and find the first available name
- Updated corresponding test expectations to reflect the new behavior

## Implementation Details
- The method now consistently generates names like "ellipse1", "rect1", "rect2" instead of sometimes returning just "ellipse"
- This makes generated names more suitable for use as identifiers and provides predictable naming patterns
- The loop still searches up to 1000 to find an available name, skipping any that already exist as child names

https://claude.ai/code/session_01URHKDEpYZKYaQd6otFte8V