### PR TITLE
Add minimum value constraints to resample node parameters

### DIFF
--- a/crates/nodebox-gui/src/eval.rs
+++ b/crates/nodebox-gui/src/eval.rs
@@ -1091,10 +1091,10 @@ fn execute_node(
             let shape = require_path(inputs, node_name, "shape")?;
             let method = get_string(inputs, "method", "length");
             let path = if method == "length" {
-                let length = get_float(inputs, "length", 10.0);
+                let length = get_float(inputs, "length", 10.0).max(1.0);
                 nodebox_ops::resample_by_length(&shape, length)
             } else {
-                let points = get_int(inputs, "points", 20) as usize;
+                let points = get_int(inputs, "points", 20).max(0) as usize;
                 nodebox_ops::resample(&shape, points)
             };
             Ok(NodeOutput::Path(path))

--- a/crates/nodebox-gui/src/node_library.rs
+++ b/crates/nodebox-gui/src/node_library.rs
@@ -510,8 +510,8 @@ pub fn create_node_from_template(template: &NodeTemplate, library: &NodeLibrary,
                     MenuItem::new("length", "By length"),
                     MenuItem::new("amount", "By amount"),
                 ]))
-                .with_input(Port::float("length", 10.0))
-                .with_input(Port::int("points", 10))
+                .with_input(Port::float("length", 10.0).with_min(1.0))
+                .with_input(Port::int("points", 10).with_min(1.0))
                 .with_input(Port::boolean("per_contour", false));
         }
         "wiggle" => {


### PR DESCRIPTION
## Summary
This PR adds minimum value constraints to the resample node's parameters to prevent invalid configurations that could cause errors or unexpected behavior.

## Key Changes
- **eval.rs**: Added runtime validation to ensure resample parameters stay within valid ranges:
  - `length` parameter now enforces a minimum of 1.0 using `.max(1.0)`
  - `points` parameter now enforces a minimum of 0 using `.max(0)` before casting to usize
  
- **node_library.rs**: Added UI-level constraints to the resample node's input ports:
  - `length` port now has a minimum value of 1.0
  - `points` port now has a minimum value of 1.0

## Implementation Details
The changes implement validation at two levels:
1. **UI constraints** prevent users from setting invalid values in the node editor
2. **Runtime guards** ensure that even if invalid values somehow reach the execution layer, they are clamped to safe minimums

This prevents potential issues with the `resample_by_length` and `resample` operations that would fail or produce incorrect results with zero or negative parameters.

https://claude.ai/code/session_01PFA511hyP4JEAhG8TgVrPT