### PR TITLE
Implement undo grouping for drag operations

### DIFF
--- a/crates/nodebox-gui/src/app.rs
+++ b/crates/nodebox-gui/src/app.rs
@@ -40,6 +40,8 @@ pub struct NodeBoxApp {
     history: History,
     /// Previous library state for detecting changes.
     previous_library_hash: u64,
+    /// Snapshot of the library at end of last frame, used for undo (pre-mutation state).
+    previous_library: Arc<nodebox_core::node::NodeLibrary>,
     /// Background render worker.
     render_worker: RenderWorkerHandle,
     /// State tracking for render requests.
@@ -105,6 +107,7 @@ impl NodeBoxApp {
         }
 
         let hash = Self::hash_library(&state.library);
+        let prev_library = Arc::clone(&state.library);
         Self {
             port,
             project_context,
@@ -118,6 +121,7 @@ impl NodeBoxApp {
             icon_cache: IconCache::new(),
             history: History::new(),
             previous_library_hash: hash,
+            previous_library: prev_library,
             render_worker: RenderWorkerHandle::spawn(),
             render_state: RenderState::new(),
             render_pending: true,
@@ -187,6 +191,7 @@ impl NodeBoxApp {
         }
 
         let hash = Self::hash_library(&state.library);
+        let prev_library = Arc::clone(&state.library);
         Self {
             port,
             project_context,
@@ -200,6 +205,7 @@ impl NodeBoxApp {
             icon_cache: IconCache::new(),
             history: History::new(),
             previous_library_hash: hash,
+            previous_library: prev_library,
             render_worker: RenderWorkerHandle::spawn(),
             render_state: RenderState::new(),
             render_pending: true,
@@ -219,6 +225,7 @@ impl NodeBoxApp {
     pub fn new_for_testing() -> Self {
         let state = AppState::new();
         let hash = Self::hash_library(&state.library);
+        let prev_library = Arc::clone(&state.library);
         Self {
             port: Arc::new(nodebox_port::DesktopPort::new()),
             project_context: ProjectContext::new_unsaved(),
@@ -232,6 +239,7 @@ impl NodeBoxApp {
             icon_cache: IconCache::new(),
             history: History::new(),
             previous_library_hash: hash,
+            previous_library: prev_library,
             render_worker: RenderWorkerHandle::spawn(),
             render_state: RenderState::new(),
             render_pending: false,
@@ -252,6 +260,7 @@ impl NodeBoxApp {
         state.library = Arc::new(nodebox_core::node::NodeLibrary::new("test"));
         state.geometry.clear();
         let hash = Self::hash_library(&state.library);
+        let prev_library = Arc::clone(&state.library);
         Self {
             port: Arc::new(nodebox_port::DesktopPort::new()),
             project_context: ProjectContext::new_unsaved(),
@@ -265,6 +274,7 @@ impl NodeBoxApp {
             icon_cache: IconCache::new(),
             history: History::new(),
             previous_library_hash: hash,
+            previous_library: prev_library,
             render_worker: RenderWorkerHandle::spawn(),
             render_state: RenderState::new(),
             render_pending: false,
@@ -341,11 +351,14 @@ impl NodeBoxApp {
     #[cfg(test)]
     #[allow(dead_code)]
     pub fn update_for_testing(&mut self) {
-        // Check for changes and save to history
+        // Check for changes and save to history (using previous_library for correct undo)
         let current_hash = Self::hash_library(&self.state.library);
         if current_hash != self.previous_library_hash {
-            self.history.save_state(&self.state.library);
+            self.history.save_state(&self.previous_library);
             self.previous_library_hash = current_hash;
+            if !self.history.is_in_group() {
+                self.previous_library = Arc::clone(&self.state.library);
+            }
             self.state.dirty = true;
         }
         // Synchronously evaluate using the app's port
@@ -450,11 +463,21 @@ impl NodeBoxApp {
     }
 
     /// Check for changes and save to history, queue render if needed.
+    ///
+    /// Saves the *previous* library state (from before this frame's mutations)
+    /// so that undo restores to the pre-mutation state.
     fn check_for_changes(&mut self) {
         let current_hash = Self::hash_library(&self.state.library);
         if current_hash != self.previous_library_hash {
-            self.history.save_state(&self.state.library);
+            self.history.save_state(&self.previous_library);
             self.previous_library_hash = current_hash;
+            // Only update previous_library when not in an undo group.
+            // During a group, the group_start_state tracks the pre-drag snapshot
+            // and previous_library must stay frozen so that the next non-grouped
+            // change still records the correct pre-mutation state.
+            if !self.history.is_in_group() {
+                self.previous_library = Arc::clone(&self.state.library);
+            }
             self.state.dirty = true;
             self.render_pending = true; // Queue async render
         }
@@ -475,6 +498,7 @@ impl NodeBoxApp {
                 if let Some(previous) = self.history.undo(&self.state.library) {
                     self.state.library = previous;
                     self.previous_library_hash = Self::hash_library(&self.state.library);
+                    self.previous_library = Arc::clone(&self.state.library);
                     self.render_pending = true;
                 }
             }
@@ -482,6 +506,7 @@ impl NodeBoxApp {
                 if let Some(next) = self.history.redo(&self.state.library) {
                     self.state.library = next;
                     self.previous_library_hash = Self::hash_library(&self.state.library);
+                    self.previous_library = Arc::clone(&self.state.library);
                     self.render_pending = true;
                 }
             }
@@ -571,6 +596,7 @@ impl NodeBoxApp {
                     if let Some(previous) = self.history.undo(&self.state.library) {
                         self.state.library = previous;
                         self.previous_library_hash = Self::hash_library(&self.state.library);
+                        self.previous_library = Arc::clone(&self.state.library);
                         self.render_pending = true;
                     }
                     ui.close();
@@ -584,6 +610,7 @@ impl NodeBoxApp {
                     if let Some(next) = self.history.redo(&self.state.library) {
                         self.state.library = next;
                         self.previous_library_hash = Self::hash_library(&self.state.library);
+                        self.previous_library = Arc::clone(&self.state.library);
                         self.render_pending = true;
                     }
                     ui.close();
@@ -919,6 +946,7 @@ impl eframe::App for NodeBoxApp {
             if let Some(previous) = self.history.undo(&self.state.library) {
                 self.state.library = previous;
                 self.previous_library_hash = Self::hash_library(&self.state.library);
+                self.previous_library = Arc::clone(&self.state.library);
                 self.render_pending = true;
             }
         }
@@ -926,6 +954,7 @@ impl eframe::App for NodeBoxApp {
             if let Some(next) = self.history.redo(&self.state.library) {
                 self.state.library = next;
                 self.previous_library_hash = Self::hash_library(&self.state.library);
+                self.previous_library = Arc::clone(&self.state.library);
                 self.render_pending = true;
             }
         }
@@ -945,8 +974,9 @@ impl eframe::App for NodeBoxApp {
         if !is_dragging && self.was_dragging {
             // Drag just ended — close the group (creates a single undo entry).
             self.history.end_undo_group(&self.state.library);
-            // Update hash so check_for_changes doesn't create a duplicate entry.
+            // Update hash and snapshot so check_for_changes doesn't create a duplicate entry.
             self.previous_library_hash = Self::hash_library(&self.state.library);
+            self.previous_library = Arc::clone(&self.state.library);
         }
         self.was_dragging = is_dragging;
 
@@ -1281,6 +1311,7 @@ mod tests {
 
         // Update the hash to match current state
         app.previous_library_hash = NodeBoxApp::hash_library(&app.state.library);
+        app.previous_library = Arc::clone(&app.state.library);
         app.render_pending = false;
 
         // Modify the width parameter (simulates what happens when user changes value in panel)
@@ -1360,6 +1391,7 @@ mod tests {
         );
         Arc::make_mut(&mut app.state.library).root.rendered_child = Some("rect1".to_string());
         app.previous_library_hash = NodeBoxApp::hash_library(&app.state.library);
+        app.previous_library = Arc::clone(&app.state.library);
 
         assert_eq!(app.history.undo_count(), 0);
 
@@ -1385,6 +1417,7 @@ mod tests {
         // Simulate drag end
         app.history.end_undo_group(&app.state.library);
         app.previous_library_hash = NodeBoxApp::hash_library(&app.state.library);
+        app.previous_library = Arc::clone(&app.state.library);
 
         // Exactly one undo entry should exist (the group)
         assert_eq!(app.history.undo_count(), 1, "Drag should create exactly one undo entry");
@@ -1405,6 +1438,7 @@ mod tests {
         );
         Arc::make_mut(&mut app.state.library).root.rendered_child = Some("rect1".to_string());
         app.previous_library_hash = NodeBoxApp::hash_library(&app.state.library);
+        app.previous_library = Arc::clone(&app.state.library);
 
         // Simulate drag: width goes from 100 → 200
         let pre_drag = Arc::clone(&app.state.library);
@@ -1451,6 +1485,7 @@ mod tests {
         );
         Arc::make_mut(&mut app.state.library).root.rendered_child = Some("rect1".to_string());
         app.previous_library_hash = NodeBoxApp::hash_library(&app.state.library);
+        app.previous_library = Arc::clone(&app.state.library);
 
         // Make two separate changes (not grouped)
         if let Some(node) = Arc::make_mut(&mut app.state.library).root.child_mut("rect1") {
@@ -1486,6 +1521,7 @@ mod tests {
         );
         Arc::make_mut(&mut app.state.library).root.rendered_child = Some("rect1".to_string());
         app.previous_library_hash = NodeBoxApp::hash_library(&app.state.library);
+        app.previous_library = Arc::clone(&app.state.library);
 
         // Drag operation
         let pre_drag = Arc::clone(&app.state.library);
@@ -1498,6 +1534,7 @@ mod tests {
         app.check_for_changes();
         app.history.end_undo_group(&app.state.library);
         app.previous_library_hash = NodeBoxApp::hash_library(&app.state.library);
+        app.previous_library = Arc::clone(&app.state.library);
 
         // Normal change after drag
         if let Some(node) = Arc::make_mut(&mut app.state.library).root.child_mut("rect1") {
@@ -1509,5 +1546,215 @@ mod tests {
 
         // Should have 2 entries: one from drag group + one from normal change
         assert_eq!(app.history.undo_count(), 2);
+    }
+
+    /// Test that a single change can be undone (not just counted).
+    /// This is the core bug: check_for_changes saved the post-mutation state,
+    /// so undoing returned the same state.
+    #[test]
+    fn test_single_change_undo_actually_restores_previous_state() {
+        let mut app = NodeBoxApp::new_for_testing_empty();
+
+        // Set up a rect with width=100
+        Arc::make_mut(&mut app.state.library).root.children.push(
+            Node::new("rect1")
+                .with_prototype("corevector.rect")
+                .with_input(Port::point("position", Point::ZERO))
+                .with_input(Port::float("width", 100.0))
+                .with_input(Port::float("height", 100.0)),
+        );
+        Arc::make_mut(&mut app.state.library).root.rendered_child = Some("rect1".to_string());
+        app.previous_library_hash = NodeBoxApp::hash_library(&app.state.library);
+        app.previous_library = Arc::clone(&app.state.library);
+
+        // Change width to 200
+        if let Some(node) = Arc::make_mut(&mut app.state.library).root.child_mut("rect1") {
+            if let Some(port) = node.input_mut("width") {
+                port.value = nodebox_core::Value::Float(200.0);
+            }
+        }
+        app.check_for_changes();
+
+        // Verify the change took effect
+        let width = app.state.library.root.child("rect1").unwrap()
+            .input("width").unwrap().value.as_float().unwrap();
+        assert!((width - 200.0).abs() < 0.001);
+
+        // Undo should restore width=100
+        if let Some(restored) = app.history.undo(&app.state.library) {
+            app.state.library = restored;
+        }
+        let restored_width = app.state.library.root.child("rect1").unwrap()
+            .input("width").unwrap().value.as_float().unwrap();
+        assert!((restored_width - 100.0).abs() < 0.001,
+            "Expected width=100 after undo, got {}", restored_width);
+    }
+
+    /// Test that creating a node can be undone.
+    #[test]
+    fn test_undo_node_creation() {
+        let mut app = NodeBoxApp::new_for_testing_empty();
+
+        let initial_count = app.state.library.root.children.len();
+
+        // Create a new node (simulates what the node dialog does)
+        Arc::make_mut(&mut app.state.library).root.children.push(
+            Node::new("rect1")
+                .with_prototype("corevector.rect")
+                .with_input(Port::point("position", Point::ZERO))
+                .with_input(Port::float("width", 100.0))
+                .with_input(Port::float("height", 100.0)),
+        );
+        app.check_for_changes();
+
+        assert_eq!(app.state.library.root.children.len(), initial_count + 1,
+            "Node should have been added");
+
+        // Undo should remove the node
+        if let Some(restored) = app.history.undo(&app.state.library) {
+            app.state.library = restored;
+        }
+        assert_eq!(app.state.library.root.children.len(), initial_count,
+            "Undo should remove the created node");
+    }
+
+    /// Test that connecting nodes can be undone.
+    #[test]
+    fn test_undo_connection() {
+        let mut app = NodeBoxApp::new_for_testing_empty();
+
+        // Set up two nodes
+        {
+            let lib = Arc::make_mut(&mut app.state.library);
+            lib.root.children.push(
+                Node::new("ellipse1")
+                    .with_prototype("corevector.ellipse")
+                    .with_input(Port::point("position", Point::ZERO))
+                    .with_input(Port::float("width", 100.0))
+                    .with_input(Port::float("height", 100.0)),
+            );
+            lib.root.children.push(
+                Node::new("colorize1")
+                    .with_prototype("corevector.colorize")
+                    .with_input(Port::geometry("shape")),
+            );
+        }
+        app.previous_library_hash = NodeBoxApp::hash_library(&app.state.library);
+        app.previous_library = Arc::clone(&app.state.library);
+
+        assert_eq!(app.state.library.root.connections.len(), 0);
+
+        // Connect them
+        Arc::make_mut(&mut app.state.library).root.connect(
+            nodebox_core::node::Connection::new("ellipse1", "colorize1", "shape")
+        );
+        app.check_for_changes();
+
+        assert_eq!(app.state.library.root.connections.len(), 1,
+            "Connection should exist");
+
+        // Undo should remove the connection
+        if let Some(restored) = app.history.undo(&app.state.library) {
+            app.state.library = restored;
+        }
+        assert_eq!(app.state.library.root.connections.len(), 0,
+            "Undo should remove the connection");
+    }
+
+    /// Test that setting the rendered node can be undone.
+    #[test]
+    fn test_undo_set_rendered_node() {
+        let mut app = NodeBoxApp::new_for_testing_empty();
+
+        // Set up two nodes with ellipse1 as rendered
+        {
+            let lib = Arc::make_mut(&mut app.state.library);
+            lib.root.children.push(
+                Node::new("ellipse1").with_prototype("corevector.ellipse"),
+            );
+            lib.root.children.push(
+                Node::new("rect1").with_prototype("corevector.rect"),
+            );
+            lib.root.rendered_child = Some("ellipse1".to_string());
+        }
+        app.previous_library_hash = NodeBoxApp::hash_library(&app.state.library);
+        app.previous_library = Arc::clone(&app.state.library);
+
+        // Change rendered to rect1
+        Arc::make_mut(&mut app.state.library).root.rendered_child = Some("rect1".to_string());
+        app.check_for_changes();
+
+        assert_eq!(app.state.library.root.rendered_child.as_deref(), Some("rect1"));
+
+        // Undo should restore rendered to ellipse1
+        if let Some(restored) = app.history.undo(&app.state.library) {
+            app.state.library = restored;
+        }
+        assert_eq!(app.state.library.root.rendered_child.as_deref(), Some("ellipse1"),
+            "Undo should restore the rendered node to ellipse1");
+    }
+
+    /// Test the exact user-reported scenario: set rendered node, drag node, then undo.
+    /// Should take exactly 2 undos (not 3 with an empty one).
+    #[test]
+    fn test_set_rendered_then_drag_undo_no_empty_steps() {
+        let mut app = NodeBoxApp::new_for_testing_empty();
+
+        // Set up two nodes with ellipse1 as rendered
+        {
+            let lib = Arc::make_mut(&mut app.state.library);
+            lib.root.children.push(
+                Node::new("ellipse1").with_prototype("corevector.ellipse")
+                    .with_input(Port::float("width", 100.0)),
+            );
+            lib.root.children.push(
+                Node::new("rect1").with_prototype("corevector.rect")
+                    .with_input(Port::float("width", 50.0)),
+            );
+            lib.root.rendered_child = Some("ellipse1".to_string());
+        }
+        app.previous_library_hash = NodeBoxApp::hash_library(&app.state.library);
+        app.previous_library = Arc::clone(&app.state.library);
+
+        // Operation 1: Set rendered to rect1
+        Arc::make_mut(&mut app.state.library).root.rendered_child = Some("rect1".to_string());
+        app.check_for_changes();
+
+        // Operation 2: Drag (change width from 50 to 200)
+        let pre_drag = Arc::clone(&app.state.library);
+        app.history.begin_undo_group(&pre_drag);
+        for i in 1..=5 {
+            if let Some(node) = Arc::make_mut(&mut app.state.library).root.child_mut("rect1") {
+                if let Some(port) = node.input_mut("width") {
+                    port.value = nodebox_core::Value::Float(50.0 + i as f64 * 30.0);
+                }
+            }
+            app.check_for_changes();
+        }
+        app.history.end_undo_group(&app.state.library);
+        app.previous_library_hash = NodeBoxApp::hash_library(&app.state.library);
+        app.previous_library = Arc::clone(&app.state.library);
+
+        // Should have exactly 2 undo entries (set rendered + drag)
+        assert_eq!(app.history.undo_count(), 2,
+            "Should have exactly 2 undo entries, not more");
+
+        // Undo #1: Should undo the drag (width back to 50)
+        if let Some(restored) = app.history.undo(&app.state.library) {
+            app.state.library = restored;
+        }
+        let width = app.state.library.root.child("rect1").unwrap()
+            .input("width").unwrap().value.as_float().unwrap();
+        assert!((width - 50.0).abs() < 0.001,
+            "First undo should restore width to 50, got {}", width);
+        assert_eq!(app.state.library.root.rendered_child.as_deref(), Some("rect1"),
+            "First undo should keep rendered=rect1");
+
+        // Undo #2: Should undo the rendered node change (back to ellipse1)
+        if let Some(restored) = app.history.undo(&app.state.library) {
+            app.state.library = restored;
+        }
+        assert_eq!(app.state.library.root.rendered_child.as_deref(), Some("ellipse1"),
+            "Second undo should restore rendered to ellipse1");
     }
 }

--- a/crates/nodebox-gui/src/app.rs
+++ b/crates/nodebox-gui/src/app.rs
@@ -53,6 +53,8 @@ pub struct NodeBoxApp {
     /// Pending connection to create after the node dialog selects a node.
     /// Stores (from_node_name, output_type) from a drag-to-empty-space action.
     pending_connection: Option<(String, PortType)>,
+    /// Whether any component was dragging in the previous frame (for undo group detection).
+    was_dragging: bool,
 }
 
 impl NodeBoxApp {
@@ -122,6 +124,7 @@ impl NodeBoxApp {
             native_menu,
             recent_files,
             pending_connection: None,
+            was_dragging: false,
         }
     }
 
@@ -203,6 +206,7 @@ impl NodeBoxApp {
             native_menu,
             recent_files,
             pending_connection: None,
+            was_dragging: false,
         }
     }
 
@@ -234,6 +238,7 @@ impl NodeBoxApp {
             native_menu: None,
             recent_files: RecentFiles::new(),
             pending_connection: None,
+            was_dragging: false,
         }
     }
 
@@ -266,6 +271,7 @@ impl NodeBoxApp {
             native_menu: None,
             recent_files: RecentFiles::new(),
             pending_connection: None,
+            was_dragging: false,
         }
     }
 
@@ -714,6 +720,10 @@ impl eframe::App for NodeBoxApp {
             ctx.request_repaint();
         }
 
+        // Capture pre-frame library state for undo group detection.
+        // This is a cheap Arc clone (just a pointer + refcount increment).
+        let pre_frame_library = Arc::clone(&self.state.library);
+
         // 4. Right side panel containing Parameters (top) and Network (bottom)
         //
         // Style the built-in separator: egui uses noninteractive.bg_stroke (normal),
@@ -919,6 +929,26 @@ impl eframe::App for NodeBoxApp {
                 self.render_pending = true;
             }
         }
+
+        // Detect drag transitions for undo grouping.
+        // When a drag starts, begin an undo group so all intermediate changes
+        // are collapsed into a single undo entry. When the drag ends, close the group.
+        let is_dragging = self.viewer_pane.is_dragging()
+            || self.network_view.is_dragging_nodes()
+            || self.parameters.is_dragging();
+
+        if is_dragging && !self.was_dragging {
+            // Drag just started — begin undo group with the pre-frame state
+            // (captured before any panel mutations this frame).
+            self.history.begin_undo_group(&pre_frame_library);
+        }
+        if !is_dragging && self.was_dragging {
+            // Drag just ended — close the group (creates a single undo entry).
+            self.history.end_undo_group(&self.state.library);
+            // Update hash so check_for_changes doesn't create a duplicate entry.
+            self.previous_library_hash = Self::hash_library(&self.state.library);
+        }
+        self.was_dragging = is_dragging;
 
         // Check for state changes and save to history
         self.check_for_changes();
@@ -1311,5 +1341,173 @@ mod tests {
             app.state.geometry, initial_geometry,
             "Geometry should update after parameter change"
         );
+    }
+
+    /// Test that a simulated drag gesture creates only a single undo entry.
+    /// This simulates the full drag lifecycle: begin group, mutate across multiple
+    /// frames (calling check_for_changes each time), end group.
+    #[test]
+    fn test_drag_creates_single_undo_entry() {
+        let mut app = NodeBoxApp::new_for_testing();
+
+        // Set up a node with a width parameter
+        Arc::make_mut(&mut app.state.library).root.children.push(
+            Node::new("rect1")
+                .with_prototype("corevector.rect")
+                .with_input(Port::point("position", Point::ZERO))
+                .with_input(Port::float("width", 100.0))
+                .with_input(Port::float("height", 100.0)),
+        );
+        Arc::make_mut(&mut app.state.library).root.rendered_child = Some("rect1".to_string());
+        app.previous_library_hash = NodeBoxApp::hash_library(&app.state.library);
+
+        assert_eq!(app.history.undo_count(), 0);
+
+        // Simulate drag start: capture pre-drag state
+        let pre_drag_library = Arc::clone(&app.state.library);
+        app.history.begin_undo_group(&pre_drag_library);
+
+        // Simulate 10 frames of dragging (each mutates the library)
+        for i in 1..=10 {
+            let new_width = 100.0 + (i as f64 * 10.0);
+            if let Some(node) = Arc::make_mut(&mut app.state.library).root.child_mut("rect1") {
+                if let Some(port) = node.input_mut("width") {
+                    port.value = nodebox_core::Value::Float(new_width);
+                }
+            }
+            // check_for_changes should NOT create undo entries during group
+            app.check_for_changes();
+        }
+
+        // During drag: no undo entries should have been created
+        assert_eq!(app.history.undo_count(), 0, "No undo entries during active group");
+
+        // Simulate drag end
+        app.history.end_undo_group(&app.state.library);
+        app.previous_library_hash = NodeBoxApp::hash_library(&app.state.library);
+
+        // Exactly one undo entry should exist (the group)
+        assert_eq!(app.history.undo_count(), 1, "Drag should create exactly one undo entry");
+    }
+
+    /// Test that undoing a drag restores the pre-drag state.
+    #[test]
+    fn test_drag_undo_restores_pre_drag_state() {
+        let mut app = NodeBoxApp::new_for_testing();
+
+        // Set up a node with width=100
+        Arc::make_mut(&mut app.state.library).root.children.push(
+            Node::new("rect1")
+                .with_prototype("corevector.rect")
+                .with_input(Port::point("position", Point::ZERO))
+                .with_input(Port::float("width", 100.0))
+                .with_input(Port::float("height", 100.0)),
+        );
+        Arc::make_mut(&mut app.state.library).root.rendered_child = Some("rect1".to_string());
+        app.previous_library_hash = NodeBoxApp::hash_library(&app.state.library);
+
+        // Simulate drag: width goes from 100 → 200
+        let pre_drag = Arc::clone(&app.state.library);
+        app.history.begin_undo_group(&pre_drag);
+
+        for i in 1..=10 {
+            let new_width = 100.0 + (i as f64 * 10.0);
+            if let Some(node) = Arc::make_mut(&mut app.state.library).root.child_mut("rect1") {
+                if let Some(port) = node.input_mut("width") {
+                    port.value = nodebox_core::Value::Float(new_width);
+                }
+            }
+            app.check_for_changes();
+        }
+
+        app.history.end_undo_group(&app.state.library);
+
+        // Current width should be 200
+        let current_width = app.state.library.root.child("rect1").unwrap()
+            .input("width").unwrap().value.as_float().unwrap();
+        assert!((current_width - 200.0).abs() < 0.001);
+
+        // Undo should restore to width=100
+        if let Some(restored) = app.history.undo(&app.state.library) {
+            app.state.library = restored;
+        }
+        let restored_width = app.state.library.root.child("rect1").unwrap()
+            .input("width").unwrap().value.as_float().unwrap();
+        assert!((restored_width - 100.0).abs() < 0.001,
+            "Expected width=100 after undo, got {}", restored_width);
+    }
+
+    /// Test that non-drag changes still create individual undo entries.
+    #[test]
+    fn test_non_drag_changes_still_create_undo_entries() {
+        let mut app = NodeBoxApp::new_for_testing();
+
+        Arc::make_mut(&mut app.state.library).root.children.push(
+            Node::new("rect1")
+                .with_prototype("corevector.rect")
+                .with_input(Port::point("position", Point::ZERO))
+                .with_input(Port::float("width", 100.0))
+                .with_input(Port::float("height", 100.0)),
+        );
+        Arc::make_mut(&mut app.state.library).root.rendered_child = Some("rect1".to_string());
+        app.previous_library_hash = NodeBoxApp::hash_library(&app.state.library);
+
+        // Make two separate changes (not grouped)
+        if let Some(node) = Arc::make_mut(&mut app.state.library).root.child_mut("rect1") {
+            if let Some(port) = node.input_mut("width") {
+                port.value = nodebox_core::Value::Float(150.0);
+            }
+        }
+        app.check_for_changes();
+
+        if let Some(node) = Arc::make_mut(&mut app.state.library).root.child_mut("rect1") {
+            if let Some(port) = node.input_mut("width") {
+                port.value = nodebox_core::Value::Float(200.0);
+            }
+        }
+        app.check_for_changes();
+
+        // Should have 2 separate undo entries
+        assert_eq!(app.history.undo_count(), 2,
+            "Non-drag changes should create separate undo entries");
+    }
+
+    /// Test that a drag followed by a normal change creates 2 undo entries.
+    #[test]
+    fn test_drag_then_normal_change() {
+        let mut app = NodeBoxApp::new_for_testing();
+
+        Arc::make_mut(&mut app.state.library).root.children.push(
+            Node::new("rect1")
+                .with_prototype("corevector.rect")
+                .with_input(Port::point("position", Point::ZERO))
+                .with_input(Port::float("width", 100.0))
+                .with_input(Port::float("height", 100.0)),
+        );
+        Arc::make_mut(&mut app.state.library).root.rendered_child = Some("rect1".to_string());
+        app.previous_library_hash = NodeBoxApp::hash_library(&app.state.library);
+
+        // Drag operation
+        let pre_drag = Arc::clone(&app.state.library);
+        app.history.begin_undo_group(&pre_drag);
+        if let Some(node) = Arc::make_mut(&mut app.state.library).root.child_mut("rect1") {
+            if let Some(port) = node.input_mut("width") {
+                port.value = nodebox_core::Value::Float(200.0);
+            }
+        }
+        app.check_for_changes();
+        app.history.end_undo_group(&app.state.library);
+        app.previous_library_hash = NodeBoxApp::hash_library(&app.state.library);
+
+        // Normal change after drag
+        if let Some(node) = Arc::make_mut(&mut app.state.library).root.child_mut("rect1") {
+            if let Some(port) = node.input_mut("height") {
+                port.value = nodebox_core::Value::Float(200.0);
+            }
+        }
+        app.check_for_changes();
+
+        // Should have 2 entries: one from drag group + one from normal change
+        assert_eq!(app.history.undo_count(), 2);
     }
 }

--- a/crates/nodebox-gui/src/app.rs
+++ b/crates/nodebox-gui/src/app.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use crate::address_bar::{AddressBar, AddressBarAction};
 use crate::animation_bar::{AnimationBar, AnimationEvent};
 use crate::components;
-use crate::history::History;
+use crate::history::{History, SelectionSnapshot};
 use crate::icon_cache::IconCache;
 use crate::native_menu::{MenuAction, NativeMenuHandle};
 use crate::notification_banner;
@@ -42,6 +42,8 @@ pub struct NodeBoxApp {
     previous_library_hash: u64,
     /// Snapshot of the library at end of last frame, used for undo (pre-mutation state).
     previous_library: Arc<nodebox_core::node::NodeLibrary>,
+    /// Snapshot of the selection at end of last frame, used for undo (pre-mutation state).
+    previous_selection: SelectionSnapshot,
     /// Background render worker.
     render_worker: RenderWorkerHandle,
     /// State tracking for render requests.
@@ -122,6 +124,7 @@ impl NodeBoxApp {
             history: History::new(),
             previous_library_hash: hash,
             previous_library: prev_library,
+            previous_selection: SelectionSnapshot::default(),
             render_worker: RenderWorkerHandle::spawn(),
             render_state: RenderState::new(),
             render_pending: true,
@@ -206,6 +209,7 @@ impl NodeBoxApp {
             history: History::new(),
             previous_library_hash: hash,
             previous_library: prev_library,
+            previous_selection: SelectionSnapshot::default(),
             render_worker: RenderWorkerHandle::spawn(),
             render_state: RenderState::new(),
             render_pending: true,
@@ -240,6 +244,7 @@ impl NodeBoxApp {
             history: History::new(),
             previous_library_hash: hash,
             previous_library: prev_library,
+            previous_selection: SelectionSnapshot::default(),
             render_worker: RenderWorkerHandle::spawn(),
             render_state: RenderState::new(),
             render_pending: false,
@@ -275,6 +280,7 @@ impl NodeBoxApp {
             history: History::new(),
             previous_library_hash: hash,
             previous_library: prev_library,
+            previous_selection: SelectionSnapshot::default(),
             render_worker: RenderWorkerHandle::spawn(),
             render_state: RenderState::new(),
             render_pending: false,
@@ -354,10 +360,11 @@ impl NodeBoxApp {
         // Check for changes and save to history (using previous_library for correct undo)
         let current_hash = Self::hash_library(&self.state.library);
         if current_hash != self.previous_library_hash {
-            self.history.save_state(&self.previous_library);
+            self.history.save_state(&self.previous_library, &self.previous_selection);
             self.previous_library_hash = current_hash;
             if !self.history.is_in_group() {
                 self.previous_library = Arc::clone(&self.state.library);
+                self.previous_selection = self.current_selection();
             }
             self.state.dirty = true;
         }
@@ -462,6 +469,29 @@ impl NodeBoxApp {
         }
     }
 
+    /// Build a snapshot of the current selection state.
+    fn current_selection(&self) -> SelectionSnapshot {
+        SelectionSnapshot {
+            selected_nodes: self.network_view.selected_nodes().clone(),
+            selected_node: self.state.selected_node.clone(),
+        }
+    }
+
+    /// Apply a restored selection snapshot, validating that referenced nodes
+    /// still exist in the current library (prunes stale names).
+    fn apply_selection(&mut self, snapshot: SelectionSnapshot) {
+        let valid_selected: std::collections::HashSet<String> = snapshot
+            .selected_nodes
+            .into_iter()
+            .filter(|name| self.state.library.root.child(name).is_some())
+            .collect();
+        let valid_selected_node = snapshot
+            .selected_node
+            .filter(|name| self.state.library.root.child(name).is_some());
+        self.network_view.set_selected(valid_selected);
+        self.state.selected_node = valid_selected_node;
+    }
+
     /// Check for changes and save to history, queue render if needed.
     ///
     /// Saves the *previous* library state (from before this frame's mutations)
@@ -469,14 +499,15 @@ impl NodeBoxApp {
     fn check_for_changes(&mut self) {
         let current_hash = Self::hash_library(&self.state.library);
         if current_hash != self.previous_library_hash {
-            self.history.save_state(&self.previous_library);
+            self.history.save_state(&self.previous_library, &self.previous_selection);
             self.previous_library_hash = current_hash;
-            // Only update previous_library when not in an undo group.
+            // Only update previous_library/selection when not in an undo group.
             // During a group, the group_start_state tracks the pre-drag snapshot
-            // and previous_library must stay frozen so that the next non-grouped
+            // and previous state must stay frozen so that the next non-grouped
             // change still records the correct pre-mutation state.
             if !self.history.is_in_group() {
                 self.previous_library = Arc::clone(&self.state.library);
+                self.previous_selection = self.current_selection();
             }
             self.state.dirty = true;
             self.render_pending = true; // Queue async render
@@ -495,18 +526,24 @@ impl NodeBoxApp {
             MenuAction::ExportPng => self.export_png(),
             MenuAction::ExportSvg => self.export_svg(),
             MenuAction::Undo => {
-                if let Some(previous) = self.history.undo(&self.state.library) {
+                let sel = self.current_selection();
+                if let Some((previous, prev_sel)) = self.history.undo(&self.state.library, &sel) {
                     self.state.library = previous;
                     self.previous_library_hash = Self::hash_library(&self.state.library);
                     self.previous_library = Arc::clone(&self.state.library);
+                    self.apply_selection(prev_sel);
+                    self.previous_selection = self.current_selection();
                     self.render_pending = true;
                 }
             }
             MenuAction::Redo => {
-                if let Some(next) = self.history.redo(&self.state.library) {
+                let sel = self.current_selection();
+                if let Some((next, next_sel)) = self.history.redo(&self.state.library, &sel) {
                     self.state.library = next;
                     self.previous_library_hash = Self::hash_library(&self.state.library);
                     self.previous_library = Arc::clone(&self.state.library);
+                    self.apply_selection(next_sel);
+                    self.previous_selection = self.current_selection();
                     self.render_pending = true;
                 }
             }
@@ -593,10 +630,13 @@ impl NodeBoxApp {
                     "Undo".to_string()
                 };
                 if ui.add_enabled(self.history.can_undo(), egui::Button::new(undo_text)).clicked() {
-                    if let Some(previous) = self.history.undo(&self.state.library) {
+                    let sel = self.current_selection();
+                    if let Some((previous, prev_sel)) = self.history.undo(&self.state.library, &sel) {
                         self.state.library = previous;
                         self.previous_library_hash = Self::hash_library(&self.state.library);
                         self.previous_library = Arc::clone(&self.state.library);
+                        self.apply_selection(prev_sel);
+                        self.previous_selection = self.current_selection();
                         self.render_pending = true;
                     }
                     ui.close();
@@ -607,10 +647,13 @@ impl NodeBoxApp {
                     "Redo".to_string()
                 };
                 if ui.add_enabled(self.history.can_redo(), egui::Button::new(redo_text)).clicked() {
-                    if let Some(next) = self.history.redo(&self.state.library) {
+                    let sel = self.current_selection();
+                    if let Some((next, next_sel)) = self.history.redo(&self.state.library, &sel) {
                         self.state.library = next;
                         self.previous_library_hash = Self::hash_library(&self.state.library);
                         self.previous_library = Arc::clone(&self.state.library);
+                        self.apply_selection(next_sel);
+                        self.previous_selection = self.current_selection();
                         self.render_pending = true;
                     }
                     ui.close();
@@ -747,9 +790,10 @@ impl eframe::App for NodeBoxApp {
             ctx.request_repaint();
         }
 
-        // Capture pre-frame library state for undo group detection.
-        // This is a cheap Arc clone (just a pointer + refcount increment).
+        // Capture pre-frame library state and selection for undo group detection.
+        // These are cheap clones (Arc pointer + small HashSet).
         let pre_frame_library = Arc::clone(&self.state.library);
+        let pre_frame_selection = self.current_selection();
 
         // 4. Right side panel containing Parameters (top) and Network (bottom)
         //
@@ -943,18 +987,24 @@ impl eframe::App for NodeBoxApp {
         }
 
         if do_undo {
-            if let Some(previous) = self.history.undo(&self.state.library) {
+            let sel = self.current_selection();
+            if let Some((previous, prev_sel)) = self.history.undo(&self.state.library, &sel) {
                 self.state.library = previous;
                 self.previous_library_hash = Self::hash_library(&self.state.library);
                 self.previous_library = Arc::clone(&self.state.library);
+                self.apply_selection(prev_sel);
+                self.previous_selection = self.current_selection();
                 self.render_pending = true;
             }
         }
         if do_redo {
-            if let Some(next) = self.history.redo(&self.state.library) {
+            let sel = self.current_selection();
+            if let Some((next, next_sel)) = self.history.redo(&self.state.library, &sel) {
                 self.state.library = next;
                 self.previous_library_hash = Self::hash_library(&self.state.library);
                 self.previous_library = Arc::clone(&self.state.library);
+                self.apply_selection(next_sel);
+                self.previous_selection = self.current_selection();
                 self.render_pending = true;
             }
         }
@@ -969,7 +1019,7 @@ impl eframe::App for NodeBoxApp {
         if is_dragging && !self.was_dragging {
             // Drag just started — begin undo group with the pre-frame state
             // (captured before any panel mutations this frame).
-            self.history.begin_undo_group(&pre_frame_library);
+            self.history.begin_undo_group(&pre_frame_library, &pre_frame_selection);
         }
         if !is_dragging && self.was_dragging {
             // Drag just ended — close the group (creates a single undo entry).
@@ -977,6 +1027,7 @@ impl eframe::App for NodeBoxApp {
             // Update hash and snapshot so check_for_changes doesn't create a duplicate entry.
             self.previous_library_hash = Self::hash_library(&self.state.library);
             self.previous_library = Arc::clone(&self.state.library);
+            self.previous_selection = self.current_selection();
         }
         self.was_dragging = is_dragging;
 
@@ -1397,7 +1448,8 @@ mod tests {
 
         // Simulate drag start: capture pre-drag state
         let pre_drag_library = Arc::clone(&app.state.library);
-        app.history.begin_undo_group(&pre_drag_library);
+        let sel = SelectionSnapshot::default();
+        app.history.begin_undo_group(&pre_drag_library, &sel);
 
         // Simulate 10 frames of dragging (each mutates the library)
         for i in 1..=10 {
@@ -1442,7 +1494,8 @@ mod tests {
 
         // Simulate drag: width goes from 100 → 200
         let pre_drag = Arc::clone(&app.state.library);
-        app.history.begin_undo_group(&pre_drag);
+        let sel = SelectionSnapshot::default();
+        app.history.begin_undo_group(&pre_drag, &sel);
 
         for i in 1..=10 {
             let new_width = 100.0 + (i as f64 * 10.0);
@@ -1462,7 +1515,8 @@ mod tests {
         assert!((current_width - 200.0).abs() < 0.001);
 
         // Undo should restore to width=100
-        if let Some(restored) = app.history.undo(&app.state.library) {
+        let sel = SelectionSnapshot::default();
+        if let Some((restored, _)) = app.history.undo(&app.state.library, &sel) {
             app.state.library = restored;
         }
         let restored_width = app.state.library.root.child("rect1").unwrap()
@@ -1525,7 +1579,8 @@ mod tests {
 
         // Drag operation
         let pre_drag = Arc::clone(&app.state.library);
-        app.history.begin_undo_group(&pre_drag);
+        let sel = SelectionSnapshot::default();
+        app.history.begin_undo_group(&pre_drag, &sel);
         if let Some(node) = Arc::make_mut(&mut app.state.library).root.child_mut("rect1") {
             if let Some(port) = node.input_mut("width") {
                 port.value = nodebox_core::Value::Float(200.0);
@@ -1581,8 +1636,11 @@ mod tests {
         assert!((width - 200.0).abs() < 0.001);
 
         // Undo should restore width=100
-        if let Some(restored) = app.history.undo(&app.state.library) {
-            app.state.library = restored;
+        {
+            let sel = SelectionSnapshot::default();
+            if let Some((restored, _)) = app.history.undo(&app.state.library, &sel) {
+                app.state.library = restored;
+            }
         }
         let restored_width = app.state.library.root.child("rect1").unwrap()
             .input("width").unwrap().value.as_float().unwrap();
@@ -1611,8 +1669,11 @@ mod tests {
             "Node should have been added");
 
         // Undo should remove the node
-        if let Some(restored) = app.history.undo(&app.state.library) {
-            app.state.library = restored;
+        {
+            let sel = SelectionSnapshot::default();
+            if let Some((restored, _)) = app.history.undo(&app.state.library, &sel) {
+                app.state.library = restored;
+            }
         }
         assert_eq!(app.state.library.root.children.len(), initial_count,
             "Undo should remove the created node");
@@ -1654,8 +1715,11 @@ mod tests {
             "Connection should exist");
 
         // Undo should remove the connection
-        if let Some(restored) = app.history.undo(&app.state.library) {
-            app.state.library = restored;
+        {
+            let sel = SelectionSnapshot::default();
+            if let Some((restored, _)) = app.history.undo(&app.state.library, &sel) {
+                app.state.library = restored;
+            }
         }
         assert_eq!(app.state.library.root.connections.len(), 0,
             "Undo should remove the connection");
@@ -1687,8 +1751,11 @@ mod tests {
         assert_eq!(app.state.library.root.rendered_child.as_deref(), Some("rect1"));
 
         // Undo should restore rendered to ellipse1
-        if let Some(restored) = app.history.undo(&app.state.library) {
-            app.state.library = restored;
+        {
+            let sel = SelectionSnapshot::default();
+            if let Some((restored, _)) = app.history.undo(&app.state.library, &sel) {
+                app.state.library = restored;
+            }
         }
         assert_eq!(app.state.library.root.rendered_child.as_deref(), Some("ellipse1"),
             "Undo should restore the rendered node to ellipse1");
@@ -1722,7 +1789,8 @@ mod tests {
 
         // Operation 2: Drag (change width from 50 to 200)
         let pre_drag = Arc::clone(&app.state.library);
-        app.history.begin_undo_group(&pre_drag);
+        let sel = SelectionSnapshot::default();
+        app.history.begin_undo_group(&pre_drag, &sel);
         for i in 1..=5 {
             if let Some(node) = Arc::make_mut(&mut app.state.library).root.child_mut("rect1") {
                 if let Some(port) = node.input_mut("width") {
@@ -1740,8 +1808,11 @@ mod tests {
             "Should have exactly 2 undo entries, not more");
 
         // Undo #1: Should undo the drag (width back to 50)
-        if let Some(restored) = app.history.undo(&app.state.library) {
-            app.state.library = restored;
+        {
+            let sel = SelectionSnapshot::default();
+            if let Some((restored, _)) = app.history.undo(&app.state.library, &sel) {
+                app.state.library = restored;
+            }
         }
         let width = app.state.library.root.child("rect1").unwrap()
             .input("width").unwrap().value.as_float().unwrap();
@@ -1751,10 +1822,127 @@ mod tests {
             "First undo should keep rendered=rect1");
 
         // Undo #2: Should undo the rendered node change (back to ellipse1)
-        if let Some(restored) = app.history.undo(&app.state.library) {
-            app.state.library = restored;
+        {
+            let sel = SelectionSnapshot::default();
+            if let Some((restored, _)) = app.history.undo(&app.state.library, &sel) {
+                app.state.library = restored;
+            }
         }
         assert_eq!(app.state.library.root.rendered_child.as_deref(), Some("ellipse1"),
             "Second undo should restore rendered to ellipse1");
+    }
+
+    /// Test that undoing node creation clears the selection.
+    /// When a node is created and selected, undoing should clear the selection
+    /// because the node no longer exists.
+    #[test]
+    fn test_undo_node_creation_clears_selection() {
+        let mut app = NodeBoxApp::new_for_testing_empty();
+
+        // Create a new node and select it
+        Arc::make_mut(&mut app.state.library).root.children.push(
+            Node::new("ellipse1")
+                .with_prototype("corevector.ellipse")
+                .with_input(Port::float("width", 100.0)),
+        );
+        app.state.selected_node = Some("ellipse1".to_string());
+        app.network_view.set_selected(["ellipse1".to_string()].into_iter().collect());
+        app.check_for_changes();
+
+        assert_eq!(app.state.selected_node.as_deref(), Some("ellipse1"));
+        assert!(app.network_view.selected_nodes().contains("ellipse1"));
+
+        // Undo: node is removed, selection should be cleared
+        let sel = app.current_selection();
+        if let Some((restored, restored_sel)) = app.history.undo(&app.state.library, &sel) {
+            app.state.library = restored;
+            app.apply_selection(restored_sel);
+        }
+
+        assert_eq!(app.state.selected_node, None,
+            "Selection should be cleared after undoing node creation");
+        assert!(app.network_view.selected_nodes().is_empty(),
+            "Network view selection should be empty after undoing node creation");
+    }
+
+    /// Test that undoing restores the previous selection.
+    /// If node A was selected, then node B was created and selected,
+    /// undoing should restore node A as selected.
+    #[test]
+    fn test_undo_restores_previous_selection() {
+        let mut app = NodeBoxApp::new_for_testing_empty();
+
+        // Start with node A
+        Arc::make_mut(&mut app.state.library).root.children.push(
+            Node::new("rect1")
+                .with_prototype("corevector.rect")
+                .with_input(Port::float("width", 100.0)),
+        );
+        app.state.selected_node = Some("rect1".to_string());
+        app.network_view.set_selected(["rect1".to_string()].into_iter().collect());
+        app.previous_library_hash = NodeBoxApp::hash_library(&app.state.library);
+        app.previous_library = Arc::clone(&app.state.library);
+        app.previous_selection = app.current_selection();
+
+        // Create node B and select it
+        Arc::make_mut(&mut app.state.library).root.children.push(
+            Node::new("ellipse1")
+                .with_prototype("corevector.ellipse")
+                .with_input(Port::float("width", 100.0)),
+        );
+        app.state.selected_node = Some("ellipse1".to_string());
+        app.network_view.set_selected(["ellipse1".to_string()].into_iter().collect());
+        app.check_for_changes();
+
+        assert_eq!(app.state.selected_node.as_deref(), Some("ellipse1"));
+
+        // Undo: node B removed, selection should restore to rect1
+        let sel = app.current_selection();
+        if let Some((restored, restored_sel)) = app.history.undo(&app.state.library, &sel) {
+            app.state.library = restored;
+            app.apply_selection(restored_sel);
+        }
+
+        assert_eq!(app.state.selected_node.as_deref(), Some("rect1"),
+            "Undo should restore previous selection to rect1");
+        assert!(app.network_view.selected_nodes().contains("rect1"),
+            "Network view should show rect1 selected after undo");
+    }
+
+    /// Test that redo restores the selection from before the undo.
+    #[test]
+    fn test_redo_restores_selection() {
+        let mut app = NodeBoxApp::new_for_testing_empty();
+
+        // Create node and select it
+        Arc::make_mut(&mut app.state.library).root.children.push(
+            Node::new("ellipse1")
+                .with_prototype("corevector.ellipse")
+                .with_input(Port::float("width", 100.0)),
+        );
+        app.state.selected_node = Some("ellipse1".to_string());
+        app.network_view.set_selected(["ellipse1".to_string()].into_iter().collect());
+        app.check_for_changes();
+
+        // Undo: removes node, clears selection
+        let sel = app.current_selection();
+        if let Some((restored, restored_sel)) = app.history.undo(&app.state.library, &sel) {
+            app.state.library = restored;
+            app.apply_selection(restored_sel);
+        }
+
+        assert_eq!(app.state.selected_node, None);
+
+        // Redo: restores node and selection
+        let sel = app.current_selection();
+        if let Some((restored, restored_sel)) = app.history.redo(&app.state.library, &sel) {
+            app.state.library = restored;
+            app.apply_selection(restored_sel);
+        }
+
+        assert_eq!(app.state.selected_node.as_deref(), Some("ellipse1"),
+            "Redo should restore selection to ellipse1");
+        assert!(app.network_view.selected_nodes().contains("ellipse1"),
+            "Network view should show ellipse1 selected after redo");
     }
 }

--- a/crates/nodebox-gui/src/history.rs
+++ b/crates/nodebox-gui/src/history.rs
@@ -15,6 +15,9 @@ pub struct History {
     /// The last saved state (to track changes).
     #[allow(dead_code)]
     last_saved_state: Option<Arc<NodeLibrary>>,
+    /// When set, an undo group is active: `save_state` calls are suppressed
+    /// and the stored state will be pushed as a single undo entry on `end_undo_group`.
+    group_start_state: Option<Arc<NodeLibrary>>,
 }
 
 impl Default for History {
@@ -30,6 +33,7 @@ impl History {
             undo_stack: Vec::new(),
             redo_stack: Vec::new(),
             last_saved_state: None,
+            group_start_state: None,
         }
     }
 
@@ -45,7 +49,14 @@ impl History {
 
     /// Save the current state before making changes.
     /// Call this BEFORE modifying the library.
+    ///
+    /// If an undo group is active (between `begin_undo_group` and `end_undo_group`),
+    /// this call is suppressed — the group will create a single undo entry on end.
     pub fn save_state(&mut self, library: &Arc<NodeLibrary>) {
+        if self.group_start_state.is_some() {
+            return;
+        }
+
         self.undo_stack.push(Arc::clone(library));
 
         // Clear redo stack when new changes are made
@@ -55,6 +66,37 @@ impl History {
         while self.undo_stack.len() > MAX_HISTORY {
             self.undo_stack.remove(0);
         }
+    }
+
+    /// Begin an undo group. All `save_state` calls between `begin_undo_group` and
+    /// `end_undo_group` are suppressed. When the group ends, a single undo entry
+    /// is created that restores the state from before the group started.
+    ///
+    /// If a group is already active, this call is ignored (the first begin wins).
+    pub fn begin_undo_group(&mut self, library: &Arc<NodeLibrary>) {
+        if self.group_start_state.is_none() {
+            self.group_start_state = Some(Arc::clone(library));
+        }
+    }
+
+    /// End an undo group. Pushes the pre-group state as a single undo entry.
+    /// If no group is active, this is a no-op. If the state hasn't changed
+    /// since the group started, no undo entry is created.
+    pub fn end_undo_group(&mut self, current: &Arc<NodeLibrary>) {
+        if let Some(start_state) = self.group_start_state.take() {
+            if start_state.as_ref() != current.as_ref() {
+                self.undo_stack.push(start_state);
+                self.redo_stack.clear();
+                while self.undo_stack.len() > MAX_HISTORY {
+                    self.undo_stack.remove(0);
+                }
+            }
+        }
+    }
+
+    /// Check if an undo group is currently active.
+    pub fn is_in_group(&self) -> bool {
+        self.group_start_state.is_some()
     }
 
     /// Undo the last change, returning the previous state.

--- a/crates/nodebox-gui/src/history.rs
+++ b/crates/nodebox-gui/src/history.rs
@@ -1,23 +1,33 @@
 //! Undo/redo history management.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 use nodebox_core::node::NodeLibrary;
 
 /// Maximum number of undo states to keep.
 const MAX_HISTORY: usize = 50;
 
+/// A snapshot of the selection state at a point in time.
+#[derive(Clone, Debug, Default)]
+pub struct SelectionSnapshot {
+    /// Names of selected nodes in the network view.
+    pub selected_nodes: HashSet<String>,
+    /// The single "active" selected node (shown in parameter panel).
+    pub selected_node: Option<String>,
+}
+
 /// The undo/redo history manager.
 pub struct History {
     /// Past states (undo stack).
-    undo_stack: Vec<Arc<NodeLibrary>>,
+    undo_stack: Vec<(Arc<NodeLibrary>, SelectionSnapshot)>,
     /// Future states (redo stack).
-    redo_stack: Vec<Arc<NodeLibrary>>,
+    redo_stack: Vec<(Arc<NodeLibrary>, SelectionSnapshot)>,
     /// The last saved state (to track changes).
     #[allow(dead_code)]
     last_saved_state: Option<Arc<NodeLibrary>>,
     /// When set, an undo group is active: `save_state` calls are suppressed
     /// and the stored state will be pushed as a single undo entry on `end_undo_group`.
-    group_start_state: Option<Arc<NodeLibrary>>,
+    group_start_state: Option<(Arc<NodeLibrary>, SelectionSnapshot)>,
 }
 
 impl Default for History {
@@ -52,12 +62,12 @@ impl History {
     ///
     /// If an undo group is active (between `begin_undo_group` and `end_undo_group`),
     /// this call is suppressed — the group will create a single undo entry on end.
-    pub fn save_state(&mut self, library: &Arc<NodeLibrary>) {
+    pub fn save_state(&mut self, library: &Arc<NodeLibrary>, selection: &SelectionSnapshot) {
         if self.group_start_state.is_some() {
             return;
         }
 
-        self.undo_stack.push(Arc::clone(library));
+        self.undo_stack.push((Arc::clone(library), selection.clone()));
 
         // Clear redo stack when new changes are made
         self.redo_stack.clear();
@@ -73,9 +83,9 @@ impl History {
     /// is created that restores the state from before the group started.
     ///
     /// If a group is already active, this call is ignored (the first begin wins).
-    pub fn begin_undo_group(&mut self, library: &Arc<NodeLibrary>) {
+    pub fn begin_undo_group(&mut self, library: &Arc<NodeLibrary>, selection: &SelectionSnapshot) {
         if self.group_start_state.is_none() {
-            self.group_start_state = Some(Arc::clone(library));
+            self.group_start_state = Some((Arc::clone(library), selection.clone()));
         }
     }
 
@@ -83,9 +93,9 @@ impl History {
     /// If no group is active, this is a no-op. If the state hasn't changed
     /// since the group started, no undo entry is created.
     pub fn end_undo_group(&mut self, current: &Arc<NodeLibrary>) {
-        if let Some(start_state) = self.group_start_state.take() {
-            if start_state.as_ref() != current.as_ref() {
-                self.undo_stack.push(start_state);
+        if let Some((start_lib, start_sel)) = self.group_start_state.take() {
+            if start_lib.as_ref() != current.as_ref() {
+                self.undo_stack.push((start_lib, start_sel));
                 self.redo_stack.clear();
                 while self.undo_stack.len() > MAX_HISTORY {
                     self.undo_stack.remove(0);
@@ -99,24 +109,32 @@ impl History {
         self.group_start_state.is_some()
     }
 
-    /// Undo the last change, returning the previous state.
+    /// Undo the last change, returning the previous state and selection.
     /// Call this to restore the library to its previous state.
-    pub fn undo(&mut self, current: &Arc<NodeLibrary>) -> Option<Arc<NodeLibrary>> {
-        if let Some(previous) = self.undo_stack.pop() {
+    pub fn undo(
+        &mut self,
+        current: &Arc<NodeLibrary>,
+        current_selection: &SelectionSnapshot,
+    ) -> Option<(Arc<NodeLibrary>, SelectionSnapshot)> {
+        if let Some((previous_lib, previous_sel)) = self.undo_stack.pop() {
             // Save current state for redo
-            self.redo_stack.push(Arc::clone(current));
-            Some(previous)
+            self.redo_stack.push((Arc::clone(current), current_selection.clone()));
+            Some((previous_lib, previous_sel))
         } else {
             None
         }
     }
 
-    /// Redo the last undone change, returning the restored state.
-    pub fn redo(&mut self, current: &Arc<NodeLibrary>) -> Option<Arc<NodeLibrary>> {
-        if let Some(next) = self.redo_stack.pop() {
+    /// Redo the last undone change, returning the restored state and selection.
+    pub fn redo(
+        &mut self,
+        current: &Arc<NodeLibrary>,
+        current_selection: &SelectionSnapshot,
+    ) -> Option<(Arc<NodeLibrary>, SelectionSnapshot)> {
+        if let Some((next_lib, next_sel)) = self.redo_stack.pop() {
             // Save current state for undo
-            self.undo_stack.push(Arc::clone(current));
-            Some(next)
+            self.undo_stack.push((Arc::clone(current), current_selection.clone()));
+            Some((next_lib, next_sel))
         } else {
             None
         }

--- a/crates/nodebox-gui/src/lib.rs
+++ b/crates/nodebox-gui/src/lib.rs
@@ -51,7 +51,7 @@ pub mod vello_viewer;
 
 // Re-export key types for testing and external use
 pub use app::NodeBoxApp;
-pub use history::History;
+pub use history::{History, SelectionSnapshot};
 pub use state::{populate_default_ports, AppState, Notification, NotificationLevel};
 
 // Re-export commonly used types from dependencies

--- a/crates/nodebox-gui/src/network_view.rs
+++ b/crates/nodebox-gui/src/network_view.rs
@@ -122,6 +122,11 @@ impl NetworkView {
         }
     }
 
+    /// Whether the user is currently dragging selected nodes.
+    pub fn is_dragging_nodes(&self) -> bool {
+        self.is_dragging_selection
+    }
+
     /// Get the currently selected nodes.
     pub fn selected_nodes(&self) -> &HashSet<String> {
         &self.selected

--- a/crates/nodebox-gui/src/network_view.rs
+++ b/crates/nodebox-gui/src/network_view.rs
@@ -132,6 +132,11 @@ impl NetworkView {
         &self.selected
     }
 
+    /// Set the selected nodes (used by undo/redo to restore selection).
+    pub fn set_selected(&mut self, names: HashSet<String>) {
+        self.selected = names;
+    }
+
     /// Clone all selected nodes and their internal/incoming connections.
     /// Updates `self.selected` to point to the new clones.
     fn perform_alt_copy(&mut self, library: &mut Arc<NodeLibrary>) {

--- a/crates/nodebox-gui/src/parameter_panel.rs
+++ b/crates/nodebox-gui/src/parameter_panel.rs
@@ -74,6 +74,15 @@ impl ParameterPanel {
         // Zero spacing so header sits flush against content
         ui.style_mut().spacing.item_spacing = egui::vec2(0.0, 0.0);
 
+        // Validate that the selected node still exists (e.g., after undo).
+        // If not, clear the stale selection to avoid "not found" errors
+        // and a double PARAMETERS header render.
+        if let Some(ref name) = state.selected_node {
+            if state.library.root.child(name).is_none() {
+                state.selected_node = None;
+            }
+        }
+
         if let Some(ref node_name) = state.selected_node.clone() {
             // First, collect connected ports while we only have immutable borrow
             let connected_ports: std::collections::HashSet<String> = state

--- a/crates/nodebox-gui/src/parameter_panel.rs
+++ b/crates/nodebox-gui/src/parameter_panel.rs
@@ -27,6 +27,8 @@ pub struct ParameterPanel {
     label_edit_committed_value: Option<f64>,
     /// Accumulates sub-pixel drag deltas so that default (non-Alt) drags snap to integers.
     drag_accumulator: f64,
+    /// Whether the user is currently dragging a parameter label or drag-value widget.
+    is_dragging: bool,
 }
 
 impl Default for ParameterPanel {
@@ -47,7 +49,13 @@ impl ParameterPanel {
             label_edit_apply_both: false,
             label_edit_committed_value: None,
             drag_accumulator: 0.0,
+            is_dragging: false,
         }
+    }
+
+    /// Whether the user is currently dragging a parameter label or drag-value widget.
+    pub fn is_dragging(&self) -> bool {
+        self.is_dragging
     }
 
     /// Show the parameter panel.
@@ -58,6 +66,11 @@ impl ParameterPanel {
         port: &dyn Port,
         project_context: &ProjectContext,
     ) {
+        // Clear drag state when the primary button is released
+        if self.is_dragging && ui.input(|i| !i.pointer.primary_down()) {
+            self.is_dragging = false;
+        }
+
         // Zero spacing so header sits flush against content
         ui.style_mut().spacing.item_spacing = egui::vec2(0.0, 0.0);
 
@@ -314,6 +327,7 @@ impl ParameterPanel {
                     }
                     if response.drag_started() {
                         drag_started = true;
+                        self.is_dragging = true;
                     }
                     if response.dragged() {
                         drag_delta_x = response.drag_delta().x;
@@ -930,6 +944,7 @@ impl ParameterPanel {
 
             if response.drag_started() {
                 self.drag_accumulator = 0.0;
+                self.is_dragging = true;
             }
             if response.dragged() {
                 let modifier = Self::drag_modifier(ui);
@@ -1079,6 +1094,7 @@ impl ParameterPanel {
 
             if response.drag_started() {
                 self.drag_accumulator = 0.0;
+                self.is_dragging = true;
             }
             if response.dragged() {
                 let modifier = Self::drag_modifier(ui);

--- a/crates/nodebox-gui/src/viewer_pane.rs
+++ b/crates/nodebox-gui/src/viewer_pane.rs
@@ -273,6 +273,12 @@ impl ViewerPane {
         }
     }
 
+    /// Whether the user is currently dragging a handle in the viewer.
+    pub fn is_dragging(&self) -> bool {
+        self.dragging_handle.is_some()
+            || self.four_point_handle.as_ref().is_some_and(|fp| fp.is_dragging())
+    }
+
     /// Get the current pan offset.
     #[allow(dead_code)]
     pub fn pan(&self) -> Vec2 {

--- a/crates/nodebox-gui/tests/history_tests.rs
+++ b/crates/nodebox-gui/tests/history_tests.rs
@@ -3,7 +3,7 @@
 mod common;
 
 use std::sync::Arc;
-use nodebox_gui::{History, Node, NodeLibrary, Port};
+use nodebox_gui::{History, SelectionSnapshot, Node, NodeLibrary, Port};
 
 /// Create a simple test library with an ellipse.
 fn create_test_library(x: f64) -> Arc<NodeLibrary> {
@@ -21,6 +21,10 @@ fn create_test_library(x: f64) -> Arc<NodeLibrary> {
     Arc::new(library)
 }
 
+fn default_sel() -> SelectionSnapshot {
+    SelectionSnapshot::default()
+}
+
 #[test]
 fn test_history_new_is_empty() {
     let history = History::new();
@@ -35,7 +39,7 @@ fn test_history_save_enables_undo() {
     let mut history = History::new();
     let library = create_test_library(0.0);
 
-    history.save_state(&library);
+    history.save_state(&library, &default_sel());
 
     assert!(history.can_undo());
     assert!(!history.can_redo());
@@ -48,13 +52,13 @@ fn test_history_undo_restores_previous_state() {
 
     // Save initial state
     let library_v1 = create_test_library(0.0);
-    history.save_state(&library_v1);
+    history.save_state(&library_v1, &default_sel());
 
     // Current state has different x value
     let library_v2 = create_test_library(100.0);
 
     // Undo should restore v1
-    let restored = history.undo(&library_v2).unwrap();
+    let (restored, _) = history.undo(&library_v2, &default_sel()).unwrap();
 
     // Check that the x value was restored
     let node = restored.root.child("ellipse1").unwrap();
@@ -67,10 +71,10 @@ fn test_history_undo_enables_redo() {
     let mut history = History::new();
 
     let library_v1 = create_test_library(0.0);
-    history.save_state(&library_v1);
+    history.save_state(&library_v1, &default_sel());
 
     let library_v2 = create_test_library(100.0);
-    history.undo(&library_v2);
+    history.undo(&library_v2, &default_sel());
 
     assert!(history.can_redo());
     assert_eq!(history.redo_count(), 1);
@@ -81,15 +85,15 @@ fn test_history_redo_restores_undone_state() {
     let mut history = History::new();
 
     let library_v1 = create_test_library(0.0);
-    history.save_state(&library_v1);
+    history.save_state(&library_v1, &default_sel());
 
     let library_v2 = create_test_library(100.0);
 
     // Undo returns v1
-    let after_undo = history.undo(&library_v2).unwrap();
+    let (after_undo, _) = history.undo(&library_v2, &default_sel()).unwrap();
 
     // Redo should return v2
-    let after_redo = history.redo(&after_undo).unwrap();
+    let (after_redo, _) = history.redo(&after_undo, &default_sel()).unwrap();
 
     let node = after_redo.root.child("ellipse1").unwrap();
     let x = node.input("x").unwrap().value.as_float().unwrap();
@@ -101,17 +105,17 @@ fn test_history_new_changes_clear_redo_stack() {
     let mut history = History::new();
 
     let library_v1 = create_test_library(0.0);
-    history.save_state(&library_v1);
+    history.save_state(&library_v1, &default_sel());
 
     let library_v2 = create_test_library(100.0);
 
     // Undo to enable redo
-    history.undo(&library_v2);
+    history.undo(&library_v2, &default_sel());
     assert!(history.can_redo());
 
     // Save new state (simulating new change)
     let library_v3 = create_test_library(50.0);
-    history.save_state(&library_v3);
+    history.save_state(&library_v3, &default_sel());
 
     // Redo should now be unavailable
     assert!(!history.can_redo());
@@ -124,22 +128,22 @@ fn test_history_multiple_undos() {
 
     // Create and save multiple states
     let library_v1 = create_test_library(0.0);
-    history.save_state(&library_v1);
+    history.save_state(&library_v1, &default_sel());
 
     let library_v2 = create_test_library(50.0);
-    history.save_state(&library_v2);
+    history.save_state(&library_v2, &default_sel());
 
     let library_v3 = create_test_library(100.0);
 
     assert_eq!(history.undo_count(), 2);
 
     // Undo twice
-    let after_first_undo = history.undo(&library_v3).unwrap();
+    let (after_first_undo, _) = history.undo(&library_v3, &default_sel()).unwrap();
     let node = after_first_undo.root.child("ellipse1").unwrap();
     let x = node.input("x").unwrap().value.as_float().unwrap();
     assert!((x - 50.0).abs() < 0.001);
 
-    let after_second_undo = history.undo(&after_first_undo).unwrap();
+    let (after_second_undo, _) = history.undo(&after_first_undo, &default_sel()).unwrap();
     let node = after_second_undo.root.child("ellipse1").unwrap();
     let x = node.input("x").unwrap().value.as_float().unwrap();
     assert!((x - 0.0).abs() < 0.001);
@@ -153,26 +157,26 @@ fn test_history_multiple_redos() {
     let mut history = History::new();
 
     let library_v1 = create_test_library(0.0);
-    history.save_state(&library_v1);
+    history.save_state(&library_v1, &default_sel());
 
     let library_v2 = create_test_library(50.0);
-    history.save_state(&library_v2);
+    history.save_state(&library_v2, &default_sel());
 
     let library_v3 = create_test_library(100.0);
 
     // Undo twice
-    let after_first_undo = history.undo(&library_v3).unwrap();
-    let after_second_undo = history.undo(&after_first_undo).unwrap();
+    let (after_first_undo, _) = history.undo(&library_v3, &default_sel()).unwrap();
+    let (after_second_undo, _) = history.undo(&after_first_undo, &default_sel()).unwrap();
 
     assert_eq!(history.redo_count(), 2);
 
     // Redo twice
-    let after_first_redo = history.redo(&after_second_undo).unwrap();
+    let (after_first_redo, _) = history.redo(&after_second_undo, &default_sel()).unwrap();
     let node = after_first_redo.root.child("ellipse1").unwrap();
     let x = node.input("x").unwrap().value.as_float().unwrap();
     assert!((x - 50.0).abs() < 0.001);
 
-    let after_second_redo = history.redo(&after_first_redo).unwrap();
+    let (after_second_redo, _) = history.redo(&after_first_redo, &default_sel()).unwrap();
     let node = after_second_redo.root.child("ellipse1").unwrap();
     let x = node.input("x").unwrap().value.as_float().unwrap();
     assert!((x - 100.0).abs() < 0.001);
@@ -186,9 +190,9 @@ fn test_history_clear() {
     let mut history = History::new();
 
     let library_v1 = create_test_library(0.0);
-    history.save_state(&library_v1);
-    history.save_state(&library_v1);
-    history.save_state(&library_v1);
+    history.save_state(&library_v1, &default_sel());
+    history.save_state(&library_v1, &default_sel());
+    history.save_state(&library_v1, &default_sel());
 
     assert_eq!(history.undo_count(), 3);
 
@@ -220,7 +224,7 @@ fn test_history_undo_on_empty_returns_none() {
     let mut history = History::new();
     let library = create_test_library(0.0);
 
-    let result = history.undo(&library);
+    let result = history.undo(&library, &default_sel());
     assert!(result.is_none());
 }
 
@@ -229,7 +233,7 @@ fn test_history_redo_on_empty_returns_none() {
     let mut history = History::new();
     let library = create_test_library(0.0);
 
-    let result = history.redo(&library);
+    let result = history.redo(&library, &default_sel());
     assert!(result.is_none());
 }
 
@@ -241,12 +245,12 @@ fn test_save_state_suppressed_during_group() {
     let library_v1 = create_test_library(0.0);
 
     // Begin a group
-    history.begin_undo_group(&library_v1);
+    history.begin_undo_group(&library_v1, &default_sel());
 
     // Multiple save_state calls should be suppressed
     for i in 1..=5 {
         let lib = create_test_library(i as f64 * 10.0);
-        history.save_state(&lib);
+        history.save_state(&lib, &default_sel());
     }
 
     // End the group with the final state
@@ -263,13 +267,13 @@ fn test_group_undo_restores_pre_group_state() {
     let library_v1 = create_test_library(0.0);
 
     // Begin group with state A (x=0)
-    history.begin_undo_group(&library_v1);
+    history.begin_undo_group(&library_v1, &default_sel());
 
     // Simulate intermediate changes during drag
     let library_v2 = create_test_library(25.0);
-    history.save_state(&library_v2);
+    history.save_state(&library_v2, &default_sel());
     let library_v3 = create_test_library(50.0);
-    history.save_state(&library_v3);
+    history.save_state(&library_v3, &default_sel());
 
     // End group with final state (x=50)
     history.end_undo_group(&library_v3);
@@ -277,7 +281,7 @@ fn test_group_undo_restores_pre_group_state() {
     assert_eq!(history.undo_count(), 1);
 
     // Undo should restore the pre-group state (x=0)
-    let restored = history.undo(&library_v3).unwrap();
+    let (restored, _) = history.undo(&library_v3, &default_sel()).unwrap();
     let node = restored.root.child("ellipse1").unwrap();
     let x = node.input("x").unwrap().value.as_float().unwrap();
     assert!((x - 0.0).abs() < 0.001, "Expected x=0.0 (pre-group), got x={}", x);
@@ -301,7 +305,7 @@ fn test_no_op_group_creates_no_entry() {
     let library = create_test_library(0.0);
 
     // Begin and end group with the same state (no actual changes)
-    history.begin_undo_group(&library);
+    history.begin_undo_group(&library, &default_sel());
     history.end_undo_group(&library);
 
     // No undo entry should be created since nothing changed
@@ -314,14 +318,14 @@ fn test_group_clears_redo_stack() {
 
     // Set up: create some undo history, then undo to populate redo stack
     let library_v1 = create_test_library(0.0);
-    history.save_state(&library_v1);
+    history.save_state(&library_v1, &default_sel());
     let library_v2 = create_test_library(50.0);
-    history.undo(&library_v2);
+    history.undo(&library_v2, &default_sel());
     assert!(history.can_redo());
 
     // Now perform a group operation
     let library_v3 = create_test_library(100.0);
-    history.begin_undo_group(&library_v3);
+    history.begin_undo_group(&library_v3, &default_sel());
     let library_v4 = create_test_library(200.0);
     history.end_undo_group(&library_v4);
 
@@ -337,16 +341,16 @@ fn test_nested_begin_group_keeps_first() {
     let library_b = create_test_library(50.0);
 
     // First begin_undo_group captures state A
-    history.begin_undo_group(&library_a);
+    history.begin_undo_group(&library_a, &default_sel());
 
     // Second begin_undo_group should be ignored (first wins)
-    history.begin_undo_group(&library_b);
+    history.begin_undo_group(&library_b, &default_sel());
 
     let library_c = create_test_library(100.0);
     history.end_undo_group(&library_c);
 
     // Undo should restore A (from the first begin), not B
-    let restored = history.undo(&library_c).unwrap();
+    let (restored, _) = history.undo(&library_c, &default_sel()).unwrap();
     let node = restored.root.child("ellipse1").unwrap();
     let x = node.input("x").unwrap().value.as_float().unwrap();
     assert!((x - 0.0).abs() < 0.001, "Expected x=0.0 (first begin), got x={}", x);
@@ -358,13 +362,13 @@ fn test_group_followed_by_normal_saves() {
 
     // Do a grouped operation
     let library_v1 = create_test_library(0.0);
-    history.begin_undo_group(&library_v1);
+    history.begin_undo_group(&library_v1, &default_sel());
     let library_v2 = create_test_library(50.0);
     history.end_undo_group(&library_v2);
 
     // Then do normal saves
     let library_v3 = create_test_library(75.0);
-    history.save_state(&library_v3);
+    history.save_state(&library_v3, &default_sel());
 
     // Should have 2 entries: the group + the normal save
     assert_eq!(history.undo_count(), 2);
@@ -377,9 +381,77 @@ fn test_is_in_group() {
 
     assert!(!history.is_in_group());
 
-    history.begin_undo_group(&library);
+    history.begin_undo_group(&library, &default_sel());
     assert!(history.is_in_group());
 
     history.end_undo_group(&library);
     assert!(!history.is_in_group());
+}
+
+// --- Selection snapshot tests ---
+
+#[test]
+fn test_undo_restores_selection_snapshot() {
+    let mut history = History::new();
+    let library_v1 = create_test_library(0.0);
+
+    // Save state with ellipse1 selected
+    let sel_v1 = SelectionSnapshot {
+        selected_nodes: ["ellipse1".to_string()].into_iter().collect(),
+        selected_node: Some("ellipse1".to_string()),
+    };
+    history.save_state(&library_v1, &sel_v1);
+
+    // Current state: no selection
+    let library_v2 = create_test_library(100.0);
+    let sel_v2 = SelectionSnapshot::default();
+
+    // Undo should restore the selection
+    let (_, restored_sel) = history.undo(&library_v2, &sel_v2).unwrap();
+    assert_eq!(restored_sel.selected_node, Some("ellipse1".to_string()));
+    assert!(restored_sel.selected_nodes.contains("ellipse1"));
+}
+
+#[test]
+fn test_redo_restores_selection_snapshot() {
+    let mut history = History::new();
+    let library_v1 = create_test_library(0.0);
+
+    // Save state with no selection
+    history.save_state(&library_v1, &default_sel());
+
+    // Current state: ellipse1 selected
+    let library_v2 = create_test_library(100.0);
+    let sel_v2 = SelectionSnapshot {
+        selected_nodes: ["ellipse1".to_string()].into_iter().collect(),
+        selected_node: Some("ellipse1".to_string()),
+    };
+
+    // Undo (saves sel_v2 for redo)
+    history.undo(&library_v2, &sel_v2);
+
+    // Redo should restore sel_v2
+    let (_, restored_sel) = history.redo(&library_v1, &default_sel()).unwrap();
+    assert_eq!(restored_sel.selected_node, Some("ellipse1".to_string()));
+}
+
+#[test]
+fn test_undo_group_restores_pre_group_selection() {
+    let mut history = History::new();
+    let library_v1 = create_test_library(0.0);
+
+    // Begin group with ellipse1 selected
+    let sel = SelectionSnapshot {
+        selected_nodes: ["ellipse1".to_string()].into_iter().collect(),
+        selected_node: Some("ellipse1".to_string()),
+    };
+    history.begin_undo_group(&library_v1, &sel);
+
+    // End group with changed library
+    let library_v2 = create_test_library(100.0);
+    history.end_undo_group(&library_v2);
+
+    // Undo should restore the pre-group selection
+    let (_, restored_sel) = history.undo(&library_v2, &default_sel()).unwrap();
+    assert_eq!(restored_sel.selected_node, Some("ellipse1".to_string()));
 }

--- a/crates/nodebox-gui/tests/history_tests.rs
+++ b/crates/nodebox-gui/tests/history_tests.rs
@@ -232,3 +232,154 @@ fn test_history_redo_on_empty_returns_none() {
     let result = history.redo(&library);
     assert!(result.is_none());
 }
+
+// --- Undo group tests ---
+
+#[test]
+fn test_save_state_suppressed_during_group() {
+    let mut history = History::new();
+    let library_v1 = create_test_library(0.0);
+
+    // Begin a group
+    history.begin_undo_group(&library_v1);
+
+    // Multiple save_state calls should be suppressed
+    for i in 1..=5 {
+        let lib = create_test_library(i as f64 * 10.0);
+        history.save_state(&lib);
+    }
+
+    // End the group with the final state
+    let library_final = create_test_library(50.0);
+    history.end_undo_group(&library_final);
+
+    // Only one undo entry (the group itself)
+    assert_eq!(history.undo_count(), 1);
+}
+
+#[test]
+fn test_group_undo_restores_pre_group_state() {
+    let mut history = History::new();
+    let library_v1 = create_test_library(0.0);
+
+    // Begin group with state A (x=0)
+    history.begin_undo_group(&library_v1);
+
+    // Simulate intermediate changes during drag
+    let library_v2 = create_test_library(25.0);
+    history.save_state(&library_v2);
+    let library_v3 = create_test_library(50.0);
+    history.save_state(&library_v3);
+
+    // End group with final state (x=50)
+    history.end_undo_group(&library_v3);
+
+    assert_eq!(history.undo_count(), 1);
+
+    // Undo should restore the pre-group state (x=0)
+    let restored = history.undo(&library_v3).unwrap();
+    let node = restored.root.child("ellipse1").unwrap();
+    let x = node.input("x").unwrap().value.as_float().unwrap();
+    assert!((x - 0.0).abs() < 0.001, "Expected x=0.0 (pre-group), got x={}", x);
+}
+
+#[test]
+fn test_end_group_without_begin_is_noop() {
+    let mut history = History::new();
+    let library = create_test_library(0.0);
+
+    // end_undo_group without begin should not crash or add entries
+    history.end_undo_group(&library);
+
+    assert_eq!(history.undo_count(), 0);
+    assert!(!history.can_undo());
+}
+
+#[test]
+fn test_no_op_group_creates_no_entry() {
+    let mut history = History::new();
+    let library = create_test_library(0.0);
+
+    // Begin and end group with the same state (no actual changes)
+    history.begin_undo_group(&library);
+    history.end_undo_group(&library);
+
+    // No undo entry should be created since nothing changed
+    assert_eq!(history.undo_count(), 0);
+}
+
+#[test]
+fn test_group_clears_redo_stack() {
+    let mut history = History::new();
+
+    // Set up: create some undo history, then undo to populate redo stack
+    let library_v1 = create_test_library(0.0);
+    history.save_state(&library_v1);
+    let library_v2 = create_test_library(50.0);
+    history.undo(&library_v2);
+    assert!(history.can_redo());
+
+    // Now perform a group operation
+    let library_v3 = create_test_library(100.0);
+    history.begin_undo_group(&library_v3);
+    let library_v4 = create_test_library(200.0);
+    history.end_undo_group(&library_v4);
+
+    // Redo stack should be cleared by the group
+    assert!(!history.can_redo());
+    assert_eq!(history.redo_count(), 0);
+}
+
+#[test]
+fn test_nested_begin_group_keeps_first() {
+    let mut history = History::new();
+    let library_a = create_test_library(0.0);
+    let library_b = create_test_library(50.0);
+
+    // First begin_undo_group captures state A
+    history.begin_undo_group(&library_a);
+
+    // Second begin_undo_group should be ignored (first wins)
+    history.begin_undo_group(&library_b);
+
+    let library_c = create_test_library(100.0);
+    history.end_undo_group(&library_c);
+
+    // Undo should restore A (from the first begin), not B
+    let restored = history.undo(&library_c).unwrap();
+    let node = restored.root.child("ellipse1").unwrap();
+    let x = node.input("x").unwrap().value.as_float().unwrap();
+    assert!((x - 0.0).abs() < 0.001, "Expected x=0.0 (first begin), got x={}", x);
+}
+
+#[test]
+fn test_group_followed_by_normal_saves() {
+    let mut history = History::new();
+
+    // Do a grouped operation
+    let library_v1 = create_test_library(0.0);
+    history.begin_undo_group(&library_v1);
+    let library_v2 = create_test_library(50.0);
+    history.end_undo_group(&library_v2);
+
+    // Then do normal saves
+    let library_v3 = create_test_library(75.0);
+    history.save_state(&library_v3);
+
+    // Should have 2 entries: the group + the normal save
+    assert_eq!(history.undo_count(), 2);
+}
+
+#[test]
+fn test_is_in_group() {
+    let mut history = History::new();
+    let library = create_test_library(0.0);
+
+    assert!(!history.is_in_group());
+
+    history.begin_undo_group(&library);
+    assert!(history.is_in_group());
+
+    history.end_undo_group(&library);
+    assert!(!history.is_in_group());
+}


### PR DESCRIPTION
## Summary
This PR implements undo grouping for drag operations, allowing multiple intermediate changes during a drag gesture to be collapsed into a single undo entry. This improves the user experience by making undo/redo more intuitive when dragging parameters, nodes, or handles.

## Key Changes

- **History API**: Added `begin_undo_group()` and `end_undo_group()` methods to the `History` struct that suppress individual `save_state()` calls and create a single undo entry for the entire group.

- **Drag Detection**: Added `is_dragging()` methods to three UI components:
  - `ViewerPane::is_dragging()` - detects handle dragging in the viewer
  - `NetworkView::is_dragging_nodes()` - detects node selection dragging
  - `ParameterPanel::is_dragging()` - detects parameter value dragging

- **Drag Lifecycle Management**: In `NodeBoxApp::update()`, added logic to:
  - Detect drag start/end transitions using the new `is_dragging()` methods
  - Call `begin_undo_group()` when a drag starts (with pre-frame library state)
  - Call `end_undo_group()` when a drag ends
  - Track drag state with `was_dragging` field to detect transitions

- **Parameter Panel**: Enhanced to track drag state by setting `is_dragging = true` when drag starts and clearing it when the primary mouse button is released.

- **Comprehensive Tests**: Added 8 new tests covering:
  - Single undo entry creation during drag
  - Undo restoration to pre-drag state
  - Non-drag changes still creating individual entries
  - Drag followed by normal changes
  - Group state suppression and restoration
  - Edge cases (nested begins, no-op groups, redo stack clearing)

## Implementation Details

- The pre-frame library state is captured as an `Arc` clone (cheap pointer operation) before any panel mutations occur, ensuring the group captures the true pre-drag state.
- Groups suppress `save_state()` calls by checking `group_start_state.is_some()` and returning early.
- No-op groups (where state doesn't change) don't create undo entries, keeping history clean.
- Nested `begin_undo_group()` calls are ignored; the first one wins.
- The redo stack is cleared when a group ends, consistent with normal undo behavior.

https://claude.ai/code/session_01BGyKyaR55Mgbw1R1V4kbLw