### PR TITLE
Add notification banners and graceful handling of old file formats

### DIFF
--- a/crates/nodebox-gui/src/app.rs
+++ b/crates/nodebox-gui/src/app.rs
@@ -11,6 +11,7 @@ use crate::components;
 use crate::history::History;
 use crate::icon_cache::IconCache;
 use crate::native_menu::{MenuAction, NativeMenuHandle};
+use crate::notification_banner;
 use crate::recent_files::RecentFiles;
 use crate::network_view::{NetworkAction, NetworkView};
 use crate::node_selection_dialog::NodeSelectionDialog;
@@ -659,6 +660,27 @@ impl eframe::App for NodeBoxApp {
                     AddressBarAction::None => {}
                 }
             });
+
+        // 2b. Notification banners (below address bar, only shown when notifications exist)
+        if !self.state.notifications.is_empty() {
+            let banner_height = notification_banner::BANNER_HEIGHT
+                * self.state.notifications.len() as f32;
+            egui::TopBottomPanel::top("notification_banners")
+                .exact_height(banner_height)
+                .frame(egui::Frame::NONE)
+                .show(ctx, |ui| {
+                    let notifs: Vec<_> = self.state.notifications
+                        .iter()
+                        .map(|n| (n.id, n.message.clone(), n.level.clone()))
+                        .collect();
+
+                    let dismissed = notification_banner::show_notifications(ui, &notifs);
+
+                    for id in dismissed {
+                        self.state.dismiss_notification(id);
+                    }
+                });
+        }
 
         // 3. Animation bar (bottom) - frameless, handles its own styling
         let anim_response = egui::TopBottomPanel::bottom("animation_bar")

--- a/crates/nodebox-gui/src/lib.rs
+++ b/crates/nodebox-gui/src/lib.rs
@@ -32,6 +32,7 @@ mod icon_cache;
 mod network_view;
 mod node_library;
 mod node_selection_dialog;
+mod notification_banner;
 mod pan_zoom;
 mod parameter_panel;
 pub mod render_worker;
@@ -51,7 +52,7 @@ pub mod vello_viewer;
 // Re-export key types for testing and external use
 pub use app::NodeBoxApp;
 pub use history::History;
-pub use state::{populate_default_ports, AppState};
+pub use state::{populate_default_ports, AppState, Notification, NotificationLevel};
 
 // Re-export commonly used types from dependencies
 pub use nodebox_core::geometry::{Color, Path, Point};

--- a/crates/nodebox-gui/src/notification_banner.rs
+++ b/crates/nodebox-gui/src/notification_banner.rs
@@ -44,23 +44,29 @@ pub fn show_notifications(
             egui::Stroke::new(1.0, theme::ZINC_600),
         );
 
-        // Warning icon
-        let icon_font = egui::FontId::proportional(12.0);
-        let icon_galley = ui.painter().layout_no_wrap(
-            "\u{26A0}".to_string(),
-            icon_font,
-            icon_color,
-        );
+        // Warning icon: draw a small triangle with "!" using lines
         let icon_x = rect.left() + theme::PADDING;
-        ui.painter().galley(
-            egui::pos2(icon_x, rect.center().y - icon_galley.size().y / 2.0),
-            icon_galley.clone(),
-            icon_color,
+        let icon_cx = icon_x + 6.0;
+        let icon_cy = rect.center().y;
+        let icon_stroke = egui::Stroke::new(1.5, icon_color);
+        // Triangle outline
+        let tri_top = egui::pos2(icon_cx, icon_cy - 5.0);
+        let tri_bl = egui::pos2(icon_cx - 6.0, icon_cy + 5.0);
+        let tri_br = egui::pos2(icon_cx + 6.0, icon_cy + 5.0);
+        ui.painter().line_segment([tri_top, tri_bl], icon_stroke);
+        ui.painter().line_segment([tri_bl, tri_br], icon_stroke);
+        ui.painter().line_segment([tri_br, tri_top], icon_stroke);
+        // Exclamation mark inside
+        ui.painter().line_segment(
+            [egui::pos2(icon_cx, icon_cy - 2.5), egui::pos2(icon_cx, icon_cy + 1.5)],
+            icon_stroke,
         );
+        ui.painter().circle_filled(egui::pos2(icon_cx, icon_cy + 3.5), 0.8, icon_color);
+        let icon_width = 12.0 + theme::PADDING_SMALL;
 
         // Message text
         let text_font = egui::FontId::proportional(11.0);
-        let text_x = icon_x + icon_galley.size().x + theme::PADDING_SMALL;
+        let text_x = icon_x + icon_width;
         let max_text_width = rect.right() - text_x - 28.0; // room for dismiss button
 
         let galley = ui.painter().layout(
@@ -94,12 +100,17 @@ pub fn show_notifications(
             theme::ZINC_400
         };
 
-        ui.painter().text(
-            dismiss_rect.center(),
-            egui::Align2::CENTER_CENTER,
-            "\u{2715}",
-            egui::FontId::proportional(12.0),
-            dismiss_color,
+        // Draw X with two line segments (avoids missing Unicode glyph issues)
+        let cx = dismiss_rect.center();
+        let half = 4.0;
+        let stroke = egui::Stroke::new(1.5, dismiss_color);
+        ui.painter().line_segment(
+            [egui::pos2(cx.x - half, cx.y - half), egui::pos2(cx.x + half, cx.y + half)],
+            stroke,
+        );
+        ui.painter().line_segment(
+            [egui::pos2(cx.x + half, cx.y - half), egui::pos2(cx.x - half, cx.y + half)],
+            stroke,
         );
 
         if dismiss_response.clicked() {

--- a/crates/nodebox-gui/src/notification_banner.rs
+++ b/crates/nodebox-gui/src/notification_banner.rs
@@ -1,0 +1,111 @@
+//! Notification banner UI component.
+//!
+//! Renders dismissible warning/info banners below the address bar.
+//! Styled with ZINC colors for an unobtrusive appearance.
+
+use eframe::egui;
+use crate::state::NotificationLevel;
+use crate::theme;
+
+/// Height of a single notification banner.
+pub const BANNER_HEIGHT: f32 = 28.0;
+
+/// Draw notification banners and return IDs of any that were dismissed.
+pub fn show_notifications(
+    ui: &mut egui::Ui,
+    notifications: &[(u64, String, NotificationLevel)],
+) -> Vec<u64> {
+    let mut dismissed = Vec::new();
+
+    for (id, message, _level) in notifications {
+        let (rect, _) = ui.allocate_exact_size(
+            egui::vec2(ui.available_width(), BANNER_HEIGHT),
+            egui::Sense::hover(),
+        );
+
+        if !ui.is_rect_visible(rect) {
+            continue;
+        }
+
+        // Zinc styling: unobtrusive, blends with the dark theme
+        let bg_color = theme::ZINC_700;
+        let text_color = theme::ZINC_300;
+        let icon_color = theme::ZINC_400;
+
+        // Background
+        ui.painter().rect_filled(rect, 0.0, bg_color);
+
+        // Subtle bottom separator
+        ui.painter().line_segment(
+            [
+                egui::pos2(rect.left(), rect.bottom() - 0.5),
+                egui::pos2(rect.right(), rect.bottom() - 0.5),
+            ],
+            egui::Stroke::new(1.0, theme::ZINC_600),
+        );
+
+        // Warning icon
+        let icon_font = egui::FontId::proportional(12.0);
+        let icon_galley = ui.painter().layout_no_wrap(
+            "\u{26A0}".to_string(),
+            icon_font,
+            icon_color,
+        );
+        let icon_x = rect.left() + theme::PADDING;
+        ui.painter().galley(
+            egui::pos2(icon_x, rect.center().y - icon_galley.size().y / 2.0),
+            icon_galley.clone(),
+            icon_color,
+        );
+
+        // Message text
+        let text_font = egui::FontId::proportional(11.0);
+        let text_x = icon_x + icon_galley.size().x + theme::PADDING_SMALL;
+        let max_text_width = rect.right() - text_x - 28.0; // room for dismiss button
+
+        let galley = ui.painter().layout(
+            message.clone(),
+            text_font,
+            text_color,
+            max_text_width,
+        );
+        ui.painter().galley(
+            egui::pos2(text_x, rect.center().y - galley.size().y / 2.0),
+            galley,
+            text_color,
+        );
+
+        // Dismiss button (x) on the right
+        let dismiss_size = 20.0;
+        let dismiss_rect = egui::Rect::from_center_size(
+            egui::pos2(rect.right() - theme::PADDING - dismiss_size / 2.0, rect.center().y),
+            egui::vec2(dismiss_size, dismiss_size),
+        );
+
+        let dismiss_response = ui.interact(
+            dismiss_rect,
+            egui::Id::new(("dismiss_notification", *id)),
+            egui::Sense::click(),
+        );
+
+        let dismiss_color = if dismiss_response.hovered() {
+            theme::ZINC_200
+        } else {
+            theme::ZINC_400
+        };
+
+        ui.painter().text(
+            dismiss_rect.center(),
+            egui::Align2::CENTER_CENTER,
+            "\u{2715}",
+            egui::FontId::proportional(12.0),
+            dismiss_color,
+        );
+
+        if dismiss_response.clicked() {
+            dismissed.push(*id);
+        }
+    }
+
+    dismissed
+}

--- a/crates/nodebox-gui/src/state.rs
+++ b/crates/nodebox-gui/src/state.rs
@@ -7,6 +7,27 @@ use nodebox_core::geometry::{Path as GeoPath, Color, Point};
 use nodebox_core::node::{Node, NodeLibrary, MenuItem, Port, PortRange, Widget};
 use crate::eval::NodeOutput;
 
+/// Severity level for a notification.
+#[derive(Debug, Clone, PartialEq)]
+pub enum NotificationLevel {
+    /// Informational notice.
+    #[allow(dead_code)]
+    Info,
+    /// Warning about potential issues.
+    Warning,
+}
+
+/// A dismissible notification shown to the user.
+#[derive(Debug, Clone)]
+pub struct Notification {
+    /// Unique identifier for this notification.
+    pub id: u64,
+    /// The message to display.
+    pub message: String,
+    /// Severity level.
+    pub level: NotificationLevel,
+}
+
 /// The main application state.
 pub struct AppState {
     /// Current file path (if saved).
@@ -37,6 +58,12 @@ pub struct AppState {
 
     /// The raw output of the rendered node (for non-geometry data display).
     pub node_output: NodeOutput,
+
+    /// Active notifications (dismissible banners).
+    pub notifications: Vec<Notification>,
+
+    /// Counter for generating unique notification IDs.
+    notification_counter: u64,
 }
 
 impl Default for AppState {
@@ -63,6 +90,8 @@ impl AppState {
             library,
             node_errors: HashMap::new(),
             node_output: NodeOutput::None,
+            notifications: Vec::new(),
+            notification_counter: 0,
         }
     }
 
@@ -95,6 +124,7 @@ impl AppState {
         self.node_output = NodeOutput::None;
         self.selected_node = None;
         self.node_errors.clear();
+        self.notifications.clear();
     }
 
     /// Load a file.
@@ -102,8 +132,9 @@ impl AppState {
     /// Note: Geometry is cleared - the render worker will evaluate with
     /// the proper Port and populate it.
     pub fn load_file(&mut self, path: &Path) -> Result<(), String> {
-        // Parse the .ndbx file
-        let mut library = nodebox_ndbx::parse_file(path).map_err(|e| e.to_string())?;
+        // Parse the .ndbx file with warnings (old format versions load best-effort)
+        let (mut library, warnings) =
+            nodebox_ndbx::parse_file_with_warnings(path).map_err(|e| e.to_string())?;
 
         // Ensure all nodes have their default ports populated
         populate_default_ports(&mut library.root);
@@ -118,7 +149,26 @@ impl AppState {
         self.node_output = NodeOutput::None;
         self.node_errors.clear();
 
+        // Surface any warnings as notifications
+        self.notifications.clear();
+        for warning in warnings {
+            self.add_notification(warning, NotificationLevel::Warning);
+        }
+
         Ok(())
+    }
+
+    /// Add a notification and return its ID.
+    pub fn add_notification(&mut self, message: String, level: NotificationLevel) -> u64 {
+        self.notification_counter += 1;
+        let id = self.notification_counter;
+        self.notifications.push(Notification { id, message, level });
+        id
+    }
+
+    /// Dismiss (remove) a notification by ID.
+    pub fn dismiss_notification(&mut self, id: u64) {
+        self.notifications.retain(|n| n.id != id);
     }
 
     /// Save the current document.

--- a/crates/nodebox-gui/tests/file_tests.rs
+++ b/crates/nodebox-gui/tests/file_tests.rs
@@ -1,9 +1,8 @@
 //! Tests for loading and evaluating .ndbx files.
 //!
-//! Note: The Rust implementation only supports .ndbx format version 21+.
-//! Older example files (version 17) from the Java implementation are rejected.
-//! These tests verify that behavior and test evaluation with programmatically
-//! created libraries.
+//! Note: Old .ndbx files (version < 21) from the Java implementation are loaded
+//! best-effort with a warning. These tests verify that behavior and test evaluation
+//! with programmatically created libraries.
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -12,7 +11,6 @@ use nodebox_core::geometry::{Color, Point};
 use nodebox_core::node::{Connection, Node, NodeLibrary, Port};
 use nodebox_gui::eval::evaluate_network;
 use nodebox_gui::{populate_default_ports, AppState};
-use nodebox_ndbx::NdbxError;
 use nodebox_port::{Port as PortTrait, ProjectContext, TestPort};
 
 /// Create a test port and project context for evaluation tests.
@@ -47,23 +45,22 @@ fn libraries_dir() -> PathBuf {
 // ============================================================================
 
 #[test]
-fn test_old_version_files_are_rejected() {
+fn test_old_version_files_load_with_warning() {
     // The Primitives example has formatVersion="17" which is below our minimum (21)
+    // but should load best-effort with a warning
     let path = examples_dir().join("01 Basics/01 Shape/01 Primitives/01 Primitives.ndbx");
     if !path.exists() {
         println!("Skipping test - example file not found");
         return;
     }
 
-    let result = nodebox_ndbx::parse_file(&path);
-    assert!(result.is_err(), "Old version files should be rejected");
+    let result = nodebox_ndbx::parse_file_with_warnings(&path);
+    assert!(result.is_ok(), "Old version files should load best-effort");
 
-    match result.unwrap_err() {
-        NdbxError::UnsupportedVersion(v) => {
-            assert_eq!(v, 17, "Expected version 17 rejection");
-        }
-        other => panic!("Expected UnsupportedVersion error, got: {:?}", other),
-    }
+    let (library, warnings) = result.unwrap();
+    assert!(!warnings.is_empty(), "Should have a warning about old format version");
+    assert!(warnings[0].contains("17"), "Warning should mention the file's version");
+    assert_eq!(library.format_version, 22, "Should be upgraded to current version");
 }
 
 #[test]
@@ -338,10 +335,10 @@ fn test_app_state_new() {
 }
 
 #[test]
-fn test_app_state_load_file_old_version() {
+fn test_app_state_load_file_old_version_warns() {
     let mut state = AppState::new();
 
-    // Try to load an old version file - should fail
+    // Old version files should load best-effort with notifications
     let path = examples_dir().join("01 Basics/01 Shape/01 Primitives/01 Primitives.ndbx");
     if !path.exists() {
         println!("Skipping test - example file not found");
@@ -350,8 +347,12 @@ fn test_app_state_load_file_old_version() {
 
     let result = state.load_file(&path);
     assert!(
-        result.is_err(),
-        "load_file should fail for old version files"
+        result.is_ok(),
+        "load_file should succeed for old version files (best-effort)"
+    );
+    assert!(
+        !state.notifications.is_empty(),
+        "Should have notification warning about old format"
     );
 }
 

--- a/crates/nodebox-ndbx/src/lib.rs
+++ b/crates/nodebox-ndbx/src/lib.rs
@@ -21,6 +21,6 @@ mod serializer;
 mod upgrades;
 
 pub use error::{NdbxError, Result};
-pub use parser::{parse, parse_file};
+pub use parser::{parse, parse_file, parse_file_with_warnings};
 pub use serializer::{serialize, serialize_to_file};
-pub use upgrades::{upgrade, CURRENT_FORMAT_VERSION, MIN_SUPPORTED_VERSION};
+pub use upgrades::{upgrade, UpgradeResult, CURRENT_FORMAT_VERSION, MIN_SUPPORTED_VERSION};

--- a/crates/nodebox-ndbx/src/parser.rs
+++ b/crates/nodebox-ndbx/src/parser.rs
@@ -13,13 +13,23 @@ use nodebox_core::Value;
 use crate::error::{NdbxError, Result};
 use crate::upgrades::upgrade;
 
+/// Parses an NDBX file from the given path, returning the library and any warnings.
+///
+/// Unlike `parse_file`, this function also returns non-fatal warnings
+/// (e.g., when loading old format versions best-effort).
+pub fn parse_file_with_warnings(path: impl AsRef<Path>) -> Result<(NodeLibrary, Vec<String>)> {
+    let content = fs::read_to_string(path)?;
+    let mut library = parse(&content)?;
+    let upgrade_result = upgrade(&mut library)?;
+    Ok((library, upgrade_result.warnings))
+}
+
 /// Parses an NDBX file from the given path.
 ///
 /// After parsing, the library is automatically upgraded to the current format version.
+/// Warnings from upgrading old format versions are discarded.
 pub fn parse_file(path: impl AsRef<Path>) -> Result<NodeLibrary> {
-    let content = fs::read_to_string(path)?;
-    let mut library = parse(&content)?;
-    upgrade(&mut library)?;
+    let (library, _warnings) = parse_file_with_warnings(path)?;
     Ok(library)
 }
 

--- a/crates/nodebox-ndbx/src/upgrades.rs
+++ b/crates/nodebox-ndbx/src/upgrades.rs
@@ -1,7 +1,7 @@
 //! Version upgrades for .ndbx files.
 //!
 //! This module handles upgrading older .ndbx file formats to the current version.
-//! Currently supports upgrading from Java's version 21 to Rust's version 22.
+//! Old versions (< 21) are loaded best-effort with a warning.
 
 use nodebox_core::node::NodeLibrary;
 
@@ -10,24 +10,41 @@ use crate::error::NdbxError;
 /// The current format version used when saving .ndbx files.
 pub const CURRENT_FORMAT_VERSION: u32 = 22;
 
-/// The minimum format version we can load (Java's latest).
+/// The minimum format version we can load without warnings (Java's latest).
 pub const MIN_SUPPORTED_VERSION: u32 = 21;
+
+/// Result of upgrading a NodeLibrary, with optional warnings.
+#[derive(Debug, Default)]
+pub struct UpgradeResult {
+    /// Non-fatal warnings encountered during upgrade.
+    pub warnings: Vec<String>,
+}
 
 /// Upgrades a NodeLibrary to the current format version.
 ///
-/// # Errors
-///
-/// Returns an error if the format version is too old (< 21) or too new (> 22).
-pub fn upgrade(library: &mut NodeLibrary) -> Result<(), NdbxError> {
+/// Old versions (< 21) are upgraded best-effort with a warning.
+/// Future versions (> current) return an error since they may contain
+/// structures we cannot parse.
+pub fn upgrade(library: &mut NodeLibrary) -> Result<UpgradeResult, NdbxError> {
+    let mut result = UpgradeResult::default();
+
     match library.format_version {
-        v if v < MIN_SUPPORTED_VERSION => Err(NdbxError::UnsupportedVersion(v)),
+        v if v < MIN_SUPPORTED_VERSION => {
+            result.warnings.push(format!(
+                "This file uses format version {}, which is older than the supported \
+                 version {}. Some features may not work correctly.",
+                v, MIN_SUPPORTED_VERSION
+            ));
+            library.format_version = CURRENT_FORMAT_VERSION;
+            Ok(result)
+        }
         21 => {
             // Upgrade from Java version 21 to Rust version 22
             // Currently a no-op (format is compatible)
             library.format_version = CURRENT_FORMAT_VERSION;
-            Ok(())
+            Ok(result)
         }
-        22 => Ok(()), // Already current
+        22 => Ok(result), // Already current
         v => Err(NdbxError::UnsupportedVersion(v)),
     }
 }
@@ -41,8 +58,9 @@ mod tests {
         let mut library = NodeLibrary::default();
         library.format_version = 21;
 
-        upgrade(&mut library).unwrap();
+        let result = upgrade(&mut library).unwrap();
         assert_eq!(library.format_version, 22);
+        assert!(result.warnings.is_empty());
     }
 
     #[test]
@@ -50,17 +68,30 @@ mod tests {
         let mut library = NodeLibrary::default();
         library.format_version = 22;
 
-        upgrade(&mut library).unwrap();
+        let result = upgrade(&mut library).unwrap();
         assert_eq!(library.format_version, 22);
+        assert!(result.warnings.is_empty());
     }
 
     #[test]
-    fn test_upgrade_old_version_error() {
+    fn test_upgrade_old_version_warns() {
         let mut library = NodeLibrary::default();
         library.format_version = 20;
 
-        let result = upgrade(&mut library);
-        assert!(result.is_err());
+        let result = upgrade(&mut library).unwrap();
+        assert!(!result.warnings.is_empty(), "Old version should produce a warning");
+        assert_eq!(library.format_version, CURRENT_FORMAT_VERSION);
+    }
+
+    #[test]
+    fn test_upgrade_very_old_version_warns() {
+        let mut library = NodeLibrary::default();
+        library.format_version = 17;
+
+        let result = upgrade(&mut library).unwrap();
+        assert!(!result.warnings.is_empty());
+        assert!(result.warnings[0].contains("17"));
+        assert_eq!(library.format_version, CURRENT_FORMAT_VERSION);
     }
 
     #[test]

--- a/crates/nodebox-ndbx/tests/parse_examples.rs
+++ b/crates/nodebox-ndbx/tests/parse_examples.rs
@@ -1,11 +1,11 @@
 //! Integration tests for parsing actual NDBX files.
 
-use nodebox_ndbx::{parse_file, NdbxError, MIN_SUPPORTED_VERSION};
+use nodebox_ndbx::{parse_file, parse_file_with_warnings};
 use std::path::Path;
 
-/// Test that parsing old format versions (< 21) returns an error.
+/// Test that parsing old format versions (< 21) succeeds best-effort with warnings.
 #[test]
-fn test_parse_old_version_returns_error() {
+fn test_parse_old_version_loads_with_warning() {
     let path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../../examples/01 Basics/01 Shape/01 Primitives/01 Primitives.ndbx");
 
@@ -15,15 +15,16 @@ fn test_parse_old_version_returns_error() {
     }
 
     // This file has formatVersion="17" which is below our minimum supported version
-    let result = parse_file(&path);
-    assert!(result.is_err(), "Expected error for old format version");
+    // but should load best-effort with a warning
+    let (library, warnings) = parse_file_with_warnings(&path)
+        .expect("Old version files should load best-effort");
+    assert!(!warnings.is_empty(), "Expected warning for old format version");
+    assert!(warnings[0].contains("17"), "Warning should mention the file's version");
+    assert_eq!(library.format_version, 22, "Should be upgraded to current version");
 
-    match result.unwrap_err() {
-        NdbxError::UnsupportedVersion(v) => {
-            assert!(v < MIN_SUPPORTED_VERSION, "Expected version < 21, got {}", v);
-        }
-        other => panic!("Expected UnsupportedVersion error, got: {:?}", other),
-    }
+    // parse_file (without warnings) should also succeed
+    let library = parse_file(&path).expect("parse_file should also succeed for old versions");
+    assert_eq!(library.format_version, 22);
 }
 
 /// Test parsing the corevector library.
@@ -61,9 +62,9 @@ fn test_parse_corevector_library() {
     assert!(rect_port_names.contains(&"height"), "rect missing height port");
 }
 
-/// Test that parsing a very old demo file (version 0) returns an error.
+/// Test that parsing a very old demo file (version 0) succeeds best-effort with warnings.
 #[test]
-fn test_parse_old_demo_file_returns_error() {
+fn test_parse_old_demo_file_loads_with_warning() {
     let path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../../src/test/files/demo.ndbx");
 
@@ -72,7 +73,9 @@ fn test_parse_old_demo_file_returns_error() {
         return;
     }
 
-    // This file has an old/missing format version
-    let result = parse_file(&path);
-    assert!(result.is_err(), "Expected error for old format version");
+    // This file has an old/missing format version but should still load best-effort
+    let (library, warnings) = parse_file_with_warnings(&path)
+        .expect("Old demo file should load best-effort");
+    assert_eq!(library.format_version, 22, "Should be upgraded to current version");
+    // May or may not have warnings depending on the file's version
 }


### PR DESCRIPTION
## Summary
This PR introduces a notification banner UI component and changes the file format upgrade strategy from strict rejection to best-effort loading with warnings for old .ndbx files (version < 21).

## Key Changes

### Notification System
- **New `notification_banner` module**: Renders dismissible warning/info banners below the address bar with ZINC color styling
- **Notification state management**: Added `Notification` struct and `NotificationLevel` enum to track active notifications
- **AppState integration**: Added methods to create and dismiss notifications, with unique ID generation
- **UI integration**: Notifications are displayed in a top panel that dynamically sizes based on active notifications

### File Format Handling
- **Graceful degradation**: Old format versions (< 21) now load successfully with warnings instead of failing
- **UpgradeResult struct**: New return type from `upgrade()` that includes non-fatal warnings
- **New API**: Added `parse_file_with_warnings()` to expose upgrade warnings to callers
- **User feedback**: Warnings from old file formats are surfaced as notifications in the UI

### Testing Updates
- Updated tests to verify best-effort loading behavior instead of error cases
- Added test coverage for very old format versions (v17, v0)
- Tests now verify that warnings are generated and format is upgraded to current version

## Implementation Details
- Notification IDs are generated sequentially to ensure uniqueness
- Banner height is constant (28.0) and panels stack vertically
- Dismiss button uses hover state for visual feedback
- Old files are upgraded to current format version (22) even when loaded best-effort
- The `parse_file()` API discards warnings for backward compatibility; callers needing warnings use `parse_file_with_warnings()`

https://claude.ai/code/session_01JG1Wm6BwvGAZ7MPVi9PeLY