### PR TITLE
Add freehand drawing support to viewer pane

### DIFF
--- a/crates/nodebox-gui/src/app.rs
+++ b/crates/nodebox-gui/src/app.rs
@@ -917,6 +917,10 @@ impl eframe::App for NodeBoxApp {
                         self.handle_four_point_change(x, y, width, height);
                         self.render_pending = true;
                     }
+                    HandleResult::StringChange { param, value } => {
+                        self.handle_string_change(&param, &value);
+                        self.render_pending = true;
+                    }
                     HandleResult::None => {}
                 }
             });
@@ -1055,6 +1059,17 @@ impl NodeBoxApp {
                 }
                 if let Some(port) = node.input_mut("height") {
                     port.value = nodebox_core::Value::Float(height);
+                }
+            }
+        }
+    }
+
+    /// Handle string parameter change from freehand handle.
+    fn handle_string_change(&mut self, param_name: &str, value: &str) {
+        if let Some(ref node_name) = self.state.selected_node {
+            if let Some(node) = Arc::make_mut(&mut self.state.library).root.child_mut(node_name) {
+                if let Some(port) = node.input_mut(param_name) {
+                    port.value = nodebox_core::Value::String(value.to_string());
                 }
             }
         }
@@ -1285,6 +1300,10 @@ mod tests {
                 app.handle_four_point_change(x, y, width, height);
                 app.render_pending = true;
             }
+            HandleResult::StringChange { param, value } => {
+                app.handle_string_change(&param, &value);
+                app.render_pending = true;
+            }
             HandleResult::None => {}
         }
 
@@ -1332,6 +1351,10 @@ mod tests {
             HandleResult::FourPointChange { x, y, width, height } => {
                 app.handle_four_point_change(x, y, width, height);
                 app.render_pending = true; // This is the fix!
+            }
+            HandleResult::StringChange { param, value } => {
+                app.handle_string_change(&param, &value);
+                app.render_pending = true;
             }
             HandleResult::None => {}
         }

--- a/crates/nodebox-gui/src/viewer_pane.rs
+++ b/crates/nodebox-gui/src/viewer_pane.rs
@@ -32,6 +32,55 @@ pub enum HandleResult {
     PointChange { param: String, value: Point },
     /// FourPointHandle changed (x, y, width, height).
     FourPointChange { x: f64, y: f64, width: f64, height: f64 },
+    /// A string parameter changed (e.g., freehand path drawing).
+    StringChange { param: String, value: String },
+}
+
+/// State for freehand drawing on the canvas.
+struct FreehandState {
+    /// The parameter name to write to ("path").
+    param_name: String,
+    /// Whether we are currently drawing (mouse is pressed).
+    is_drawing: bool,
+    /// The accumulated path string.
+    path_string: String,
+    /// Whether the next point starts a new contour (needs "M" prefix).
+    new_contour: bool,
+}
+
+impl FreehandState {
+    fn new(param_name: &str, initial_path: &str) -> Self {
+        Self {
+            param_name: param_name.to_string(),
+            is_drawing: false,
+            path_string: initial_path.to_string(),
+            new_contour: true,
+        }
+    }
+
+    /// Start a new drawing stroke.
+    fn start_stroke(&mut self) {
+        self.is_drawing = true;
+        self.new_contour = true;
+    }
+
+    /// Add a point to the current stroke.
+    fn add_point(&mut self, x: f64, y: f64) {
+        if self.new_contour {
+            self.path_string.push('M');
+            self.new_contour = false;
+        } else {
+            self.path_string.push(' ');
+        }
+        // Match Java format: "%.2f,%.2f"
+        use std::fmt::Write;
+        let _ = write!(self.path_string, "{:.2},{:.2}", x, y);
+    }
+
+    /// End the current stroke.
+    fn end_stroke(&mut self) {
+        self.is_drawing = false;
+    }
 }
 
 /// Which tab is currently selected in the viewer.
@@ -238,6 +287,8 @@ pub struct ViewerPane {
     preferred_geometry_tab: ViewerTab,
     /// Whether the Visual tab is available (rendered node outputs Geometry/Point).
     visual_tab_available: bool,
+    /// Freehand drawing state (active when a freehand node is selected).
+    freehand_state: Option<FreehandState>,
 }
 
 impl Default for ViewerPane {
@@ -270,6 +321,7 @@ impl ViewerPane {
             data_view_mode: DataViewMode::Points,
             preferred_geometry_tab: ViewerTab::Viewer,
             visual_tab_available: true,
+            freehand_state: None,
         }
     }
 
@@ -277,6 +329,7 @@ impl ViewerPane {
     pub fn is_dragging(&self) -> bool {
         self.dragging_handle.is_some()
             || self.four_point_handle.as_ref().is_some_and(|fp| fp.is_dragging())
+            || self.freehand_state.as_ref().is_some_and(|fs| fs.is_drawing)
     }
 
     /// Get the current pan offset.
@@ -659,6 +712,67 @@ impl ViewerPane {
         // Handle interactions (only if not panning)
         if !self.is_space_pressed && self.show_handles {
             let mouse_pos = ui.input(|i| i.pointer.hover_pos());
+
+            // Handle freehand drawing (takes priority when freehand node is selected)
+            if self.freehand_state.is_some() {
+                // Draw cursor indicator (5px radius circle, like Java FreehandHandle)
+                if let Some(pos) = mouse_pos {
+                    if response.hovered() {
+                        painter.circle_stroke(
+                            pos,
+                            5.0,
+                            Stroke::new(1.0, Color32::from_gray(128)),
+                        );
+                    }
+                }
+
+                // Mouse pressed: start new contour
+                if response.drag_started_by(egui::PointerButton::Primary) {
+                    let freehand = self.freehand_state.as_mut().unwrap();
+                    freehand.start_stroke();
+                    if let Some(pos) = mouse_pos {
+                        let world = screen_to_world(pos, self.pan_zoom.zoom, self.pan_zoom.pan, center);
+                        freehand.add_point(world.x, world.y);
+                    }
+                    return HandleResult::StringChange {
+                        param: self.freehand_state.as_ref().unwrap().param_name.clone(),
+                        value: self.freehand_state.as_ref().unwrap().path_string.clone(),
+                    };
+                }
+
+                // Mouse dragged: add points to current contour
+                if self.freehand_state.as_ref().unwrap().is_drawing
+                    && response.dragged_by(egui::PointerButton::Primary)
+                {
+                    if let Some(pos) = mouse_pos {
+                        let freehand = self.freehand_state.as_mut().unwrap();
+                        let world = screen_to_world(pos, self.pan_zoom.zoom, self.pan_zoom.pan, center);
+                        freehand.add_point(world.x, world.y);
+                    }
+                    return HandleResult::StringChange {
+                        param: self.freehand_state.as_ref().unwrap().param_name.clone(),
+                        value: self.freehand_state.as_ref().unwrap().path_string.clone(),
+                    };
+                }
+
+                // Mouse released: end stroke
+                if self.freehand_state.as_ref().unwrap().is_drawing
+                    && response.drag_stopped_by(egui::PointerButton::Primary)
+                {
+                    self.freehand_state.as_mut().unwrap().end_stroke();
+                    return HandleResult::StringChange {
+                        param: self.freehand_state.as_ref().unwrap().param_name.clone(),
+                        value: self.freehand_state.as_ref().unwrap().path_string.clone(),
+                    };
+                }
+
+                // Change cursor to crosshair when hovering over canvas with freehand active
+                if response.hovered() {
+                    ui.ctx().set_cursor_icon(egui::CursorIcon::Crosshair);
+                }
+
+                return HandleResult::None;
+            }
 
             // Handle FourPointHandle first (takes priority)
             if let Some(ref mut four_point) = self.four_point_handle {
@@ -1613,7 +1727,26 @@ impl ViewerPane {
 
                                 handle_set.add(Handle::point("position", position));
                             }
-                            _ => {}
+                            "corevector.freehand" => {
+                                // Read current path string from the node
+                                let path = node
+                                    .input("path")
+                                    .and_then(|p| p.value.as_string())
+                                    .unwrap_or("");
+
+                                // Initialize freehand state if not already active
+                                if self.freehand_state.is_none() {
+                                    self.freehand_state = Some(FreehandState::new("path", path));
+                                } else if let Some(ref mut fs) = self.freehand_state {
+                                    // Sync with node's current value when not drawing
+                                    if !fs.is_drawing {
+                                        fs.path_string = path.to_string();
+                                    }
+                                }
+                            }
+                            _ => {
+                                self.freehand_state = None;
+                            }
                         }
                     }
 
@@ -1631,11 +1764,13 @@ impl ViewerPane {
                 } else {
                     self.handles = None;
                     self.four_point_handle = None;
+                    self.freehand_state = None;
                 }
             }
             None => {
                 self.handles = None;
                 self.four_point_handle = None;
+                self.freehand_state = None;
             }
         }
     }


### PR DESCRIPTION
## Summary
This PR adds freehand drawing capabilities to the viewer pane, allowing users to draw paths directly on the canvas when a freehand node is selected. The implementation includes a new `StringChange` handle result type and state management for tracking drawing operations.

## Key Changes
- **New `HandleResult::StringChange` variant**: Added to support string parameter updates from freehand drawing operations
- **`FreehandState` struct**: Manages the state of freehand drawing including:
  - Current path string accumulation
  - Drawing state (whether mouse is currently pressed)
  - Contour tracking (for SVG path "M" command prefixes)
  - Methods to start/end strokes and add points
- **Freehand drawing interaction**: 
  - Detects `corevector.freehand` nodes and initializes freehand state
  - Handles mouse press to start new strokes
  - Accumulates points during mouse drag operations
  - Ends strokes on mouse release
  - Displays crosshair cursor and 5px radius circle indicator when hovering
  - Takes priority over other handle interactions
- **State synchronization**: Freehand state is cleared when switching away from freehand nodes and synced with node values when not actively drawing
- **App-level integration**: Added `handle_string_change()` method to update node parameters with string values from freehand drawing
- **Drag detection**: Updated `is_dragging()` to include freehand drawing state

## Implementation Details
- Points are formatted as "%.2f,%.2f" matching the Java implementation
- Path strings use SVG-like syntax with "M" commands for new contours and space-separated coordinates
- Coordinate conversion from screen space to world space is performed using existing `screen_to_world()` utility
- Freehand state is properly cleaned up in all node deselection paths

https://claude.ai/code/session_011SGGxrHu2QGENF6nQ7n2KD