### PR TITLE
Add macOS file association support for .ndbx files

### DIFF
--- a/crates/nodebox-gui/src/app.rs
+++ b/crates/nodebox-gui/src/app.rs
@@ -635,6 +635,12 @@ impl eframe::App for NodeBoxApp {
             self.open_dropped_file(&path);
         }
 
+        // Handle files opened via macOS file association (Finder double-click)
+        #[cfg(target_os = "macos")]
+        for path in crate::macos_file_open::take_pending_files() {
+            self.open_dropped_file(&path);
+        }
+
         // Poll for background render results
         self.poll_render_results();
 

--- a/crates/nodebox-gui/src/app.rs
+++ b/crates/nodebox-gui/src/app.rs
@@ -619,6 +619,22 @@ impl eframe::App for NodeBoxApp {
             }
         }
 
+        // Handle dropped files (drag-and-drop .ndbx files onto the window)
+        let dropped_file = ctx.input(|i| {
+            i.raw.dropped_files.iter().find_map(|f| {
+                f.path.as_ref().and_then(|p| {
+                    if p.extension().is_some_and(|ext| ext == "ndbx") {
+                        Some(p.clone())
+                    } else {
+                        None
+                    }
+                })
+            })
+        });
+        if let Some(path) = dropped_file {
+            self.open_dropped_file(&path);
+        }
+
         // Poll for background render results
         self.poll_render_results();
 
@@ -957,6 +973,22 @@ impl NodeBoxApp {
             }
             Ok(None) => {} // User cancelled
             Err(e) => log::error!("Failed to open file dialog: {}", e),
+        }
+    }
+
+    /// Open a file dropped onto the window (drag-and-drop).
+    fn open_dropped_file(&mut self, path: &std::path::Path) {
+        if let Err(e) = self.state.load_file(path) {
+            log::error!("Failed to load dropped file: {}", e);
+        } else {
+            if let (Some(parent), Some(file_name)) = (path.parent(), path.file_name()) {
+                self.project_context =
+                    ProjectContext::new(parent, file_name.to_string_lossy().to_string());
+            }
+            self.add_to_recent_files(path.to_path_buf());
+            self.history = History::new();
+            self.previous_library_hash = Self::hash_library(&self.state.library);
+            self.render_pending = true;
         }
     }
 

--- a/crates/nodebox-gui/src/lib.rs
+++ b/crates/nodebox-gui/src/lib.rs
@@ -66,6 +66,8 @@ pub use vello_renderer::{VelloConfig, VelloError, VelloRenderer, ViewTransform};
 #[cfg(feature = "gpu-rendering")]
 pub use vello_viewer::VelloViewer;
 
+#[cfg(target_os = "macos")]
+pub mod macos_file_open;
 mod native_menu;
 mod recent_files;
 
@@ -102,6 +104,13 @@ pub fn run() -> eframe::Result<()> {
     eframe::run_native(
         "NodeBox",
         options,
-        Box::new(move |cc| Ok(Box::new(NodeBoxApp::new_with_port(cc, port.clone(), initial_file)))),
+        Box::new(move |cc| {
+            // On macOS, inject application:openFiles: into winit's delegate class
+            // so the app can receive file-open events from Finder double-clicks.
+            #[cfg(target_os = "macos")]
+            macos_file_open::inject_file_open_handler();
+
+            Ok(Box::new(NodeBoxApp::new_with_port(cc, port.clone(), initial_file)))
+        }),
     )
 }

--- a/crates/nodebox-gui/src/macos_file_open.rs
+++ b/crates/nodebox-gui/src/macos_file_open.rs
@@ -1,0 +1,135 @@
+//! macOS file-open handler via Objective-C runtime method injection.
+//!
+//! When a user double-clicks a `.ndbx` file in Finder, macOS sends an
+//! `application:openFiles:` message to the app delegate. winit 0.30.12's
+//! delegate doesn't implement this method, so macOS shows an error dialog.
+//!
+//! This module injects `application:openFiles:` into winit's delegate class
+//! at runtime using `class_addMethod`. The injected method stores received
+//! file paths in a global `Mutex<Vec<PathBuf>>`, which the app's `update()`
+//! loop polls each frame.
+//!
+//! Must be called after `NSApplication` and its delegate exist (i.e., inside
+//! the eframe creation callback), but before the event loop dispatches Apple
+//! Events — which is the case because the creation callback runs during
+//! `applicationDidFinishLaunching:`, before queued events are processed.
+
+#![allow(non_snake_case)]
+
+use std::ffi::{c_char, c_void, CStr};
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+// Raw FFI to the Objective-C runtime (libobjc.dylib, always available on macOS).
+#[link(name = "objc", kind = "dylib")]
+extern "C" {
+    fn objc_getClass(name: *const c_char) -> *mut c_void;
+    fn sel_registerName(name: *const c_char) -> *mut c_void;
+    fn object_getClass(obj: *mut c_void) -> *mut c_void;
+    fn class_addMethod(
+        cls: *mut c_void,
+        name: *mut c_void,
+        imp: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, *mut c_void),
+        types: *const c_char,
+    ) -> bool;
+}
+
+// objc_msgSend uses the standard C calling convention on arm64/x86_64 for
+// pointer-sized returns. We declare typed wrappers to avoid variadic FFI issues.
+extern "C" {
+    #[link_name = "objc_msgSend"]
+    fn msg_send_ptr(obj: *mut c_void, sel: *mut c_void) -> *mut c_void;
+    #[link_name = "objc_msgSend"]
+    fn msg_send_usize(obj: *mut c_void, sel: *mut c_void) -> usize;
+    #[link_name = "objc_msgSend"]
+    fn msg_send_ptr_usize(obj: *mut c_void, sel: *mut c_void, idx: usize) -> *mut c_void;
+}
+
+/// File paths received via `application:openFiles:`.
+static PENDING_FILES: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
+
+/// The C-ABI function injected as `application:openFiles:`.
+///
+/// Called by the Objective-C runtime when macOS delivers a file-open event.
+/// Arguments: `self`, `_cmd`, `NSApplication*`, `NSArray<NSString*>*`.
+unsafe extern "C" fn handle_open_files(
+    _this: *mut c_void,
+    _sel: *mut c_void,
+    _app: *mut c_void,
+    filenames: *mut c_void,
+) {
+    if filenames.is_null() {
+        return;
+    }
+
+    let count_sel = sel_registerName(c"count".as_ptr());
+    let count = msg_send_usize(filenames, count_sel);
+
+    let object_at_sel = sel_registerName(c"objectAtIndex:".as_ptr());
+    let utf8_sel = sel_registerName(c"UTF8String".as_ptr());
+
+    let mut files = Vec::new();
+    for i in 0..count {
+        let ns_str = msg_send_ptr_usize(filenames, object_at_sel, i);
+        if ns_str.is_null() {
+            continue;
+        }
+        let c_str = msg_send_ptr(ns_str, utf8_sel) as *const c_char;
+        if c_str.is_null() {
+            continue;
+        }
+        let path_str = CStr::from_ptr(c_str).to_string_lossy();
+        let path = PathBuf::from(path_str.as_ref());
+        if path.extension().is_some_and(|ext| ext == "ndbx") {
+            files.push(path);
+        }
+    }
+
+    if let Ok(mut pending) = PENDING_FILES.lock() {
+        pending.extend(files);
+    }
+}
+
+/// Inject `application:openFiles:` into the current `NSApp` delegate's class.
+///
+/// Call this after `NSApplication` has been initialized (e.g., in the eframe
+/// creation callback). If the delegate already implements `application:openFiles:`,
+/// `class_addMethod` returns false and the existing implementation is kept.
+pub fn inject_file_open_handler() {
+    unsafe {
+        let ns_app_class = objc_getClass(c"NSApplication".as_ptr());
+        if ns_app_class.is_null() {
+            return;
+        }
+
+        let shared_sel = sel_registerName(c"sharedApplication".as_ptr());
+        let app = msg_send_ptr(ns_app_class, shared_sel);
+        if app.is_null() {
+            return;
+        }
+
+        let delegate_sel = sel_registerName(c"delegate".as_ptr());
+        let delegate = msg_send_ptr(app, delegate_sel);
+        if delegate.is_null() {
+            return;
+        }
+
+        let cls = object_getClass(delegate);
+        if cls.is_null() {
+            return;
+        }
+
+        let open_sel = sel_registerName(c"application:openFiles:".as_ptr());
+
+        // "v@:@@" = void return, self, _cmd, id (NSApplication), id (NSArray)
+        class_addMethod(cls, open_sel, handle_open_files, c"v@:@@".as_ptr());
+    }
+}
+
+/// Drain and return any file paths received via `application:openFiles:`.
+pub fn take_pending_files() -> Vec<PathBuf> {
+    PENDING_FILES
+        .lock()
+        .map(|mut f| f.drain(..).collect())
+        .unwrap_or_default()
+}

--- a/platform/mac/res/Info.plist
+++ b/platform/mac/res/Info.plist
@@ -17,6 +17,31 @@
         <string>NodeBox Document</string>
         <key>CFBundleTypeRole</key>
         <string>Editor</string>
+        <key>LSItemContentTypes</key>
+        <array>
+          <string>net.nodebox.ndbx</string>
+        </array>
+      </dict>
+    </array>
+    <key>UTExportedTypeDeclarations</key>
+    <array>
+      <dict>
+        <key>UTTypeIdentifier</key>
+        <string>net.nodebox.ndbx</string>
+        <key>UTTypeDescription</key>
+        <string>NodeBox Document</string>
+        <key>UTTypeConformsTo</key>
+        <array>
+          <string>public.xml</string>
+          <string>public.data</string>
+        </array>
+        <key>UTTypeTagSpecification</key>
+        <dict>
+          <key>public.filename-extension</key>
+          <array>
+            <string>ndbx</string>
+          </array>
+        </dict>
       </dict>
     </array>
     <key>CFBundleExecutable</key>
@@ -36,36 +61,12 @@
     <key>CFBundleSignature</key>
     <string>ndbx</string>
     <key>CFBundleGetInfoString</key>
-    <string>@@VERSION@@, Copyright EMRG, (c) 2004-2013</string>
+    <string>@@VERSION@@, Copyright EMRG</string>
     <key>CFBundleShortVersionString</key>
     <string>@@VERSION@@</string>
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>NSHighResolutionCapable</key>
     <true/>
-    <key>Java</key>
-    <dict>
-      <key>ClassPath</key>
-      <string>$APP_PACKAGE/Contents/Resources/Java/lib/nodebox.jar</string>
-      <key>JVMVersion</key>
-      <string>1.6+</string>
-      <key>MainClass</key>
-      <string>nodebox.client.Application</string>
-      <key>Properties</key>
-      <dict>
-        <key>com.apple.mrj.application.live-resize</key>
-        <string>false</string>
-        <key>apple.laf.useScreenMenuBar</key>
-        <string>true</string>
-        <key>com.apple.mrj.application.apple.menu.about.name</key>
-        <string>NodeBox</string>
-        <key>apple.awt.graphics.UseQuartz</key>
-        <string>false</string>
-      </dict>
-      <key>VMOptions</key>
-      <string>-Xms1024m -Xmx4096m</string>
-      <key>WorkingDirectory</key>
-      <string>$APP_PACKAGE/Contents/Resources/Java</string>
-   </dict>
   </dict>
 </plist>


### PR DESCRIPTION
## Summary
This PR adds support for opening `.ndbx` files on macOS through Finder double-clicks and drag-and-drop operations. It includes runtime injection of the `application:openFiles:` delegate method into winit's app delegate, along with proper file type declarations in the app bundle.

## Key Changes

- **New macOS file-open handler module** (`macos_file_open.rs`):
  - Uses Objective-C runtime FFI to inject `application:openFiles:` into winit's delegate class at runtime
  - Stores received file paths in a thread-safe global `Mutex<Vec<PathBuf>>`
  - Filters files to only accept `.ndbx` extensions
  - Injection happens during eframe initialization, before the event loop processes Apple Events

- **Updated Info.plist**:
  - Added `LSItemContentTypes` to declare support for `net.nodebox.ndbx` file type
  - Added `UTExportedTypeDeclarations` to define the custom `net.nodebox.ndbx` type with proper conformance to `public.xml` and `public.data`
  - Removed obsolete Java configuration
  - Updated copyright string

- **Enhanced app.rs**:
  - Added `open_dropped_file()` method to handle file loading from both drag-and-drop and macOS file associations
  - Integrated drag-and-drop file handling in the update loop
  - Added macOS-specific polling of pending files from the file-open handler
  - Properly updates project context, recent files, and render state when files are opened

- **Updated lib.rs**:
  - Exposed `macos_file_open` module (macOS-only)
  - Calls `inject_file_open_handler()` during app initialization

## Implementation Details

The solution works around winit 0.30.12's lack of `application:openFiles:` support by:
1. Injecting the method directly into the delegate class using `class_addMethod`
2. Storing file paths in a global mutex that the app polls each frame
3. Timing the injection to occur after NSApplication initialization but before event processing
4. Filtering received files to only process `.ndbx` documents

https://claude.ai/code/session_01NXut6FX3rsrwY1mDyjUadn