### PR TITLE
Rename "Port" to "Platform"

### DIFF
--- a/crates/nodebox-core/src/lib.rs
+++ b/crates/nodebox-core/src/lib.rs
@@ -7,7 +7,7 @@
 //! - Geometry operations (generators, filters, math, etc.)
 //! - NDBX file format (parse/serialize)
 //! - SVG rendering
-//! - Platform abstraction (Port trait)
+//! - Platform abstraction (Platform trait)
 
 pub mod geometry;
 pub mod node;
@@ -15,7 +15,7 @@ pub mod value;
 pub mod ops;
 pub mod ndbx;
 pub mod svg;
-pub mod port;
+pub mod platform;
 
 // Re-export commonly used types at the crate root
 pub use geometry::{

--- a/crates/nodebox-core/src/platform.rs
+++ b/crates/nodebox-core/src/platform.rs
@@ -1,13 +1,13 @@
 //! Platform abstraction layer for NodeBox.
 //!
-//! The Port system provides a unified interface for platform-specific I/O operations,
+//! The Platform system provides a unified interface for platform-specific I/O operations,
 //! enabling the same core logic to run across desktop (macOS, Windows, Linux),
 //! web (WASM), and mobile (iOS, Android) platforms.
 //!
 //! # Design Principles
 //!
-//! 1. **Single trait with runtime capability checking** - One `Port` trait;
-//!    unsupported operations return `Err(PortError::Unsupported)`
+//! 1. **Single trait with runtime capability checking** - One `Platform` trait;
+//!    unsupported operations return `Err(PlatformError::Unsupported)`
 //! 2. **Synchronous API** - All operations are blocking
 //! 3. **Explicit context passing** - `ProjectContext` passed to operations; no global state
 //! 4. **Sandboxed file access** - Files accessible only within project directory,
@@ -180,16 +180,16 @@ impl RelativePath {
     ///
     /// # Errors
     ///
-    /// Returns `PortError::SandboxViolation` if:
+    /// Returns `PlatformError::SandboxViolation` if:
     /// - The path contains ".." components
     /// - The path starts with "/" (absolute path)
     /// - The path starts with a Windows drive letter (e.g., "C:")
-    pub fn new(path: impl AsRef<Path>) -> Result<Self, PortError> {
+    pub fn new(path: impl AsRef<Path>) -> Result<Self, PlatformError> {
         let path = path.as_ref();
 
         // Check for absolute paths
         if path.is_absolute() {
-            return Err(PortError::SandboxViolation);
+            return Err(PlatformError::SandboxViolation);
         }
 
         // Check for Windows-style absolute paths (C:\, D:\, etc.)
@@ -197,7 +197,7 @@ impl RelativePath {
             if s.len() >= 2 {
                 let chars: Vec<char> = s.chars().take(2).collect();
                 if chars[0].is_ascii_alphabetic() && chars[1] == ':' {
-                    return Err(PortError::SandboxViolation);
+                    return Err(PlatformError::SandboxViolation);
                 }
             }
         }
@@ -205,7 +205,7 @@ impl RelativePath {
         // Check for ".." components that could escape the sandbox
         for component in path.components() {
             if let std::path::Component::ParentDir = component {
-                return Err(PortError::SandboxViolation);
+                return Err(PlatformError::SandboxViolation);
             }
         }
 
@@ -223,8 +223,8 @@ impl RelativePath {
     ///
     /// # Errors
     ///
-    /// Returns `PortError::SandboxViolation` if the resulting path would escape the sandbox.
-    pub fn join(&self, path: impl AsRef<Path>) -> Result<Self, PortError> {
+    /// Returns `PlatformError::SandboxViolation` if the resulting path would escape the sandbox.
+    pub fn join(&self, path: impl AsRef<Path>) -> Result<Self, PlatformError> {
         let joined = self.path.join(path);
         Self::new(joined)
     }
@@ -331,7 +331,7 @@ impl std::fmt::Display for LogLevel {
 
 /// Errors that can occur during Port operations.
 #[derive(Debug, Error)]
-pub enum PortError {
+pub enum PlatformError {
     /// Operation not supported on this platform
     #[error("operation not supported on this platform")]
     Unsupported,
@@ -365,21 +365,21 @@ pub enum PortError {
     Other(String),
 }
 
-impl From<std::io::Error> for PortError {
+impl From<std::io::Error> for PlatformError {
     fn from(err: std::io::Error) -> Self {
         match err.kind() {
-            std::io::ErrorKind::NotFound => PortError::NotFound,
-            std::io::ErrorKind::PermissionDenied => PortError::PermissionDenied,
-            _ => PortError::IoError(err.to_string()),
+            std::io::ErrorKind::NotFound => PlatformError::NotFound,
+            std::io::ErrorKind::PermissionDenied => PlatformError::PermissionDenied,
+            _ => PlatformError::IoError(err.to_string()),
         }
     }
 }
 
-/// The main Port trait for platform abstraction.
+/// The main Platform trait for platform abstraction.
 ///
 /// Implementations of this trait provide platform-specific behavior for
 /// file I/O, dialogs, clipboard, network, and other operations.
-pub trait Port: Send + Sync {
+pub trait Platform: Send + Sync {
     // === Platform Info ===
 
     /// Get information about the current platform.
@@ -388,7 +388,7 @@ pub trait Port: Send + Sync {
     // === File Operations ===
 
     /// Read a file from the project directory.
-    fn read_file(&self, ctx: &ProjectContext, path: &RelativePath) -> Result<Vec<u8>, PortError>;
+    fn read_file(&self, ctx: &ProjectContext, path: &RelativePath) -> Result<Vec<u8>, PlatformError>;
 
     /// Write a file to the project directory.
     fn write_file(
@@ -396,43 +396,43 @@ pub trait Port: Send + Sync {
         ctx: &ProjectContext,
         path: &RelativePath,
         data: &[u8],
-    ) -> Result<(), PortError>;
+    ) -> Result<(), PlatformError>;
 
     /// List contents of a directory within the project.
     fn list_directory(
         &self,
         ctx: &ProjectContext,
         path: &RelativePath,
-    ) -> Result<Vec<DirectoryEntry>, PortError>;
+    ) -> Result<Vec<DirectoryEntry>, PlatformError>;
 
     // === Convenience File Operations ===
 
     /// Read a text file (UTF-8) from the project directory.
-    fn read_text_file(&self, ctx: &ProjectContext, path: &str) -> Result<String, PortError>;
+    fn read_text_file(&self, ctx: &ProjectContext, path: &str) -> Result<String, PlatformError>;
 
     /// Read a binary file from the project directory.
-    fn read_binary_file(&self, ctx: &ProjectContext, path: &str) -> Result<Vec<u8>, PortError>;
+    fn read_binary_file(&self, ctx: &ProjectContext, path: &str) -> Result<Vec<u8>, PlatformError>;
 
     /// Load an application resource (icons, fonts, etc.)
-    fn load_app_resource(&self, name: &str) -> Result<Vec<u8>, PortError>;
+    fn load_app_resource(&self, name: &str) -> Result<Vec<u8>, PlatformError>;
 
     // === Project File (special handling) ===
 
     /// Read the project file.
-    fn read_project(&self, ctx: &ProjectContext) -> Result<Vec<u8>, PortError>;
+    fn read_project(&self, ctx: &ProjectContext) -> Result<Vec<u8>, PlatformError>;
 
     /// Write the project file.
-    fn write_project(&self, ctx: &ProjectContext, data: &[u8]) -> Result<(), PortError>;
+    fn write_project(&self, ctx: &ProjectContext, data: &[u8]) -> Result<(), PlatformError>;
 
     // === Library Access ===
 
     /// Load a library by name.
-    fn load_library(&self, name: &str) -> Result<Vec<u8>, PortError>;
+    fn load_library(&self, name: &str) -> Result<Vec<u8>, PlatformError>;
 
     // === Network ===
 
     /// Perform an HTTP GET request.
-    fn http_get(&self, url: &str) -> Result<Vec<u8>, PortError>;
+    fn http_get(&self, url: &str) -> Result<Vec<u8>, PlatformError>;
 
     // === Dialogs (Project-level, return absolute paths) ===
 
@@ -440,14 +440,14 @@ pub trait Port: Send + Sync {
     fn show_open_project_dialog(
         &self,
         filters: &[FileFilter],
-    ) -> Result<Option<PathBuf>, PortError>;
+    ) -> Result<Option<PathBuf>, PlatformError>;
 
     /// Show dialog to choose where to save a new project.
     fn show_save_project_dialog(
         &self,
         filters: &[FileFilter],
         default_name: Option<&str>,
-    ) -> Result<Option<PathBuf>, PortError>;
+    ) -> Result<Option<PathBuf>, PlatformError>;
 
     // === Dialogs (Asset-level, sandboxed to project) ===
 
@@ -456,7 +456,7 @@ pub trait Port: Send + Sync {
         &self,
         ctx: &ProjectContext,
         filters: &[FileFilter],
-    ) -> Result<Option<RelativePath>, PortError>;
+    ) -> Result<Option<RelativePath>, PlatformError>;
 
     /// Show "Save File" dialog for exporting assets.
     fn show_save_file_dialog(
@@ -464,16 +464,16 @@ pub trait Port: Send + Sync {
         ctx: &ProjectContext,
         filters: &[FileFilter],
         default_name: Option<&str>,
-    ) -> Result<Option<RelativePath>, PortError>;
+    ) -> Result<Option<RelativePath>, PlatformError>;
 
     /// Show a "Select Folder" dialog for selecting a directory within the project.
     fn show_select_folder_dialog(
         &self,
         ctx: &ProjectContext,
-    ) -> Result<Option<RelativePath>, PortError>;
+    ) -> Result<Option<RelativePath>, PlatformError>;
 
     /// Show a confirmation dialog with OK and Cancel buttons.
-    fn show_confirm_dialog(&self, title: &str, message: &str) -> Result<bool, PortError>;
+    fn show_confirm_dialog(&self, title: &str, message: &str) -> Result<bool, PlatformError>;
 
     /// Show a message dialog with custom buttons.
     fn show_message_dialog(
@@ -481,15 +481,15 @@ pub trait Port: Send + Sync {
         title: &str,
         message: &str,
         buttons: &[&str],
-    ) -> Result<Option<usize>, PortError>;
+    ) -> Result<Option<usize>, PlatformError>;
 
     // === Clipboard ===
 
     /// Read text from the clipboard.
-    fn clipboard_read_text(&self) -> Result<Option<String>, PortError>;
+    fn clipboard_read_text(&self) -> Result<Option<String>, PlatformError>;
 
     /// Write text to the clipboard.
-    fn clipboard_write_text(&self, text: &str) -> Result<(), PortError>;
+    fn clipboard_write_text(&self, text: &str) -> Result<(), PlatformError>;
 
     // === Logging ===
 
@@ -507,32 +507,32 @@ pub trait Port: Send + Sync {
     // === Configuration ===
 
     /// Get the configuration directory for storing app settings.
-    fn get_config_dir(&self) -> Result<PathBuf, PortError>;
+    fn get_config_dir(&self) -> Result<PathBuf, PlatformError>;
 
     /// List available font families on the system.
     fn list_fonts(&self) -> Vec<String>;
 }
 
-/// A minimal Port implementation for testing.
+/// A minimal Platform implementation for testing.
 ///
-/// This port returns `Unsupported` for most operations, making it suitable
+/// Returns `Unsupported` for most operations, making it suitable
 /// for tests that don't need actual file or dialog operations.
-pub struct TestPort;
+pub struct TestPlatform;
 
-impl TestPort {
-    /// Create a new TestPort.
+impl TestPlatform {
+    /// Create a new TestPlatform.
     pub fn new() -> Self {
         Self
     }
 }
 
-impl Default for TestPort {
+impl Default for TestPlatform {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl Port for TestPort {
+impl Platform for TestPlatform {
     fn platform_info(&self) -> PlatformInfo {
         PlatformInfo {
             os_name: "test".to_string(),
@@ -543,8 +543,8 @@ impl Port for TestPort {
         }
     }
 
-    fn read_file(&self, _ctx: &ProjectContext, _path: &RelativePath) -> Result<Vec<u8>, PortError> {
-        Err(PortError::Unsupported)
+    fn read_file(&self, _ctx: &ProjectContext, _path: &RelativePath) -> Result<Vec<u8>, PlatformError> {
+        Err(PlatformError::Unsupported)
     }
 
     fn write_file(
@@ -552,67 +552,67 @@ impl Port for TestPort {
         _ctx: &ProjectContext,
         _path: &RelativePath,
         _data: &[u8],
-    ) -> Result<(), PortError> {
-        Err(PortError::Unsupported)
+    ) -> Result<(), PlatformError> {
+        Err(PlatformError::Unsupported)
     }
 
     fn list_directory(
         &self,
         _ctx: &ProjectContext,
         _path: &RelativePath,
-    ) -> Result<Vec<DirectoryEntry>, PortError> {
-        Err(PortError::Unsupported)
+    ) -> Result<Vec<DirectoryEntry>, PlatformError> {
+        Err(PlatformError::Unsupported)
     }
 
-    fn read_text_file(&self, _ctx: &ProjectContext, _path: &str) -> Result<String, PortError> {
-        Err(PortError::Unsupported)
+    fn read_text_file(&self, _ctx: &ProjectContext, _path: &str) -> Result<String, PlatformError> {
+        Err(PlatformError::Unsupported)
     }
 
-    fn read_binary_file(&self, _ctx: &ProjectContext, _path: &str) -> Result<Vec<u8>, PortError> {
-        Err(PortError::Unsupported)
+    fn read_binary_file(&self, _ctx: &ProjectContext, _path: &str) -> Result<Vec<u8>, PlatformError> {
+        Err(PlatformError::Unsupported)
     }
 
-    fn load_app_resource(&self, _name: &str) -> Result<Vec<u8>, PortError> {
-        Err(PortError::Unsupported)
+    fn load_app_resource(&self, _name: &str) -> Result<Vec<u8>, PlatformError> {
+        Err(PlatformError::Unsupported)
     }
 
-    fn read_project(&self, _ctx: &ProjectContext) -> Result<Vec<u8>, PortError> {
-        Err(PortError::Unsupported)
+    fn read_project(&self, _ctx: &ProjectContext) -> Result<Vec<u8>, PlatformError> {
+        Err(PlatformError::Unsupported)
     }
 
-    fn write_project(&self, _ctx: &ProjectContext, _data: &[u8]) -> Result<(), PortError> {
-        Err(PortError::Unsupported)
+    fn write_project(&self, _ctx: &ProjectContext, _data: &[u8]) -> Result<(), PlatformError> {
+        Err(PlatformError::Unsupported)
     }
 
-    fn load_library(&self, _name: &str) -> Result<Vec<u8>, PortError> {
-        Err(PortError::Unsupported)
+    fn load_library(&self, _name: &str) -> Result<Vec<u8>, PlatformError> {
+        Err(PlatformError::Unsupported)
     }
 
-    fn http_get(&self, _url: &str) -> Result<Vec<u8>, PortError> {
-        Err(PortError::Unsupported)
+    fn http_get(&self, _url: &str) -> Result<Vec<u8>, PlatformError> {
+        Err(PlatformError::Unsupported)
     }
 
     fn show_open_project_dialog(
         &self,
         _filters: &[FileFilter],
-    ) -> Result<Option<PathBuf>, PortError> {
-        Err(PortError::Unsupported)
+    ) -> Result<Option<PathBuf>, PlatformError> {
+        Err(PlatformError::Unsupported)
     }
 
     fn show_save_project_dialog(
         &self,
         _filters: &[FileFilter],
         _default_name: Option<&str>,
-    ) -> Result<Option<PathBuf>, PortError> {
-        Err(PortError::Unsupported)
+    ) -> Result<Option<PathBuf>, PlatformError> {
+        Err(PlatformError::Unsupported)
     }
 
     fn show_open_file_dialog(
         &self,
         _ctx: &ProjectContext,
         _filters: &[FileFilter],
-    ) -> Result<Option<RelativePath>, PortError> {
-        Err(PortError::Unsupported)
+    ) -> Result<Option<RelativePath>, PlatformError> {
+        Err(PlatformError::Unsupported)
     }
 
     fn show_save_file_dialog(
@@ -620,19 +620,19 @@ impl Port for TestPort {
         _ctx: &ProjectContext,
         _filters: &[FileFilter],
         _default_name: Option<&str>,
-    ) -> Result<Option<RelativePath>, PortError> {
-        Err(PortError::Unsupported)
+    ) -> Result<Option<RelativePath>, PlatformError> {
+        Err(PlatformError::Unsupported)
     }
 
     fn show_select_folder_dialog(
         &self,
         _ctx: &ProjectContext,
-    ) -> Result<Option<RelativePath>, PortError> {
-        Err(PortError::Unsupported)
+    ) -> Result<Option<RelativePath>, PlatformError> {
+        Err(PlatformError::Unsupported)
     }
 
-    fn show_confirm_dialog(&self, _title: &str, _message: &str) -> Result<bool, PortError> {
-        Err(PortError::Unsupported)
+    fn show_confirm_dialog(&self, _title: &str, _message: &str) -> Result<bool, PlatformError> {
+        Err(PlatformError::Unsupported)
     }
 
     fn show_message_dialog(
@@ -640,16 +640,16 @@ impl Port for TestPort {
         _title: &str,
         _message: &str,
         _buttons: &[&str],
-    ) -> Result<Option<usize>, PortError> {
-        Err(PortError::Unsupported)
+    ) -> Result<Option<usize>, PlatformError> {
+        Err(PlatformError::Unsupported)
     }
 
-    fn clipboard_read_text(&self) -> Result<Option<String>, PortError> {
-        Err(PortError::Unsupported)
+    fn clipboard_read_text(&self) -> Result<Option<String>, PlatformError> {
+        Err(PlatformError::Unsupported)
     }
 
-    fn clipboard_write_text(&self, _text: &str) -> Result<(), PortError> {
-        Err(PortError::Unsupported)
+    fn clipboard_write_text(&self, _text: &str) -> Result<(), PlatformError> {
+        Err(PlatformError::Unsupported)
     }
 
     fn log(&self, _level: LogLevel, _message: &str) {}
@@ -658,8 +658,8 @@ impl Port for TestPort {
 
     fn performance_mark_with_details(&self, _name: &str, _details: &str) {}
 
-    fn get_config_dir(&self) -> Result<PathBuf, PortError> {
-        Err(PortError::Unsupported)
+    fn get_config_dir(&self) -> Result<PathBuf, PlatformError> {
+        Err(PlatformError::Unsupported)
     }
 
     fn list_fonts(&self) -> Vec<String> {
@@ -681,22 +681,22 @@ mod tests {
 
     #[test]
     fn test_relative_path_rejects_parent_dir() {
-        assert!(matches!(RelativePath::new(".."), Err(PortError::SandboxViolation)));
-        assert!(matches!(RelativePath::new("../file.txt"), Err(PortError::SandboxViolation)));
-        assert!(matches!(RelativePath::new("subdir/../other.txt"), Err(PortError::SandboxViolation)));
-        assert!(matches!(RelativePath::new("a/b/../../c.txt"), Err(PortError::SandboxViolation)));
+        assert!(matches!(RelativePath::new(".."), Err(PlatformError::SandboxViolation)));
+        assert!(matches!(RelativePath::new("../file.txt"), Err(PlatformError::SandboxViolation)));
+        assert!(matches!(RelativePath::new("subdir/../other.txt"), Err(PlatformError::SandboxViolation)));
+        assert!(matches!(RelativePath::new("a/b/../../c.txt"), Err(PlatformError::SandboxViolation)));
     }
 
     #[test]
     fn test_relative_path_rejects_absolute() {
-        assert!(matches!(RelativePath::new("/etc/passwd"), Err(PortError::SandboxViolation)));
-        assert!(matches!(RelativePath::new("/home/user/file.txt"), Err(PortError::SandboxViolation)));
+        assert!(matches!(RelativePath::new("/etc/passwd"), Err(PlatformError::SandboxViolation)));
+        assert!(matches!(RelativePath::new("/home/user/file.txt"), Err(PlatformError::SandboxViolation)));
     }
 
     #[test]
     fn test_relative_path_rejects_windows_absolute() {
-        assert!(matches!(RelativePath::new("C:/Users/file.txt"), Err(PortError::SandboxViolation)));
-        assert!(matches!(RelativePath::new("D:\\Documents\\file.txt"), Err(PortError::SandboxViolation)));
+        assert!(matches!(RelativePath::new("C:/Users/file.txt"), Err(PlatformError::SandboxViolation)));
+        assert!(matches!(RelativePath::new("D:\\Documents\\file.txt"), Err(PlatformError::SandboxViolation)));
     }
 
     #[test]
@@ -704,7 +704,7 @@ mod tests {
         let base = RelativePath::new("subdir").unwrap();
         let joined = base.join("file.txt").unwrap();
         assert_eq!(joined.as_path(), Path::new("subdir/file.txt"));
-        assert!(matches!(base.join("../escape.txt"), Err(PortError::SandboxViolation)));
+        assert!(matches!(base.join("../escape.txt"), Err(PlatformError::SandboxViolation)));
     }
 
     #[test]
@@ -761,21 +761,21 @@ mod tests {
     #[test]
     fn test_port_error_from_io_error() {
         let not_found = std::io::Error::new(std::io::ErrorKind::NotFound, "not found");
-        assert!(matches!(PortError::from(not_found), PortError::NotFound));
+        assert!(matches!(PlatformError::from(not_found), PlatformError::NotFound));
         let permission = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied");
-        assert!(matches!(PortError::from(permission), PortError::PermissionDenied));
+        assert!(matches!(PlatformError::from(permission), PlatformError::PermissionDenied));
         let other = std::io::Error::new(std::io::ErrorKind::Other, "something else");
-        assert!(matches!(PortError::from(other), PortError::IoError(_)));
+        assert!(matches!(PlatformError::from(other), PlatformError::IoError(_)));
     }
 
     #[test]
     fn test_port_error_display() {
-        assert_eq!(format!("{}", PortError::Unsupported), "operation not supported on this platform");
-        assert_eq!(format!("{}", PortError::NotFound), "not found");
-        assert_eq!(format!("{}", PortError::PermissionDenied), "permission denied");
-        assert_eq!(format!("{}", PortError::SandboxViolation), "path escapes project sandbox");
-        assert_eq!(format!("{}", PortError::NetworkError("timeout".to_string())), "network error: timeout");
-        assert_eq!(format!("{}", PortError::LibraryNotFound("math".to_string())), "library not found: math");
+        assert_eq!(format!("{}", PlatformError::Unsupported), "operation not supported on this platform");
+        assert_eq!(format!("{}", PlatformError::NotFound), "not found");
+        assert_eq!(format!("{}", PlatformError::PermissionDenied), "permission denied");
+        assert_eq!(format!("{}", PlatformError::SandboxViolation), "path escapes project sandbox");
+        assert_eq!(format!("{}", PlatformError::NetworkError("timeout".to_string())), "network error: timeout");
+        assert_eq!(format!("{}", PlatformError::LibraryNotFound("math".to_string())), "library not found: math");
     }
 
     #[test]

--- a/crates/nodebox-desktop/Cargo.toml
+++ b/crates/nodebox-desktop/Cargo.toml
@@ -40,7 +40,7 @@ smol = "2"
 [target.'cfg(target_os = "macos")'.dependencies]
 muda = "0.15"
 
-# DesktopPort dependencies (desktop only)
+# DesktopPlatform dependencies (desktop only)
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rfd = "0.15"
 

--- a/crates/nodebox-desktop/src/app.rs
+++ b/crates/nodebox-desktop/src/app.rs
@@ -2,7 +2,7 @@
 
 use eframe::egui::{self, Pos2, Rect};
 use nodebox_core::geometry::Point;
-use nodebox_core::port::{Port, ProjectContext};
+use nodebox_core::platform::{Platform, ProjectContext};
 use std::sync::Arc;
 
 use crate::address_bar::{AddressBar, AddressBarAction};
@@ -24,8 +24,8 @@ use crate::viewer_pane::{HandleResult, ViewerPane};
 
 /// The main NodeBox application.
 pub struct NodeBoxApp {
-    /// Port for platform-abstracted file operations.
-    port: Arc<dyn Port>,
+    /// Platform for platform-abstracted file operations.
+    port: Arc<dyn Platform>,
     /// Project context for the current project (tracks save location).
     project_context: ProjectContext,
     state: AppState,
@@ -64,13 +64,13 @@ pub struct NodeBoxApp {
 }
 
 impl NodeBoxApp {
-    /// Create a new NodeBox application instance with a Port for file operations.
+    /// Create a new NodeBox application instance with a Platform for file operations.
     ///
-    /// This is the primary constructor that accepts an `Arc<dyn Port>` for
+    /// This is the primary constructor that accepts an `Arc<dyn Platform>` for
     /// platform-abstracted file operations.
     pub fn new_with_port(
         cc: &eframe::CreationContext<'_>,
-        port: Arc<dyn Port>,
+        port: Arc<dyn Platform>,
         initial_file: Option<std::path::PathBuf>,
     ) -> Self {
         // Configure the global theme/style
@@ -140,7 +140,7 @@ impl NodeBoxApp {
 
     /// Create a new NodeBox application instance (legacy constructor).
     ///
-    /// This constructor creates a DesktopPort internally for backwards compatibility.
+    /// This constructor creates a DesktopPlatform internally for backwards compatibility.
     /// Prefer using `new_with_port` for new code.
     #[allow(dead_code)]
     pub fn new(_cc: &eframe::CreationContext<'_>) -> Self {
@@ -149,7 +149,7 @@ impl NodeBoxApp {
 
     /// Create a new NodeBox application instance, optionally loading an initial file.
     ///
-    /// This constructor creates a DesktopPort internally for backwards compatibility.
+    /// This constructor creates a DesktopPlatform internally for backwards compatibility.
     /// Prefer using `new_with_port` for new code.
     pub fn new_with_file(
         cc: &eframe::CreationContext<'_>,
@@ -159,11 +159,11 @@ impl NodeBoxApp {
         // Configure the global theme/style
         theme::configure_style(&cc.egui_ctx);
 
-        // Create a default DesktopPort for backwards compatibility
+        // Create a default DesktopPlatform for backwards compatibility
         #[cfg(not(target_arch = "wasm32"))]
-        let port: Arc<dyn Port> = Arc::new(crate::DesktopPort::new());
+        let port: Arc<dyn Platform> = Arc::new(crate::DesktopPlatform::new());
         #[cfg(target_arch = "wasm32")]
-        compile_error!("WASM builds must use new_with_port with a custom Port implementation");
+        compile_error!("WASM builds must use new_with_port with a custom Platform implementation");
 
         let mut state = AppState::new();
 
@@ -235,7 +235,7 @@ impl NodeBoxApp {
         let hash = Self::hash_library(&state.library);
         let prev_library = Arc::clone(&state.library);
         Self {
-            port: Arc::new(crate::DesktopPort::new()),
+            port: Arc::new(crate::DesktopPlatform::new()),
             project_context: ProjectContext::new_unsaved(),
             state,
             address_bar: AddressBar::new(),
@@ -272,7 +272,7 @@ impl NodeBoxApp {
         let hash = Self::hash_library(&state.library);
         let prev_library = Arc::clone(&state.library);
         Self {
-            port: Arc::new(crate::DesktopPort::new()),
+            port: Arc::new(crate::DesktopPlatform::new()),
             project_context: ProjectContext::new_unsaved(),
             state,
             address_bar: AddressBar::new(),
@@ -321,9 +321,9 @@ impl NodeBoxApp {
         &mut self.history
     }
 
-    /// Get a reference to the Port for file operations.
+    /// Get a reference to the Platform for file operations.
     #[allow(dead_code)]
-    pub fn port(&self) -> &Arc<dyn Port> {
+    pub fn port(&self) -> &Arc<dyn Platform> {
         &self.port
     }
 
@@ -1185,7 +1185,7 @@ impl NodeBoxApp {
     }
 
     fn open_file(&mut self) {
-        use nodebox_core::port::FileFilter;
+        use nodebox_core::platform::FileFilter;
 
         match self.port.show_open_project_dialog(&[FileFilter::nodebox()]) {
             Ok(Some(path)) => {
@@ -1248,7 +1248,7 @@ impl NodeBoxApp {
     }
 
     fn save_file_as(&mut self) {
-        use nodebox_core::port::FileFilter;
+        use nodebox_core::platform::FileFilter;
 
         match self.port.show_save_project_dialog(&[FileFilter::nodebox()], Some("untitled.ndbx")) {
             Ok(Some(path)) => {
@@ -1269,7 +1269,7 @@ impl NodeBoxApp {
     }
 
     fn export_svg(&mut self) {
-        use nodebox_core::port::FileFilter;
+        use nodebox_core::platform::FileFilter;
 
         // Export dialogs use save_project_dialog since exports are not sandboxed
         match self.port.show_save_project_dialog(&[FileFilter::svg()], Some("export.svg")) {
@@ -1287,7 +1287,7 @@ impl NodeBoxApp {
     }
 
     fn export_png(&mut self) {
-        use nodebox_core::port::FileFilter;
+        use nodebox_core::platform::FileFilter;
 
         // Export dialogs use save_project_dialog since exports are not sandboxed
         match self.port.show_save_project_dialog(&[FileFilter::png()], Some("export.png")) {

--- a/crates/nodebox-desktop/src/desktop_platform.rs
+++ b/crates/nodebox-desktop/src/desktop_platform.rs
@@ -1,31 +1,31 @@
-//! Desktop (macOS, Windows, Linux) implementation of the Port trait.
+//! Desktop (macOS, Windows, Linux) implementation of the Platform trait.
 
-use nodebox_core::port::{
-    DirectoryEntry, FileFilter, LogLevel, PlatformInfo, Port, PortError, ProjectContext,
+use nodebox_core::platform::{
+    DirectoryEntry, FileFilter, LogLevel, PlatformInfo, Platform, PlatformError, ProjectContext,
     RelativePath,
 };
 use std::path::{Path, PathBuf};
 
-/// Desktop implementation of the Port trait.
+/// Desktop implementation of the Platform trait.
 ///
 /// Uses native filesystem, rfd for dialogs, arboard for clipboard, and ureq for HTTP.
 #[derive(Debug, Default)]
-pub struct DesktopPort;
+pub struct DesktopPlatform;
 
-impl DesktopPort {
-    /// Create a new DesktopPort instance.
+impl DesktopPlatform {
+    /// Create a new DesktopPlatform instance.
     pub fn new() -> Self {
         Self
     }
 
     /// Get the library directory for the current platform.
-    fn library_dir(&self) -> Result<PathBuf, PortError> {
+    fn library_dir(&self) -> Result<PathBuf, PlatformError> {
         if let Some(proj_dirs) =
             directories::ProjectDirs::from("net", "nodebox", "NodeBox")
         {
             Ok(proj_dirs.data_dir().join("libraries"))
         } else {
-            Err(PortError::Other(
+            Err(PlatformError::Other(
                 "Could not determine library directory".to_string(),
             ))
         }
@@ -37,25 +37,25 @@ impl DesktopPort {
     fn validate_within_project(
         ctx: &ProjectContext,
         path: &Path,
-    ) -> Result<RelativePath, PortError> {
-        let root = ctx.root.as_ref().ok_or(PortError::Unsupported)?;
+    ) -> Result<RelativePath, PlatformError> {
+        let root = ctx.root.as_ref().ok_or(PlatformError::Unsupported)?;
 
         // Canonicalize both paths to resolve symlinks and normalize
         let canonical_root = root.canonicalize().map_err(|e| {
-            PortError::IoError(format!("Failed to canonicalize project root: {}", e))
+            PlatformError::IoError(format!("Failed to canonicalize project root: {}", e))
         })?;
         let canonical_path = path.canonicalize().map_err(|e| {
-            PortError::IoError(format!("Failed to canonicalize selected path: {}", e))
+            PlatformError::IoError(format!("Failed to canonicalize selected path: {}", e))
         })?;
 
         // Check if the selected path is within the project root
         if canonical_path.starts_with(&canonical_root) {
             let relative = canonical_path
                 .strip_prefix(&canonical_root)
-                .map_err(|_| PortError::SandboxViolation)?;
+                .map_err(|_| PlatformError::SandboxViolation)?;
             RelativePath::new(relative)
         } else {
-            Err(PortError::SandboxViolation)
+            Err(PlatformError::SandboxViolation)
         }
     }
 
@@ -65,12 +65,12 @@ impl DesktopPort {
     fn validate_save_path_within_project(
         ctx: &ProjectContext,
         path: &Path,
-    ) -> Result<RelativePath, PortError> {
-        let root = ctx.root.as_ref().ok_or(PortError::Unsupported)?;
+    ) -> Result<RelativePath, PlatformError> {
+        let root = ctx.root.as_ref().ok_or(PlatformError::Unsupported)?;
 
         // Canonicalize the project root
         let canonical_root = root.canonicalize().map_err(|e| {
-            PortError::IoError(format!("Failed to canonicalize project root: {}", e))
+            PlatformError::IoError(format!("Failed to canonicalize project root: {}", e))
         })?;
 
         // For the save path, canonicalize the parent directory (which should exist)
@@ -80,7 +80,7 @@ impl DesktopPort {
                 // Try to canonicalize the parent. If it doesn't exist, try its parent, etc.
                 let canonical_parent = if parent.exists() {
                     parent.canonicalize().map_err(|e| {
-                        PortError::IoError(format!(
+                        PlatformError::IoError(format!(
                             "Failed to canonicalize parent directory: {}",
                             e
                         ))
@@ -92,7 +92,7 @@ impl DesktopPort {
                     loop {
                         if ancestor.exists() {
                             break ancestor.canonicalize().map_err(|e| {
-                                PortError::IoError(format!(
+                                PlatformError::IoError(format!(
                                     "Failed to canonicalize ancestor: {}",
                                     e
                                 ))
@@ -101,7 +101,7 @@ impl DesktopPort {
                         if let Some(p) = ancestor.parent() {
                             ancestor = p.to_path_buf();
                         } else {
-                            return Err(PortError::SandboxViolation);
+                            return Err(PlatformError::SandboxViolation);
                         }
                     }
                 };
@@ -114,7 +114,7 @@ impl DesktopPort {
                     } else {
                         canonical_parent
                             .strip_prefix(&canonical_root)
-                            .map_err(|_| PortError::SandboxViolation)?
+                            .map_err(|_| PlatformError::SandboxViolation)?
                             .to_path_buf()
                     };
 
@@ -151,10 +151,10 @@ impl DesktopPort {
 
                     RelativePath::new(full_relative)
                 } else {
-                    Err(PortError::SandboxViolation)
+                    Err(PlatformError::SandboxViolation)
                 }
             } else {
-                Err(PortError::SandboxViolation)
+                Err(PlatformError::SandboxViolation)
             }
         } else {
             // Path has no parent - just a filename, which is fine
@@ -163,15 +163,15 @@ impl DesktopPort {
     }
 }
 
-impl Port for DesktopPort {
+impl Platform for DesktopPlatform {
     fn platform_info(&self) -> PlatformInfo {
         PlatformInfo::current()
     }
 
-    fn read_file(&self, ctx: &ProjectContext, path: &RelativePath) -> Result<Vec<u8>, PortError> {
-        let root = ctx.root.as_ref().ok_or(PortError::Unsupported)?;
+    fn read_file(&self, ctx: &ProjectContext, path: &RelativePath) -> Result<Vec<u8>, PlatformError> {
+        let root = ctx.root.as_ref().ok_or(PlatformError::Unsupported)?;
         let full_path = root.join(path.as_path());
-        std::fs::read(&full_path).map_err(PortError::from)
+        std::fs::read(&full_path).map_err(PlatformError::from)
     }
 
     fn write_file(
@@ -179,8 +179,8 @@ impl Port for DesktopPort {
         ctx: &ProjectContext,
         path: &RelativePath,
         data: &[u8],
-    ) -> Result<(), PortError> {
-        let root = ctx.root.as_ref().ok_or(PortError::Unsupported)?;
+    ) -> Result<(), PlatformError> {
+        let root = ctx.root.as_ref().ok_or(PlatformError::Unsupported)?;
         let full_path = root.join(path.as_path());
 
         // Create parent directories if needed
@@ -188,15 +188,15 @@ impl Port for DesktopPort {
             std::fs::create_dir_all(parent)?;
         }
 
-        std::fs::write(&full_path, data).map_err(PortError::from)
+        std::fs::write(&full_path, data).map_err(PlatformError::from)
     }
 
     fn list_directory(
         &self,
         ctx: &ProjectContext,
         path: &RelativePath,
-    ) -> Result<Vec<DirectoryEntry>, PortError> {
-        let root = ctx.root.as_ref().ok_or(PortError::Unsupported)?;
+    ) -> Result<Vec<DirectoryEntry>, PlatformError> {
+        let root = ctx.root.as_ref().ok_or(PlatformError::Unsupported)?;
         let full_path = root.join(path.as_path());
 
         let entries = std::fs::read_dir(&full_path)?
@@ -213,22 +213,22 @@ impl Port for DesktopPort {
         Ok(entries)
     }
 
-    fn read_text_file(&self, ctx: &ProjectContext, path: &str) -> Result<String, PortError> {
-        let root = ctx.root.as_ref().ok_or(PortError::Unsupported)?;
+    fn read_text_file(&self, ctx: &ProjectContext, path: &str) -> Result<String, PlatformError> {
+        let root = ctx.root.as_ref().ok_or(PlatformError::Unsupported)?;
         let relative = RelativePath::new(path)?;
         let full_path = root.join(relative.as_path());
         let bytes = std::fs::read(&full_path)?;
-        String::from_utf8(bytes).map_err(|_| PortError::IoError("Invalid UTF-8".to_string()))
+        String::from_utf8(bytes).map_err(|_| PlatformError::IoError("Invalid UTF-8".to_string()))
     }
 
-    fn read_binary_file(&self, ctx: &ProjectContext, path: &str) -> Result<Vec<u8>, PortError> {
-        let root = ctx.root.as_ref().ok_or(PortError::Unsupported)?;
+    fn read_binary_file(&self, ctx: &ProjectContext, path: &str) -> Result<Vec<u8>, PlatformError> {
+        let root = ctx.root.as_ref().ok_or(PlatformError::Unsupported)?;
         let relative = RelativePath::new(path)?;
         let full_path = root.join(relative.as_path());
-        std::fs::read(&full_path).map_err(PortError::from)
+        std::fs::read(&full_path).map_err(PlatformError::from)
     }
 
-    fn load_app_resource(&self, name: &str) -> Result<Vec<u8>, PortError> {
+    fn load_app_resource(&self, name: &str) -> Result<Vec<u8>, PlatformError> {
         // Locate resources relative to executable or in standard location
         let exe_dir = std::env::current_exe()
             .ok()
@@ -243,50 +243,50 @@ impl Port for DesktopPort {
         for dir in resource_dirs.iter().flatten() {
             let path = dir.join(name);
             if path.exists() {
-                return std::fs::read(&path).map_err(PortError::from);
+                return std::fs::read(&path).map_err(PlatformError::from);
             }
         }
 
-        Err(PortError::NotFound)
+        Err(PlatformError::NotFound)
     }
 
-    fn read_project(&self, ctx: &ProjectContext) -> Result<Vec<u8>, PortError> {
-        let path = ctx.project_path().ok_or(PortError::Unsupported)?;
-        std::fs::read(&path).map_err(PortError::from)
+    fn read_project(&self, ctx: &ProjectContext) -> Result<Vec<u8>, PlatformError> {
+        let path = ctx.project_path().ok_or(PlatformError::Unsupported)?;
+        std::fs::read(&path).map_err(PlatformError::from)
     }
 
-    fn write_project(&self, ctx: &ProjectContext, data: &[u8]) -> Result<(), PortError> {
-        let path = ctx.project_path().ok_or(PortError::Unsupported)?;
+    fn write_project(&self, ctx: &ProjectContext, data: &[u8]) -> Result<(), PlatformError> {
+        let path = ctx.project_path().ok_or(PlatformError::Unsupported)?;
 
         // Create parent directories if needed
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
 
-        std::fs::write(&path, data).map_err(PortError::from)
+        std::fs::write(&path, data).map_err(PlatformError::from)
     }
 
-    fn load_library(&self, name: &str) -> Result<Vec<u8>, PortError> {
+    fn load_library(&self, name: &str) -> Result<Vec<u8>, PlatformError> {
         let library_dir = self.library_dir()?;
         let library_path = library_dir.join(format!("{}.ndbx", name));
 
         if !library_path.exists() {
-            return Err(PortError::LibraryNotFound(name.to_string()));
+            return Err(PlatformError::LibraryNotFound(name.to_string()));
         }
 
-        std::fs::read(&library_path).map_err(PortError::from)
+        std::fs::read(&library_path).map_err(PlatformError::from)
     }
 
-    fn http_get(&self, url: &str) -> Result<Vec<u8>, PortError> {
+    fn http_get(&self, url: &str) -> Result<Vec<u8>, PlatformError> {
         let response = ureq::get(url)
             .call()
-            .map_err(|e| PortError::NetworkError(e.to_string()))?;
+            .map_err(|e| PlatformError::NetworkError(e.to_string()))?;
 
         let mut bytes = Vec::new();
         response
             .into_reader()
             .read_to_end(&mut bytes)
-            .map_err(|e| PortError::NetworkError(e.to_string()))?;
+            .map_err(|e| PlatformError::NetworkError(e.to_string()))?;
 
         Ok(bytes)
     }
@@ -294,7 +294,7 @@ impl Port for DesktopPort {
     fn show_open_project_dialog(
         &self,
         filters: &[FileFilter],
-    ) -> Result<Option<PathBuf>, PortError> {
+    ) -> Result<Option<PathBuf>, PlatformError> {
         let mut dialog = rfd::FileDialog::new();
 
         for filter in filters {
@@ -309,7 +309,7 @@ impl Port for DesktopPort {
         &self,
         filters: &[FileFilter],
         default_name: Option<&str>,
-    ) -> Result<Option<PathBuf>, PortError> {
+    ) -> Result<Option<PathBuf>, PlatformError> {
         let mut dialog = rfd::FileDialog::new();
 
         for filter in filters {
@@ -328,8 +328,8 @@ impl Port for DesktopPort {
         &self,
         ctx: &ProjectContext,
         filters: &[FileFilter],
-    ) -> Result<Option<RelativePath>, PortError> {
-        let root = ctx.root.as_ref().ok_or(PortError::Unsupported)?;
+    ) -> Result<Option<RelativePath>, PlatformError> {
+        let root = ctx.root.as_ref().ok_or(PlatformError::Unsupported)?;
         let mut dialog = rfd::FileDialog::new();
 
         // Start in the project directory
@@ -355,8 +355,8 @@ impl Port for DesktopPort {
         ctx: &ProjectContext,
         filters: &[FileFilter],
         default_name: Option<&str>,
-    ) -> Result<Option<RelativePath>, PortError> {
-        let root = ctx.root.as_ref().ok_or(PortError::Unsupported)?;
+    ) -> Result<Option<RelativePath>, PlatformError> {
+        let root = ctx.root.as_ref().ok_or(PlatformError::Unsupported)?;
         let mut dialog = rfd::FileDialog::new();
 
         // Start in the project directory
@@ -384,8 +384,8 @@ impl Port for DesktopPort {
     fn show_select_folder_dialog(
         &self,
         ctx: &ProjectContext,
-    ) -> Result<Option<RelativePath>, PortError> {
-        let root = ctx.root.as_ref().ok_or(PortError::Unsupported)?;
+    ) -> Result<Option<RelativePath>, PlatformError> {
+        let root = ctx.root.as_ref().ok_or(PlatformError::Unsupported)?;
         let mut dialog = rfd::FileDialog::new();
 
         // Start in the project directory
@@ -401,7 +401,7 @@ impl Port for DesktopPort {
         }
     }
 
-    fn show_confirm_dialog(&self, title: &str, message: &str) -> Result<bool, PortError> {
+    fn show_confirm_dialog(&self, title: &str, message: &str) -> Result<bool, PlatformError> {
         let result = rfd::MessageDialog::new()
             .set_title(title)
             .set_description(message)
@@ -416,7 +416,7 @@ impl Port for DesktopPort {
         title: &str,
         message: &str,
         buttons: &[&str],
-    ) -> Result<Option<usize>, PortError> {
+    ) -> Result<Option<usize>, PlatformError> {
         // rfd doesn't support custom button labels directly
         // Map to available button types based on count
         let button_type = match buttons.len() {
@@ -448,24 +448,24 @@ impl Port for DesktopPort {
         Ok(index)
     }
 
-    fn clipboard_read_text(&self) -> Result<Option<String>, PortError> {
+    fn clipboard_read_text(&self) -> Result<Option<String>, PlatformError> {
         let mut clipboard =
-            arboard::Clipboard::new().map_err(|e| PortError::Other(e.to_string()))?;
+            arboard::Clipboard::new().map_err(|e| PlatformError::Other(e.to_string()))?;
 
         match clipboard.get_text() {
             Ok(text) => Ok(Some(text)),
             Err(arboard::Error::ContentNotAvailable) => Ok(None),
-            Err(e) => Err(PortError::Other(e.to_string())),
+            Err(e) => Err(PlatformError::Other(e.to_string())),
         }
     }
 
-    fn clipboard_write_text(&self, text: &str) -> Result<(), PortError> {
+    fn clipboard_write_text(&self, text: &str) -> Result<(), PlatformError> {
         let mut clipboard =
-            arboard::Clipboard::new().map_err(|e| PortError::Other(e.to_string()))?;
+            arboard::Clipboard::new().map_err(|e| PlatformError::Other(e.to_string()))?;
 
         clipboard
             .set_text(text)
-            .map_err(|e| PortError::Other(e.to_string()))
+            .map_err(|e| PlatformError::Other(e.to_string()))
     }
 
     fn log(&self, level: LogLevel, message: &str) {
@@ -485,13 +485,13 @@ impl Port for DesktopPort {
         log::trace!("[PERF] {} - {}", name, details);
     }
 
-    fn get_config_dir(&self) -> Result<PathBuf, PortError> {
+    fn get_config_dir(&self) -> Result<PathBuf, PlatformError> {
         if let Some(proj_dirs) =
             directories::ProjectDirs::from("net", "nodebox", "NodeBox")
         {
             Ok(proj_dirs.config_dir().to_path_buf())
         } else {
-            Err(PortError::Other(
+            Err(PlatformError::Other(
                 "Could not determine config directory".to_string(),
             ))
         }
@@ -518,7 +518,7 @@ mod tests {
 
     #[test]
     fn test_platform_info() {
-        let port = DesktopPort::new();
+        let port = DesktopPlatform::new();
         let info = port.platform_info();
 
         assert!(info.has_filesystem);
@@ -529,7 +529,7 @@ mod tests {
     #[test]
     fn test_read_write_file() {
         let (_temp_dir, ctx) = create_test_context();
-        let port = DesktopPort::new();
+        let port = DesktopPlatform::new();
 
         let path = RelativePath::new("test.txt").unwrap();
         let data = b"Hello, World!";
@@ -545,7 +545,7 @@ mod tests {
     #[test]
     fn test_write_creates_directories() {
         let (_temp_dir, ctx) = create_test_context();
-        let port = DesktopPort::new();
+        let port = DesktopPlatform::new();
 
         let path = RelativePath::new("subdir/nested/file.txt").unwrap();
         let data = b"nested content";
@@ -559,18 +559,18 @@ mod tests {
     #[test]
     fn test_read_nonexistent_file() {
         let (_temp_dir, ctx) = create_test_context();
-        let port = DesktopPort::new();
+        let port = DesktopPlatform::new();
 
         let path = RelativePath::new("nonexistent.txt").unwrap();
         let result = port.read_file(&ctx, &path);
 
-        assert!(matches!(result, Err(PortError::NotFound)));
+        assert!(matches!(result, Err(PlatformError::NotFound)));
     }
 
     #[test]
     fn test_list_directory() {
         let (_temp_dir, ctx) = create_test_context();
-        let port = DesktopPort::new();
+        let port = DesktopPlatform::new();
 
         // Create some files and directories
         port.write_file(&ctx, &RelativePath::new("file1.txt").unwrap(), b"1")
@@ -597,7 +597,7 @@ mod tests {
     #[test]
     fn test_read_write_project() {
         let (_temp_dir, ctx) = create_test_context();
-        let port = DesktopPort::new();
+        let port = DesktopPlatform::new();
 
         let data = b"<ndbx>project content</ndbx>";
 
@@ -609,15 +609,15 @@ mod tests {
 
     #[test]
     fn test_load_library_not_found() {
-        let port = DesktopPort::new();
+        let port = DesktopPlatform::new();
         let result = port.load_library("nonexistent_library_xyz");
 
-        assert!(matches!(result, Err(PortError::LibraryNotFound(_))));
+        assert!(matches!(result, Err(PlatformError::LibraryNotFound(_))));
     }
 
     #[test]
     fn test_get_config_dir() {
-        let port = DesktopPort::new();
+        let port = DesktopPlatform::new();
         let result = port.get_config_dir();
 
         assert!(result.is_ok());
@@ -629,7 +629,7 @@ mod tests {
 
     #[test]
     fn test_log_levels() {
-        let port = DesktopPort::new();
+        let port = DesktopPlatform::new();
 
         // Just verify these don't panic
         port.log(LogLevel::Error, "test error");
@@ -640,7 +640,7 @@ mod tests {
 
     #[test]
     fn test_performance_marks() {
-        let port = DesktopPort::new();
+        let port = DesktopPlatform::new();
 
         // Just verify these don't panic
         port.performance_mark("test-mark");
@@ -656,7 +656,7 @@ mod tests {
         std::fs::write(&file_path, "test content").unwrap();
 
         // Validation should succeed
-        let result = DesktopPort::validate_within_project(&ctx, &file_path);
+        let result = DesktopPlatform::validate_within_project(&ctx, &file_path);
         assert!(result.is_ok());
         let relative = result.unwrap();
         assert_eq!(relative.as_path(), Path::new("test_file.txt"));
@@ -673,7 +673,7 @@ mod tests {
         std::fs::write(&file_path, "nested content").unwrap();
 
         // Validation should succeed
-        let result = DesktopPort::validate_within_project(&ctx, &file_path);
+        let result = DesktopPlatform::validate_within_project(&ctx, &file_path);
         assert!(result.is_ok());
         let relative = result.unwrap();
         assert_eq!(relative.as_path(), Path::new("subdir/nested_file.txt"));
@@ -691,8 +691,8 @@ mod tests {
         std::fs::write(&outside_file, "outside content").unwrap();
 
         // Validation should fail with SandboxViolation
-        let result = DesktopPort::validate_within_project(&ctx, &outside_file);
-        assert!(matches!(result, Err(PortError::SandboxViolation)));
+        let result = DesktopPlatform::validate_within_project(&ctx, &outside_file);
+        assert!(matches!(result, Err(PlatformError::SandboxViolation)));
     }
 
     #[test]
@@ -707,8 +707,8 @@ mod tests {
         std::fs::write(&parent_file, "parent content").unwrap();
 
         // Validation should fail
-        let result = DesktopPort::validate_within_project(&ctx, &parent_file);
-        assert!(matches!(result, Err(PortError::SandboxViolation)));
+        let result = DesktopPlatform::validate_within_project(&ctx, &parent_file);
+        assert!(matches!(result, Err(PlatformError::SandboxViolation)));
     }
 
     #[test]
@@ -718,7 +718,7 @@ mod tests {
         // Save path to an existing location (the file doesn't exist but parent does)
         let save_path = ctx.root.as_ref().unwrap().join("new_file.txt");
 
-        let result = DesktopPort::validate_save_path_within_project(&ctx, &save_path);
+        let result = DesktopPlatform::validate_save_path_within_project(&ctx, &save_path);
         assert!(result.is_ok());
         let relative = result.unwrap();
         assert_eq!(relative.as_path(), Path::new("new_file.txt"));
@@ -735,7 +735,7 @@ mod tests {
         // Save path to the existing subdirectory
         let save_path = subdir.join("new_image.png");
 
-        let result = DesktopPort::validate_save_path_within_project(&ctx, &save_path);
+        let result = DesktopPlatform::validate_save_path_within_project(&ctx, &save_path);
         assert!(result.is_ok());
         let relative = result.unwrap();
         assert_eq!(relative.as_path(), Path::new("assets/new_image.png"));
@@ -751,14 +751,14 @@ mod tests {
         // Try to save outside the project
         let outside_path = temp_dir.path().join("outside.txt");
 
-        let result = DesktopPort::validate_save_path_within_project(&ctx, &outside_path);
-        assert!(matches!(result, Err(PortError::SandboxViolation)));
+        let result = DesktopPlatform::validate_save_path_within_project(&ctx, &outside_path);
+        assert!(matches!(result, Err(PlatformError::SandboxViolation)));
     }
 
     #[test]
     fn test_read_text_file() {
         let (_temp_dir, ctx) = create_test_context();
-        let port = DesktopPort::new();
+        let port = DesktopPlatform::new();
 
         // Create a text file
         let file_path = ctx.root.as_ref().unwrap().join("test.txt");
@@ -772,7 +772,7 @@ mod tests {
     #[test]
     fn test_read_text_file_nested() {
         let (_temp_dir, ctx) = create_test_context();
-        let port = DesktopPort::new();
+        let port = DesktopPlatform::new();
 
         // Create a nested text file
         let subdir = ctx.root.as_ref().unwrap().join("assets");
@@ -787,7 +787,7 @@ mod tests {
     #[test]
     fn test_read_text_file_invalid_utf8() {
         let (_temp_dir, ctx) = create_test_context();
-        let port = DesktopPort::new();
+        let port = DesktopPlatform::new();
 
         // Create a binary file (invalid UTF-8)
         let file_path = ctx.root.as_ref().unwrap().join("binary.dat");
@@ -795,37 +795,37 @@ mod tests {
 
         // Should fail with IoError for invalid UTF-8
         let result = port.read_text_file(&ctx, "binary.dat");
-        assert!(matches!(result, Err(PortError::IoError(_))));
+        assert!(matches!(result, Err(PlatformError::IoError(_))));
     }
 
     #[test]
     fn test_read_text_file_rejects_sandbox_violation() {
         let (_temp_dir, ctx) = create_test_context();
-        let port = DesktopPort::new();
+        let port = DesktopPlatform::new();
 
         // Try to read with ".." in path
         let result = port.read_text_file(&ctx, "../escape.txt");
-        assert!(matches!(result, Err(PortError::SandboxViolation)));
+        assert!(matches!(result, Err(PlatformError::SandboxViolation)));
 
         // Try with absolute path
         let result = port.read_text_file(&ctx, "/etc/passwd");
-        assert!(matches!(result, Err(PortError::SandboxViolation)));
+        assert!(matches!(result, Err(PlatformError::SandboxViolation)));
     }
 
     #[test]
     fn test_read_text_file_unsaved_project() {
-        let port = DesktopPort::new();
+        let port = DesktopPlatform::new();
         let ctx = ProjectContext::new_unsaved();
 
         // Should fail because project is unsaved
         let result = port.read_text_file(&ctx, "test.txt");
-        assert!(matches!(result, Err(PortError::Unsupported)));
+        assert!(matches!(result, Err(PlatformError::Unsupported)));
     }
 
     #[test]
     fn test_read_binary_file() {
         let (_temp_dir, ctx) = create_test_context();
-        let port = DesktopPort::new();
+        let port = DesktopPlatform::new();
 
         // Create a binary file
         let data = vec![0x89, 0x50, 0x4E, 0x47]; // PNG magic bytes
@@ -840,19 +840,19 @@ mod tests {
     #[test]
     fn test_read_binary_file_rejects_sandbox_violation() {
         let (_temp_dir, ctx) = create_test_context();
-        let port = DesktopPort::new();
+        let port = DesktopPlatform::new();
 
         // Try to read with ".." in path
         let result = port.read_binary_file(&ctx, "../escape.bin");
-        assert!(matches!(result, Err(PortError::SandboxViolation)));
+        assert!(matches!(result, Err(PlatformError::SandboxViolation)));
     }
 
     #[test]
     fn test_load_app_resource_not_found() {
-        let port = DesktopPort::new();
+        let port = DesktopPlatform::new();
 
         // Resources that don't exist should return NotFound
         let result = port.load_app_resource("nonexistent/icon.png");
-        assert!(matches!(result, Err(PortError::NotFound)));
+        assert!(matches!(result, Err(PlatformError::NotFound)));
     }
 }

--- a/crates/nodebox-desktop/src/eval.rs
+++ b/crates/nodebox-desktop/src/eval.rs
@@ -2274,7 +2274,7 @@ mod tests {
     use nodebox_core::platform::{TestPlatform, ProjectContext};
 
     /// Create a test platform and project context for evaluation tests.
-    fn test_port_and_context() -> (Arc<dyn nodebox_core::platform::Platform>, ProjectContext) {
+    fn test_platform_and_context() -> (Arc<dyn nodebox_core::platform::Platform>, ProjectContext) {
         (Arc::new(TestPlatform::new()), ProjectContext::new_unsaved())
     }
 
@@ -2291,7 +2291,7 @@ mod tests {
             )
             .with_rendered_child("ellipse1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
 
@@ -2322,7 +2322,7 @@ mod tests {
             .with_connection(Connection::new("ellipse1", "colorize1", "shape"))
             .with_rendered_child("colorize1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
 
@@ -2361,7 +2361,7 @@ mod tests {
             .with_connection(Connection::new("rect1", "merge1", "shapes"))
             .with_rendered_child("merge1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
         // Merge collects all connected shapes
         assert_eq!(paths.len(), 2);
@@ -2380,7 +2380,7 @@ mod tests {
             )
             .with_rendered_child("rect1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
 
@@ -2402,7 +2402,7 @@ mod tests {
             )
             .with_rendered_child("line1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
 
@@ -2425,7 +2425,7 @@ mod tests {
             )
             .with_rendered_child("polygon1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
 
@@ -2449,7 +2449,7 @@ mod tests {
             )
             .with_rendered_child("star1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
 
@@ -2474,7 +2474,7 @@ mod tests {
             )
             .with_rendered_child("arc1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
     }
@@ -2499,7 +2499,7 @@ mod tests {
             .with_connection(Connection::new("ellipse1", "translate1", "shape"))
             .with_rendered_child("translate1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
 
@@ -2533,7 +2533,7 @@ mod tests {
             .with_connection(Connection::new("ellipse1", "scale1", "shape"))
             .with_rendered_child("scale1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
 
@@ -2567,7 +2567,7 @@ mod tests {
             .with_connection(Connection::new("ellipse1", "copy1", "shape"))
             .with_rendered_child("copy1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
         // Should have 3 copies
         assert_eq!(paths.len(), 3);
@@ -2576,7 +2576,7 @@ mod tests {
     #[test]
     fn test_evaluate_empty_network() {
         let library = NodeLibrary::new("test");
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
         assert!(paths.is_empty());
     }
@@ -2594,7 +2594,7 @@ mod tests {
             );
         // No rendered_child set
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
         assert!(paths.is_empty());
     }
@@ -2614,7 +2614,7 @@ mod tests {
             .with_rendered_child("colorize1");
 
         // Should handle missing input gracefully
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
         assert!(paths.is_empty());
     }
@@ -2630,7 +2630,7 @@ mod tests {
             .with_rendered_child("unknown1");
 
         // Should handle unknown node type gracefully
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
         assert!(paths.is_empty());
     }
@@ -2655,7 +2655,7 @@ mod tests {
             .with_connection(Connection::new("ellipse1", "resample1", "shape"))
             .with_rendered_child("resample1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
         // Resampled path should have the specified number of points
@@ -2685,7 +2685,7 @@ mod tests {
             .with_connection(Connection::new("grid1", "connect1", "points"))
             .with_rendered_child("connect1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
     }
@@ -2709,7 +2709,7 @@ mod tests {
             )
             .with_rendered_child("ellipse1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
 
@@ -2736,7 +2736,7 @@ mod tests {
             )
             .with_rendered_child("rect1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
 
@@ -2762,7 +2762,7 @@ mod tests {
             )
             .with_rendered_child("rect1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
         // If roundness is applied, the path should have more points than a simple rect
@@ -2783,7 +2783,7 @@ mod tests {
             )
             .with_rendered_child("polygon1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
 
@@ -2809,7 +2809,7 @@ mod tests {
             )
             .with_rendered_child("star1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
 
@@ -2838,7 +2838,7 @@ mod tests {
             )
             .with_rendered_child("arc1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
 
@@ -2874,7 +2874,7 @@ mod tests {
             .with_connection(Connection::new("ellipse1", "copy1", "shape"))
             .with_rendered_child("copy1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 3, "Should have 3 copies");
 
@@ -2912,7 +2912,7 @@ mod tests {
             .with_connection(Connection::new("grid1", "connect1", "points"))
             .with_rendered_child("connect1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
 
@@ -2946,7 +2946,7 @@ mod tests {
             .with_connection(Connection::new("ellipse1", "wiggle1", "shape"))
             .with_rendered_child("wiggle1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
         assert!(!paths.is_empty(), "Wiggle should produce output");
     }
@@ -2976,7 +2976,7 @@ mod tests {
             .with_connection(Connection::new("ellipse1", "fit1", "shape"))
             .with_rendered_child("fit1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
         assert_eq!(paths.len(), 1);
 
@@ -3079,7 +3079,7 @@ mod tests {
             .with_connection(Connection::new("polygon1", "combine1", "list3"))
             .with_rendered_child("combine1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
 
         assert_eq!(
@@ -3150,7 +3150,7 @@ mod tests {
             .with_connection(Connection::new("colorize3", "combine1", "list3"))
             .with_rendered_child("combine1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
 
         assert_eq!(
@@ -3188,7 +3188,7 @@ mod tests {
             .with_connection(Connection::new("rect1", "colorize1", "shape"))
             .with_rendered_child("colorize1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
 
         assert_eq!(
@@ -3229,7 +3229,7 @@ mod tests {
             .with_connection(Connection::new("ellipse1", "combine1", "list2"))
             .with_rendered_child("combine1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
 
         // With no port definitions, list matching treats inputs as VALUE range
@@ -3268,7 +3268,7 @@ mod tests {
             .with_connection(Connection::new("grid1", "rect1", "position"))
             .with_rendered_child("rect1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
 
         // THE KEY ASSERTION: Must produce 100 rectangles, not 1!
@@ -3297,7 +3297,7 @@ mod tests {
             )
             .with_rendered_child("colorize1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, errors) = evaluate_network(&library, &port, &ctx);
 
         // Should have no paths output
@@ -3332,7 +3332,7 @@ mod tests {
             .with_connection(Connection::new("colorize1", "translate1", "shape"))
             .with_rendered_child("translate1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, errors) = evaluate_network(&library, &port, &ctx);
 
         // Should have no output
@@ -3355,7 +3355,7 @@ mod tests {
             )
             .with_rendered_child("ellipse1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, errors) = evaluate_network(&library, &port, &ctx);
 
         // Should have output
@@ -3377,7 +3377,7 @@ mod tests {
             )
             .with_rendered_child("my_colorize_node");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (_paths, _output, errors) = evaluate_network(&library, &port, &ctx);
 
         assert!(!errors.is_empty(), "Should have an error");
@@ -3412,7 +3412,7 @@ mod tests {
             .with_connection(Connection::new("sample1", "rgb1", "red"))
             .with_rendered_child("rgb1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (_paths, output, errors) = evaluate_network(&library, &port, &ctx);
 
         assert!(errors.is_empty(), "Should not produce errors: {:?}", errors);
@@ -3442,7 +3442,7 @@ mod tests {
             )
             .with_rendered_child("ellipse1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (paths, _output, errors) = evaluate_network(&library, &port, &ctx);
 
         assert!(!paths.is_empty(), "Generator should produce output with defaults");
@@ -3493,7 +3493,7 @@ mod tests {
             .with_connection(Connection::new("sample1", "rgb_color1", "red"))
             .with_rendered_child("rgb_color1");
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
         let (_paths, output, errors) = evaluate_network(&library, &port, &ctx);
         assert!(errors.is_empty(), "Should not produce errors: {:?}", errors);
         match &output {

--- a/crates/nodebox-desktop/src/eval.rs
+++ b/crates/nodebox-desktop/src/eval.rs
@@ -2270,7 +2270,7 @@ fn execute_node(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nodebox_core::node::{Port as NodePort, Connection, PortRange};
+    use nodebox_core::node::{Port, Connection, PortRange};
     use nodebox_core::platform::{TestPlatform, ProjectContext};
 
     /// Create a test platform and project context for evaluation tests.
@@ -2285,9 +2285,9 @@ mod tests {
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(NodePort::point("position", Point::new(100.0, 100.0)))
-                    .with_input(NodePort::float("width", 50.0))
-                    .with_input(NodePort::float("height", 50.0))
+                    .with_input(Port::point("position", Point::new(100.0, 100.0)))
+                    .with_input(Port::float("width", 50.0))
+                    .with_input(Port::float("height", 50.0))
             )
             .with_rendered_child("ellipse1");
 
@@ -2307,17 +2307,17 @@ mod tests {
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(NodePort::point("position", Point::new(100.0, 100.0)))
-                    .with_input(NodePort::float("width", 50.0))
-                    .with_input(NodePort::float("height", 50.0))
+                    .with_input(Port::point("position", Point::new(100.0, 100.0)))
+                    .with_input(Port::float("width", 50.0))
+                    .with_input(Port::float("height", 50.0))
             )
             .with_child(
                 Node::new("colorize1")
                     .with_prototype("corevector.colorize")
-                    .with_input(NodePort::geometry("shape"))
-                    .with_input(NodePort::color("fill", Color::rgb(1.0, 0.0, 0.0)))
-                    .with_input(NodePort::color("stroke", Color::BLACK))
-                    .with_input(NodePort::float("strokeWidth", 2.0))
+                    .with_input(Port::geometry("shape"))
+                    .with_input(Port::color("fill", Color::rgb(1.0, 0.0, 0.0)))
+                    .with_input(Port::color("stroke", Color::BLACK))
+                    .with_input(Port::float("strokeWidth", 2.0))
             )
             .with_connection(Connection::new("ellipse1", "colorize1", "shape"))
             .with_rendered_child("colorize1");
@@ -2341,21 +2341,21 @@ mod tests {
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(NodePort::point("position", Point::ZERO))
-                    .with_input(NodePort::float("width", 50.0))
-                    .with_input(NodePort::float("height", 50.0))
+                    .with_input(Port::point("position", Point::ZERO))
+                    .with_input(Port::float("width", 50.0))
+                    .with_input(Port::float("height", 50.0))
             )
             .with_child(
                 Node::new("rect1")
                     .with_prototype("corevector.rect")
-                    .with_input(NodePort::point("position", Point::new(100.0, 0.0)))
-                    .with_input(NodePort::float("width", 50.0))
-                    .with_input(NodePort::float("height", 50.0))
+                    .with_input(Port::point("position", Point::new(100.0, 0.0)))
+                    .with_input(Port::float("width", 50.0))
+                    .with_input(Port::float("height", 50.0))
             )
             .with_child(
                 Node::new("merge1")
                     .with_prototype("corevector.merge")
-                    .with_input(NodePort::geometry("shapes"))
+                    .with_input(Port::geometry("shapes"))
             )
             .with_connection(Connection::new("ellipse1", "merge1", "shapes"))
             .with_connection(Connection::new("rect1", "merge1", "shapes"))
@@ -2374,9 +2374,9 @@ mod tests {
             .with_child(
                 Node::new("rect1")
                     .with_prototype("corevector.rect")
-                    .with_input(NodePort::point("position", Point::ZERO))
-                    .with_input(NodePort::float("width", 80.0))
-                    .with_input(NodePort::float("height", 40.0))
+                    .with_input(Port::point("position", Point::ZERO))
+                    .with_input(Port::float("width", 80.0))
+                    .with_input(Port::float("height", 40.0))
             )
             .with_rendered_child("rect1");
 
@@ -2396,9 +2396,9 @@ mod tests {
             .with_child(
                 Node::new("line1")
                     .with_prototype("corevector.line")
-                    .with_input(NodePort::point("point1", Point::new(0.0, 0.0)))
-                    .with_input(NodePort::point("point2", Point::new(100.0, 50.0)))
-                    .with_input(NodePort::int("points", 2))
+                    .with_input(Port::point("point1", Point::new(0.0, 0.0)))
+                    .with_input(Port::point("point2", Point::new(100.0, 50.0)))
+                    .with_input(Port::int("points", 2))
             )
             .with_rendered_child("line1");
 
@@ -2418,10 +2418,10 @@ mod tests {
             .with_child(
                 Node::new("polygon1")
                     .with_prototype("corevector.polygon")
-                    .with_input(NodePort::point("position", Point::ZERO))
-                    .with_input(NodePort::float("radius", 50.0))
-                    .with_input(NodePort::int("sides", 6))
-                    .with_input(NodePort::boolean("align", true))
+                    .with_input(Port::point("position", Point::ZERO))
+                    .with_input(Port::float("radius", 50.0))
+                    .with_input(Port::int("sides", 6))
+                    .with_input(Port::boolean("align", true))
             )
             .with_rendered_child("polygon1");
 
@@ -2442,10 +2442,10 @@ mod tests {
             .with_child(
                 Node::new("star1")
                     .with_prototype("corevector.star")
-                    .with_input(NodePort::point("position", Point::ZERO))
-                    .with_input(NodePort::int("points", 5))
-                    .with_input(NodePort::float("outer", 50.0))
-                    .with_input(NodePort::float("inner", 25.0))
+                    .with_input(Port::point("position", Point::ZERO))
+                    .with_input(Port::int("points", 5))
+                    .with_input(Port::float("outer", 50.0))
+                    .with_input(Port::float("inner", 25.0))
             )
             .with_rendered_child("star1");
 
@@ -2465,12 +2465,12 @@ mod tests {
             .with_child(
                 Node::new("arc1")
                     .with_prototype("corevector.arc")
-                    .with_input(NodePort::point("position", Point::ZERO))
-                    .with_input(NodePort::float("width", 100.0))
-                    .with_input(NodePort::float("height", 100.0))
-                    .with_input(NodePort::float("start_angle", 0.0))
-                    .with_input(NodePort::float("degrees", 180.0))
-                    .with_input(NodePort::string("type", "pie"))
+                    .with_input(Port::point("position", Point::ZERO))
+                    .with_input(Port::float("width", 100.0))
+                    .with_input(Port::float("height", 100.0))
+                    .with_input(Port::float("start_angle", 0.0))
+                    .with_input(Port::float("degrees", 180.0))
+                    .with_input(Port::string("type", "pie"))
             )
             .with_rendered_child("arc1");
 
@@ -2486,15 +2486,15 @@ mod tests {
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(NodePort::point("position", Point::ZERO))
-                    .with_input(NodePort::float("width", 50.0))
-                    .with_input(NodePort::float("height", 50.0))
+                    .with_input(Port::point("position", Point::ZERO))
+                    .with_input(Port::float("width", 50.0))
+                    .with_input(Port::float("height", 50.0))
             )
             .with_child(
                 Node::new("translate1")
                     .with_prototype("corevector.translate")
-                    .with_input(NodePort::geometry("shape"))
-                    .with_input(NodePort::point("translate", Point::new(100.0, 50.0)))
+                    .with_input(Port::geometry("shape"))
+                    .with_input(Port::point("translate", Point::new(100.0, 50.0)))
             )
             .with_connection(Connection::new("ellipse1", "translate1", "shape"))
             .with_rendered_child("translate1");
@@ -2519,16 +2519,16 @@ mod tests {
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(NodePort::point("position", Point::ZERO))
-                    .with_input(NodePort::float("width", 100.0))
-                    .with_input(NodePort::float("height", 100.0))
+                    .with_input(Port::point("position", Point::ZERO))
+                    .with_input(Port::float("width", 100.0))
+                    .with_input(Port::float("height", 100.0))
             )
             .with_child(
                 Node::new("scale1")
                     .with_prototype("corevector.scale")
-                    .with_input(NodePort::geometry("shape"))
-                    .with_input(NodePort::point("scale", Point::new(50.0, 200.0))) // 50% x, 200% y
-                    .with_input(NodePort::point("origin", Point::ZERO))
+                    .with_input(Port::geometry("shape"))
+                    .with_input(Port::point("scale", Point::new(50.0, 200.0))) // 50% x, 200% y
+                    .with_input(Port::point("origin", Point::ZERO))
             )
             .with_connection(Connection::new("ellipse1", "scale1", "shape"))
             .with_rendered_child("scale1");
@@ -2550,19 +2550,19 @@ mod tests {
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(NodePort::point("position", Point::ZERO))
-                    .with_input(NodePort::float("width", 50.0))
-                    .with_input(NodePort::float("height", 50.0))
+                    .with_input(Port::point("position", Point::ZERO))
+                    .with_input(Port::float("width", 50.0))
+                    .with_input(Port::float("height", 50.0))
             )
             .with_child(
                 Node::new("copy1")
                     .with_prototype("corevector.copy")
-                    .with_input(NodePort::geometry("shape"))
-                    .with_input(NodePort::int("copies", 3))
-                    .with_input(NodePort::string("order", "tsr"))
-                    .with_input(NodePort::point("translate", Point::new(60.0, 0.0)))
-                    .with_input(NodePort::float("rotate", 0.0))
-                    .with_input(NodePort::point("scale", Point::new(100.0, 100.0)))
+                    .with_input(Port::geometry("shape"))
+                    .with_input(Port::int("copies", 3))
+                    .with_input(Port::string("order", "tsr"))
+                    .with_input(Port::point("translate", Point::new(60.0, 0.0)))
+                    .with_input(Port::float("rotate", 0.0))
+                    .with_input(Port::point("scale", Point::new(100.0, 100.0)))
             )
             .with_connection(Connection::new("ellipse1", "copy1", "shape"))
             .with_rendered_child("copy1");
@@ -2588,9 +2588,9 @@ mod tests {
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(NodePort::point("position", Point::ZERO))
-                    .with_input(NodePort::float("width", 50.0))
-                    .with_input(NodePort::float("height", 50.0))
+                    .with_input(Port::point("position", Point::ZERO))
+                    .with_input(Port::float("width", 50.0))
+                    .with_input(Port::float("height", 50.0))
             );
         // No rendered_child set
 
@@ -2606,10 +2606,10 @@ mod tests {
             .with_child(
                 Node::new("colorize1")
                     .with_prototype("corevector.colorize")
-                    .with_input(NodePort::geometry("shape"))
-                    .with_input(NodePort::color("fill", Color::rgb(1.0, 0.0, 0.0)))
-                    .with_input(NodePort::color("stroke", Color::BLACK))
-                    .with_input(NodePort::float("strokeWidth", 2.0))
+                    .with_input(Port::geometry("shape"))
+                    .with_input(Port::color("fill", Color::rgb(1.0, 0.0, 0.0)))
+                    .with_input(Port::color("stroke", Color::BLACK))
+                    .with_input(Port::float("strokeWidth", 2.0))
             )
             .with_rendered_child("colorize1");
 
@@ -2642,15 +2642,15 @@ mod tests {
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(NodePort::point("position", Point::ZERO))
-                    .with_input(NodePort::float("width", 100.0))
-                    .with_input(NodePort::float("height", 100.0))
+                    .with_input(Port::point("position", Point::ZERO))
+                    .with_input(Port::float("width", 100.0))
+                    .with_input(Port::float("height", 100.0))
             )
             .with_child(
                 Node::new("resample1")
                     .with_prototype("corevector.resample")
-                    .with_input(NodePort::geometry("shape"))
-                    .with_input(NodePort::int("points", 20))
+                    .with_input(Port::geometry("shape"))
+                    .with_input(Port::int("points", 20))
             )
             .with_connection(Connection::new("ellipse1", "resample1", "shape"))
             .with_rendered_child("resample1");
@@ -2669,18 +2669,18 @@ mod tests {
             .with_child(
                 Node::new("grid1")
                     .with_prototype("corevector.grid")
-                    .with_input(NodePort::int("columns", 3))
-                    .with_input(NodePort::int("rows", 3))
-                    .with_input(NodePort::float("width", 100.0))
-                    .with_input(NodePort::float("height", 100.0))
-                    .with_input(NodePort::point("position", Point::ZERO))
+                    .with_input(Port::int("columns", 3))
+                    .with_input(Port::int("rows", 3))
+                    .with_input(Port::float("width", 100.0))
+                    .with_input(Port::float("height", 100.0))
+                    .with_input(Port::point("position", Point::ZERO))
             )
             .with_child(
                 Node::new("connect1")
                     .with_prototype("corevector.connect")
                     // points port expects entire list, not individual values
-                    .with_input(NodePort::geometry("points").with_port_range(PortRange::List))
-                    .with_input(NodePort::boolean("closed", false))
+                    .with_input(Port::geometry("points").with_port_range(PortRange::List))
+                    .with_input(Port::boolean("closed", false))
             )
             .with_connection(Connection::new("grid1", "connect1", "points"))
             .with_rendered_child("connect1");
@@ -2703,9 +2703,9 @@ mod tests {
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(NodePort::point("position", Point::new(100.0, 50.0)))
-                    .with_input(NodePort::float("width", 50.0))
-                    .with_input(NodePort::float("height", 50.0))
+                    .with_input(Port::point("position", Point::new(100.0, 50.0)))
+                    .with_input(Port::float("width", 50.0))
+                    .with_input(Port::float("height", 50.0))
             )
             .with_rendered_child("ellipse1");
 
@@ -2730,9 +2730,9 @@ mod tests {
             .with_child(
                 Node::new("rect1")
                     .with_prototype("corevector.rect")
-                    .with_input(NodePort::point("position", Point::new(-50.0, 25.0)))
-                    .with_input(NodePort::float("width", 80.0))
-                    .with_input(NodePort::float("height", 40.0))
+                    .with_input(Port::point("position", Point::new(-50.0, 25.0)))
+                    .with_input(Port::float("width", 80.0))
+                    .with_input(Port::float("height", 40.0))
             )
             .with_rendered_child("rect1");
 
@@ -2755,10 +2755,10 @@ mod tests {
             .with_child(
                 Node::new("rect1")
                     .with_prototype("corevector.rect")
-                    .with_input(NodePort::point("position", Point::new(0.0, 0.0)))
-                    .with_input(NodePort::float("width", 100.0))
-                    .with_input(NodePort::float("height", 100.0))
-                    .with_input(NodePort::point("roundness", Point::new(10.0, 10.0)))
+                    .with_input(Port::point("position", Point::new(0.0, 0.0)))
+                    .with_input(Port::float("width", 100.0))
+                    .with_input(Port::float("height", 100.0))
+                    .with_input(Port::point("roundness", Point::new(10.0, 10.0)))
             )
             .with_rendered_child("rect1");
 
@@ -2776,10 +2776,10 @@ mod tests {
             .with_child(
                 Node::new("polygon1")
                     .with_prototype("corevector.polygon")
-                    .with_input(NodePort::point("position", Point::new(200.0, -100.0)))
-                    .with_input(NodePort::float("radius", 50.0))
-                    .with_input(NodePort::int("sides", 6))
-                    .with_input(NodePort::boolean("align", true))
+                    .with_input(Port::point("position", Point::new(200.0, -100.0)))
+                    .with_input(Port::float("radius", 50.0))
+                    .with_input(Port::int("sides", 6))
+                    .with_input(Port::boolean("align", true))
             )
             .with_rendered_child("polygon1");
 
@@ -2802,10 +2802,10 @@ mod tests {
             .with_child(
                 Node::new("star1")
                     .with_prototype("corevector.star")
-                    .with_input(NodePort::point("position", Point::new(75.0, 75.0)))
-                    .with_input(NodePort::int("points", 5))
-                    .with_input(NodePort::float("outer", 50.0))
-                    .with_input(NodePort::float("inner", 25.0))
+                    .with_input(Port::point("position", Point::new(75.0, 75.0)))
+                    .with_input(Port::int("points", 5))
+                    .with_input(Port::float("outer", 50.0))
+                    .with_input(Port::float("inner", 25.0))
             )
             .with_rendered_child("star1");
 
@@ -2829,12 +2829,12 @@ mod tests {
             .with_child(
                 Node::new("arc1")
                     .with_prototype("corevector.arc")
-                    .with_input(NodePort::point("position", Point::new(50.0, -50.0)))
-                    .with_input(NodePort::float("width", 100.0))
-                    .with_input(NodePort::float("height", 100.0))
-                    .with_input(NodePort::float("start_angle", 0.0))
-                    .with_input(NodePort::float("degrees", 180.0))
-                    .with_input(NodePort::string("type", "pie"))
+                    .with_input(Port::point("position", Point::new(50.0, -50.0)))
+                    .with_input(Port::float("width", 100.0))
+                    .with_input(Port::float("height", 100.0))
+                    .with_input(Port::float("start_angle", 0.0))
+                    .with_input(Port::float("degrees", 180.0))
+                    .with_input(Port::string("type", "pie"))
             )
             .with_rendered_child("arc1");
 
@@ -2857,19 +2857,19 @@ mod tests {
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(NodePort::point("position", Point::new(0.0, 0.0)))
-                    .with_input(NodePort::float("width", 50.0))
-                    .with_input(NodePort::float("height", 50.0))
+                    .with_input(Port::point("position", Point::new(0.0, 0.0)))
+                    .with_input(Port::float("width", 50.0))
+                    .with_input(Port::float("height", 50.0))
             )
             .with_child(
                 Node::new("copy1")
                     .with_prototype("corevector.copy")
-                    .with_input(NodePort::geometry("shape"))
-                    .with_input(NodePort::int("copies", 3))
-                    .with_input(NodePort::string("order", "tsr"))
-                    .with_input(NodePort::point("translate", Point::new(60.0, 0.0)))
-                    .with_input(NodePort::float("rotate", 0.0))
-                    .with_input(NodePort::point("scale", Point::new(100.0, 100.0)))
+                    .with_input(Port::geometry("shape"))
+                    .with_input(Port::int("copies", 3))
+                    .with_input(Port::string("order", "tsr"))
+                    .with_input(Port::point("translate", Point::new(60.0, 0.0)))
+                    .with_input(Port::float("rotate", 0.0))
+                    .with_input(Port::point("scale", Point::new(100.0, 100.0)))
             )
             .with_connection(Connection::new("ellipse1", "copy1", "shape"))
             .with_rendered_child("copy1");
@@ -2896,18 +2896,18 @@ mod tests {
             .with_child(
                 Node::new("grid1")
                     .with_prototype("corevector.grid")
-                    .with_input(NodePort::int("columns", 3))
-                    .with_input(NodePort::int("rows", 3))
-                    .with_input(NodePort::float("width", 100.0))
-                    .with_input(NodePort::float("height", 100.0))
-                    .with_input(NodePort::point("position", Point::new(50.0, 50.0)))
+                    .with_input(Port::int("columns", 3))
+                    .with_input(Port::int("rows", 3))
+                    .with_input(Port::float("width", 100.0))
+                    .with_input(Port::float("height", 100.0))
+                    .with_input(Port::point("position", Point::new(50.0, 50.0)))
             )
             .with_child(
                 Node::new("connect1")
                     .with_prototype("corevector.connect")
                     // points port expects entire list, not individual values
-                    .with_input(NodePort::geometry("points").with_port_range(PortRange::List))
-                    .with_input(NodePort::boolean("closed", false))
+                    .with_input(Port::geometry("points").with_port_range(PortRange::List))
+                    .with_input(Port::boolean("closed", false))
             )
             .with_connection(Connection::new("grid1", "connect1", "points"))
             .with_rendered_child("connect1");
@@ -2931,17 +2931,17 @@ mod tests {
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(NodePort::point("position", Point::new(0.0, 0.0)))
-                    .with_input(NodePort::float("width", 100.0))
-                    .with_input(NodePort::float("height", 100.0))
+                    .with_input(Port::point("position", Point::new(0.0, 0.0)))
+                    .with_input(Port::float("width", 100.0))
+                    .with_input(Port::float("height", 100.0))
             )
             .with_child(
                 Node::new("wiggle1")
                     .with_prototype("corevector.wiggle")
-                    .with_input(NodePort::geometry("shape"))
-                    .with_input(NodePort::string("scope", "points"))
-                    .with_input(NodePort::point("offset", Point::new(10.0, 10.0)))
-                    .with_input(NodePort::int("seed", 42))
+                    .with_input(Port::geometry("shape"))
+                    .with_input(Port::string("scope", "points"))
+                    .with_input(Port::point("offset", Point::new(10.0, 10.0)))
+                    .with_input(Port::int("seed", 42))
             )
             .with_connection(Connection::new("ellipse1", "wiggle1", "shape"))
             .with_rendered_child("wiggle1");
@@ -2960,18 +2960,18 @@ mod tests {
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(NodePort::point("position", Point::new(0.0, 0.0)))
-                    .with_input(NodePort::float("width", 200.0))
-                    .with_input(NodePort::float("height", 100.0))
+                    .with_input(Port::point("position", Point::new(0.0, 0.0)))
+                    .with_input(Port::float("width", 200.0))
+                    .with_input(Port::float("height", 100.0))
             )
             .with_child(
                 Node::new("fit1")
                     .with_prototype("corevector.fit")
-                    .with_input(NodePort::geometry("shape"))
-                    .with_input(NodePort::point("position", Point::new(100.0, 100.0)))
-                    .with_input(NodePort::float("width", 50.0))
-                    .with_input(NodePort::float("height", 50.0))
-                    .with_input(NodePort::boolean("keep_proportions", true))
+                    .with_input(Port::geometry("shape"))
+                    .with_input(Port::point("position", Point::new(100.0, 100.0)))
+                    .with_input(Port::float("width", 50.0))
+                    .with_input(Port::float("height", 50.0))
+                    .with_input(Port::boolean("keep_proportions", true))
             )
             .with_connection(Connection::new("ellipse1", "fit1", "shape"))
             .with_rendered_child("fit1");
@@ -3048,31 +3048,31 @@ mod tests {
             .with_child(
                 Node::new("rect1")
                     .with_prototype("corevector.rect")
-                    .with_input(NodePort::point("position", Point::new(-100.0, 0.0)))
-                    .with_input(NodePort::float("width", 50.0))
-                    .with_input(NodePort::float("height", 50.0)),
+                    .with_input(Port::point("position", Point::new(-100.0, 0.0)))
+                    .with_input(Port::float("width", 50.0))
+                    .with_input(Port::float("height", 50.0)),
             )
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(NodePort::point("position", Point::new(0.0, 0.0)))
-                    .with_input(NodePort::float("width", 50.0))
-                    .with_input(NodePort::float("height", 50.0)),
+                    .with_input(Port::point("position", Point::new(0.0, 0.0)))
+                    .with_input(Port::float("width", 50.0))
+                    .with_input(Port::float("height", 50.0)),
             )
             .with_child(
                 Node::new("polygon1")
                     .with_prototype("corevector.polygon")
-                    .with_input(NodePort::point("position", Point::new(100.0, 0.0)))
-                    .with_input(NodePort::float("radius", 25.0))
-                    .with_input(NodePort::int("sides", 6)),
+                    .with_input(Port::point("position", Point::new(100.0, 0.0)))
+                    .with_input(Port::float("radius", 25.0))
+                    .with_input(Port::int("sides", 6)),
             )
             .with_child(
                 Node::new("combine1")
                     .with_prototype("list.combine")
                     // Note: list.combine ports should accept lists, not iterate over them
-                    .with_input(NodePort::geometry("list1").with_port_range(PortRange::List))
-                    .with_input(NodePort::geometry("list2").with_port_range(PortRange::List))
-                    .with_input(NodePort::geometry("list3").with_port_range(PortRange::List)),
+                    .with_input(Port::geometry("list1").with_port_range(PortRange::List))
+                    .with_input(Port::geometry("list2").with_port_range(PortRange::List))
+                    .with_input(Port::geometry("list3").with_port_range(PortRange::List)),
             )
             .with_connection(Connection::new("rect1", "combine1", "list1"))
             .with_connection(Connection::new("ellipse1", "combine1", "list2"))
@@ -3101,41 +3101,41 @@ mod tests {
             .with_child(
                 Node::new("rect1")
                     .with_prototype("corevector.rect")
-                    .with_input(NodePort::point("position", Point::new(-100.0, 0.0)))
-                    .with_input(NodePort::float("width", 50.0))
-                    .with_input(NodePort::float("height", 50.0)),
+                    .with_input(Port::point("position", Point::new(-100.0, 0.0)))
+                    .with_input(Port::float("width", 50.0))
+                    .with_input(Port::float("height", 50.0)),
             )
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(NodePort::point("position", Point::new(0.0, 0.0)))
-                    .with_input(NodePort::float("width", 50.0))
-                    .with_input(NodePort::float("height", 50.0)),
+                    .with_input(Port::point("position", Point::new(0.0, 0.0)))
+                    .with_input(Port::float("width", 50.0))
+                    .with_input(Port::float("height", 50.0)),
             )
             .with_child(
                 Node::new("polygon1")
                     .with_prototype("corevector.polygon")
-                    .with_input(NodePort::point("position", Point::new(100.0, 0.0)))
-                    .with_input(NodePort::float("radius", 25.0))
-                    .with_input(NodePort::int("sides", 6)),
+                    .with_input(Port::point("position", Point::new(100.0, 0.0)))
+                    .with_input(Port::float("radius", 25.0))
+                    .with_input(Port::int("sides", 6)),
             )
             .with_child(
                 Node::new("colorize1")
                     .with_prototype("corevector.colorize")
-                    .with_input(NodePort::geometry("shape"))
-                    .with_input(NodePort::color("fill", Color::rgb(1.0, 0.0, 0.0))),
+                    .with_input(Port::geometry("shape"))
+                    .with_input(Port::color("fill", Color::rgb(1.0, 0.0, 0.0))),
             )
             .with_child(
                 Node::new("colorize2")
                     .with_prototype("corevector.colorize")
-                    .with_input(NodePort::geometry("shape"))
-                    .with_input(NodePort::color("fill", Color::rgb(0.0, 1.0, 0.0))),
+                    .with_input(Port::geometry("shape"))
+                    .with_input(Port::color("fill", Color::rgb(0.0, 1.0, 0.0))),
             )
             .with_child(
                 Node::new("colorize3")
                     .with_prototype("corevector.colorize")
-                    .with_input(NodePort::geometry("shape"))
-                    .with_input(NodePort::color("fill", Color::rgb(0.0, 0.0, 1.0))),
+                    .with_input(Port::geometry("shape"))
+                    .with_input(Port::color("fill", Color::rgb(0.0, 0.0, 1.0))),
             )
             .with_child(
                 Node::new("combine1")
@@ -3175,15 +3175,15 @@ mod tests {
             .with_child(
                 Node::new("rect1")
                     .with_prototype("corevector.rect")
-                    .with_input(NodePort::point("position", Point::ZERO))
-                    .with_input(NodePort::float("width", 50.0))
-                    .with_input(NodePort::float("height", 50.0)),
+                    .with_input(Port::point("position", Point::ZERO))
+                    .with_input(Port::float("width", 50.0))
+                    .with_input(Port::float("height", 50.0)),
             )
             .with_child(
                 Node::new("colorize1")
                     .with_prototype("corevector.colorize")
                     // Only fill is defined, NOT shape - mimics ndbx file
-                    .with_input(NodePort::color("fill", Color::rgb(1.0, 0.0, 0.0))),
+                    .with_input(Port::color("fill", Color::rgb(1.0, 0.0, 0.0))),
             )
             .with_connection(Connection::new("rect1", "colorize1", "shape"))
             .with_rendered_child("colorize1");
@@ -3209,16 +3209,16 @@ mod tests {
             .with_child(
                 Node::new("rect1")
                     .with_prototype("corevector.rect")
-                    .with_input(NodePort::point("position", Point::new(-100.0, 0.0)))
-                    .with_input(NodePort::float("width", 50.0))
-                    .with_input(NodePort::float("height", 50.0)),
+                    .with_input(Port::point("position", Point::new(-100.0, 0.0)))
+                    .with_input(Port::float("width", 50.0))
+                    .with_input(Port::float("height", 50.0)),
             )
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(NodePort::point("position", Point::new(0.0, 0.0)))
-                    .with_input(NodePort::float("width", 50.0))
-                    .with_input(NodePort::float("height", 50.0)),
+                    .with_input(Port::point("position", Point::new(0.0, 0.0)))
+                    .with_input(Port::float("width", 50.0))
+                    .with_input(Port::float("height", 50.0)),
             )
             .with_child(
                 Node::new("combine1")
@@ -3251,19 +3251,19 @@ mod tests {
             .with_child(
                 Node::new("grid1")
                     .with_prototype("corevector.grid")
-                    .with_input(NodePort::int("columns", 10))
-                    .with_input(NodePort::int("rows", 10))
-                    .with_input(NodePort::float("width", 300.0))
-                    .with_input(NodePort::float("height", 300.0))
-                    .with_input(NodePort::point("position", Point::ZERO)),
+                    .with_input(Port::int("columns", 10))
+                    .with_input(Port::int("rows", 10))
+                    .with_input(Port::float("width", 300.0))
+                    .with_input(Port::float("height", 300.0))
+                    .with_input(Port::point("position", Point::ZERO)),
             )
             .with_child(
                 Node::new("rect1")
                     .with_prototype("corevector.rect")
-                    .with_input(NodePort::point("position", Point::ZERO))
-                    .with_input(NodePort::float("width", 20.0))
-                    .with_input(NodePort::float("height", 20.0))
-                    .with_input(NodePort::point("roundness", Point::ZERO)),
+                    .with_input(Port::point("position", Point::ZERO))
+                    .with_input(Port::float("width", 20.0))
+                    .with_input(Port::float("height", 20.0))
+                    .with_input(Port::point("roundness", Point::ZERO)),
             )
             .with_connection(Connection::new("grid1", "rect1", "position"))
             .with_rendered_child("rect1");
@@ -3292,8 +3292,8 @@ mod tests {
             .with_child(
                 Node::new("colorize1")
                     .with_prototype("corevector.colorize")
-                    .with_input(NodePort::geometry("shape"))
-                    .with_input(NodePort::color("fill", Color::rgb(1.0, 0.0, 0.0)))
+                    .with_input(Port::geometry("shape"))
+                    .with_input(Port::color("fill", Color::rgb(1.0, 0.0, 0.0)))
             )
             .with_rendered_child("colorize1");
 
@@ -3321,13 +3321,13 @@ mod tests {
             .with_child(
                 Node::new("colorize1")
                     .with_prototype("corevector.colorize")
-                    .with_input(NodePort::geometry("shape"))
+                    .with_input(Port::geometry("shape"))
             )
             .with_child(
                 Node::new("translate1")
                     .with_prototype("corevector.translate")
-                    .with_input(NodePort::geometry("shape"))
-                    .with_input(NodePort::point("translate", Point::new(10.0, 10.0)))
+                    .with_input(Port::geometry("shape"))
+                    .with_input(Port::point("translate", Point::new(10.0, 10.0)))
             )
             .with_connection(Connection::new("colorize1", "translate1", "shape"))
             .with_rendered_child("translate1");
@@ -3349,9 +3349,9 @@ mod tests {
             .with_child(
                 Node::new("ellipse1")
                     .with_prototype("corevector.ellipse")
-                    .with_input(NodePort::point("position", Point::ZERO))
-                    .with_input(NodePort::float("width", 100.0))
-                    .with_input(NodePort::float("height", 100.0))
+                    .with_input(Port::point("position", Point::ZERO))
+                    .with_input(Port::float("width", 100.0))
+                    .with_input(Port::float("height", 100.0))
             )
             .with_rendered_child("ellipse1");
 
@@ -3373,7 +3373,7 @@ mod tests {
             .with_child(
                 Node::new("my_colorize_node")
                     .with_prototype("corevector.colorize")
-                    .with_input(NodePort::geometry("shape"))
+                    .with_input(Port::geometry("shape"))
             )
             .with_rendered_child("my_colorize_node");
 
@@ -3396,18 +3396,18 @@ mod tests {
             .with_child(
                 Node::new("sample1")
                     .with_prototype("math.sample")
-                    .with_input(NodePort::int("amount", 5))
-                    .with_input(NodePort::float("start", 0.0))
-                    .with_input(NodePort::float("end", 255.0)),
+                    .with_input(Port::int("amount", 5))
+                    .with_input(Port::float("start", 0.0))
+                    .with_input(Port::float("end", 255.0)),
             )
             .with_child(
                 Node::new("rgb1")
                     .with_prototype("color.rgb_color")
-                    .with_input(NodePort::float("red", 0.0))
-                    .with_input(NodePort::float("green", 0.0))
-                    .with_input(NodePort::float("blue", 0.0))
-                    .with_input(NodePort::float("alpha", 255.0))
-                    .with_input(NodePort::float("range", 255.0)),
+                    .with_input(Port::float("red", 0.0))
+                    .with_input(Port::float("green", 0.0))
+                    .with_input(Port::float("blue", 0.0))
+                    .with_input(Port::float("alpha", 255.0))
+                    .with_input(Port::float("range", 255.0)),
             )
             .with_connection(Connection::new("sample1", "rgb1", "red"))
             .with_rendered_child("rgb1");
@@ -3475,19 +3475,19 @@ mod tests {
             .with_child(
                 Node::new("sample1")
                     .with_prototype("math.sample")
-                    .with_input(NodePort::int("amount", 3))
-                    .with_input(NodePort::float("start", 0.0))
-                    .with_input(NodePort::float("end", 255.0))
+                    .with_input(Port::int("amount", 3))
+                    .with_input(Port::float("start", 0.0))
+                    .with_input(Port::float("end", 255.0))
                     .with_output_range(PortRange::List)
             )
             .with_child(
                 Node::new("rgb_color1")
                     .with_prototype("color.rgb_color")
-                    .with_input(NodePort::float("red", 0.0))
-                    .with_input(NodePort::float("green", 0.0))
-                    .with_input(NodePort::float("blue", 0.0))
-                    .with_input(NodePort::float("alpha", 255.0))
-                    .with_input(NodePort::float("range", 255.0))
+                    .with_input(Port::float("red", 0.0))
+                    .with_input(Port::float("green", 0.0))
+                    .with_input(Port::float("blue", 0.0))
+                    .with_input(Port::float("alpha", 255.0))
+                    .with_input(Port::float("range", 255.0))
                     .with_output_type(nodebox_core::node::PortType::Color)
             )
             .with_connection(Connection::new("sample1", "rgb_color1", "red"))

--- a/crates/nodebox-desktop/src/eval.rs
+++ b/crates/nodebox-desktop/src/eval.rs
@@ -7,7 +7,7 @@ use nodebox_core::geometry::font;
 use nodebox_core::node::{Node, NodeLibrary, EvalError};
 use nodebox_core::node::PortRange;
 use nodebox_core::Value;
-use nodebox_core::port::{Port, ProjectContext};
+use nodebox_core::platform::{Platform, ProjectContext};
 use nodebox_core::ops;
 use ops::data::DataValue;
 use crate::render_worker::CancellationToken;
@@ -294,7 +294,7 @@ impl NodeOutput {
 /// The `port` and `project_context` are used for sandboxed file access (e.g., import_svg).
 pub fn evaluate_network(
     library: &NodeLibrary,
-    port: &Arc<dyn Port>,
+    port: &Arc<dyn Platform>,
     project_context: &ProjectContext,
 ) -> (Vec<Path>, NodeOutput, Vec<NodeError>) {
     let network = &library.root;
@@ -360,7 +360,7 @@ pub fn evaluate_network_cancellable(
     library: &NodeLibrary,
     cancel_token: &CancellationToken,
     cache: &mut HashMap<String, NodeOutput>,
-    port: &Arc<dyn Port>,
+    port: &Arc<dyn Platform>,
     project_context: &ProjectContext,
 ) -> EvalOutcome {
     let network = &library.root;
@@ -600,7 +600,7 @@ fn evaluate_node_cancellable(
     node_name: &str,
     cache: &mut HashMap<String, EvalResult>,
     cancel_token: &CancellationToken,
-    port: &Arc<dyn Port>,
+    port: &Arc<dyn Platform>,
     project_context: &ProjectContext,
 ) -> EvalResult {
     // Check cancellation before starting this node
@@ -746,7 +746,7 @@ fn evaluate_node(
     network: &Node,
     node_name: &str,
     cache: &mut HashMap<String, EvalResult>,
-    port: &Arc<dyn Port>,
+    port: &Arc<dyn Platform>,
     project_context: &ProjectContext,
 ) -> EvalResult {
     // Check cache first
@@ -1013,7 +1013,7 @@ fn require_paths(inputs: &HashMap<String, NodeOutput>, node_name: &str, port_nam
 fn execute_node(
     node: &Node,
     inputs: &HashMap<String, NodeOutput>,
-    port: &Arc<dyn Port>,
+    port: &Arc<dyn Platform>,
     project_context: &ProjectContext,
 ) -> EvalResult {
     // Get the function name (prototype determines what the node does)
@@ -2271,11 +2271,11 @@ fn execute_node(
 mod tests {
     use super::*;
     use nodebox_core::node::{Port as NodePort, Connection, PortRange};
-    use nodebox_core::port::{TestPort, ProjectContext};
+    use nodebox_core::platform::{TestPlatform, ProjectContext};
 
-    /// Create a test port and project context for evaluation tests.
-    fn test_port_and_context() -> (Arc<dyn nodebox_core::port::Port>, ProjectContext) {
-        (Arc::new(TestPort::new()), ProjectContext::new_unsaved())
+    /// Create a test platform and project context for evaluation tests.
+    fn test_port_and_context() -> (Arc<dyn nodebox_core::platform::Platform>, ProjectContext) {
+        (Arc::new(TestPlatform::new()), ProjectContext::new_unsaved())
     }
 
     #[test]

--- a/crates/nodebox-desktop/src/lib.rs
+++ b/crates/nodebox-desktop/src/lib.rs
@@ -20,9 +20,9 @@
 //! - `vello_renderer` - High-level Vello renderer wrapper
 
 #[cfg(not(target_arch = "wasm32"))]
-mod desktop_port;
+mod desktop_platform;
 #[cfg(not(target_arch = "wasm32"))]
-pub use desktop_port::DesktopPort;
+pub use desktop_platform::DesktopPlatform;
 
 mod address_bar;
 mod animation_bar;
@@ -62,6 +62,7 @@ pub use state::{populate_default_ports, AppState, Notification, NotificationLeve
 // Re-export commonly used types from dependencies
 pub use nodebox_core::geometry::{Color, Path, Point};
 pub use nodebox_core::node::{Connection, Node, NodeLibrary, Port};
+pub use nodebox_core::platform::Platform;
 pub use nodebox_core::Value;
 
 // Re-export GPU rendering types when feature is enabled
@@ -80,14 +81,14 @@ use std::sync::Arc;
 
 /// Run the NodeBox GUI application.
 ///
-/// This is a convenience function that creates a DesktopPort and runs the app.
+/// This is a convenience function that creates a DesktopPlatform and runs the app.
 /// For more control, use `NodeBoxApp::new_with_port` directly.
 pub fn run() -> eframe::Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Create the desktop port for file operations
-    let port: Arc<dyn nodebox_core::port::Port> = Arc::new(crate::DesktopPort::new());
+    // Create the desktop platform for file operations
+    let port: Arc<dyn nodebox_core::platform::Platform> = Arc::new(crate::DesktopPlatform::new());
 
     // Get initial file from command line arguments
     let initial_file: Option<PathBuf> = std::env::args()

--- a/crates/nodebox-desktop/src/parameter_panel.rs
+++ b/crates/nodebox-desktop/src/parameter_panel.rs
@@ -5,7 +5,7 @@ use eframe::egui::{self, Sense};
 use nodebox_core::geometry::Color;
 use nodebox_core::node::{PortType, Widget};
 use nodebox_core::Value;
-use nodebox_core::port::{FileFilter, Port, PortError, ProjectContext};
+use nodebox_core::platform::{FileFilter, Platform, PlatformError, ProjectContext};
 use crate::components;
 use crate::state::AppState;
 use crate::theme;
@@ -63,7 +63,7 @@ impl ParameterPanel {
         &mut self,
         ui: &mut egui::Ui,
         state: &mut AppState,
-        port: &dyn Port,
+        port: &dyn Platform,
         project_context: &ProjectContext,
     ) {
         // Clear drag state when the primary button is released
@@ -363,7 +363,7 @@ impl ParameterPanel {
         is_connected: bool,
         node_name: &str,
         node_prototype: Option<&str>,
-        io_port: &dyn Port,
+        io_port: &dyn Platform,
         project_context: &ProjectContext,
     ) {
         let is_label_draggable = !is_connected
@@ -483,7 +483,7 @@ impl ParameterPanel {
         port: &mut nodebox_core::node::Port,
         node_name: &str,
         node_prototype: Option<&str>,
-        io_port: &dyn Port,
+        io_port: &dyn Platform,
         project_context: &ProjectContext,
     ) {
         let port_key = (node_name.to_string(), port.name.clone());
@@ -798,7 +798,7 @@ impl ParameterPanel {
                                     *path = relative_path.to_string();
                                 }
                                 Ok(None) => {} // User cancelled
-                                Err(PortError::SandboxViolation) => {
+                                Err(PlatformError::SandboxViolation) => {
                                     let _ = io_port.show_message_dialog(
                                         "File Outside Project",
                                         "Please copy the file to your project folder first.",

--- a/crates/nodebox-desktop/src/render_worker.rs
+++ b/crates/nodebox-desktop/src/render_worker.rs
@@ -7,7 +7,7 @@ use std::thread;
 use std::time::Instant;
 use nodebox_core::geometry::Path as GeoPath;
 use nodebox_core::node::NodeLibrary;
-use nodebox_core::port::{Port, ProjectContext};
+use nodebox_core::platform::{Platform, ProjectContext};
 use crate::eval::{NodeError, NodeOutput};
 
 /// Token for cooperative cancellation of render operations.
@@ -57,7 +57,7 @@ pub enum RenderRequest {
         id: RenderRequestId,
         library: Arc<NodeLibrary>,
         cancel_token: CancellationToken,
-        port: Arc<dyn Port>,
+        port: Arc<dyn Platform>,
         project_context: ProjectContext,
     },
     /// Shut down the worker thread.
@@ -181,7 +181,7 @@ impl RenderWorkerHandle {
         id: RenderRequestId,
         library: Arc<NodeLibrary>,
         cancel_token: CancellationToken,
-        port: Arc<dyn Port>,
+        port: Arc<dyn Platform>,
         project_context: ProjectContext,
     ) {
         if let Some(ref tx) = self.request_tx {
@@ -274,10 +274,10 @@ fn drain_to_latest(
     mut id: RenderRequestId,
     mut library: Arc<NodeLibrary>,
     mut cancel_token: CancellationToken,
-    mut port: Arc<dyn Port>,
+    mut port: Arc<dyn Platform>,
     mut project_context: ProjectContext,
     rx: &mpsc::Receiver<RenderRequest>,
-) -> (RenderRequestId, Arc<NodeLibrary>, CancellationToken, Arc<dyn Port>, ProjectContext) {
+) -> (RenderRequestId, Arc<NodeLibrary>, CancellationToken, Arc<dyn Platform>, ProjectContext) {
     while let Ok(req) = rx.try_recv() {
         match req {
             RenderRequest::Evaluate {

--- a/crates/nodebox-desktop/tests/cancellation_tests.rs
+++ b/crates/nodebox-desktop/tests/cancellation_tests.rs
@@ -8,11 +8,11 @@ use nodebox_core::geometry::Point;
 use nodebox_core::node::{Node, NodeLibrary, Port};
 use nodebox_desktop::eval::{EvalOutcome, NodeOutput, evaluate_network_cancellable};
 use nodebox_desktop::render_worker::CancellationToken;
-use nodebox_core::port::{Port as PortTrait, ProjectContext, TestPort};
+use nodebox_core::platform::{Platform, ProjectContext, TestPlatform};
 
-/// Create a test port and project context for evaluation tests.
-fn test_port_and_context() -> (Arc<dyn PortTrait>, ProjectContext) {
-    (Arc::new(TestPort::new()), ProjectContext::new_unsaved())
+/// Create a test platform and project context for evaluation tests.
+fn test_port_and_context() -> (Arc<dyn Platform>, ProjectContext) {
+    (Arc::new(TestPlatform::new()), ProjectContext::new_unsaved())
 }
 
 /// Helper to create a library with a large grid that generates many iterations.
@@ -185,7 +185,7 @@ fn test_cancellation_response_time() {
     let library_clone = library.clone();
     let handle = thread::spawn(move || {
         let mut thread_cache: HashMap<String, NodeOutput> = HashMap::new();
-        let port: Arc<dyn PortTrait> = Arc::new(TestPort::new());
+        let port: Arc<dyn Platform> = Arc::new(TestPlatform::new());
         let ctx = ProjectContext::new_unsaved();
         evaluate_network_cancellable(&library_clone, &token_for_thread, &mut thread_cache, &port, &ctx)
     });

--- a/crates/nodebox-desktop/tests/cancellation_tests.rs
+++ b/crates/nodebox-desktop/tests/cancellation_tests.rs
@@ -11,7 +11,7 @@ use nodebox_desktop::render_worker::CancellationToken;
 use nodebox_core::platform::{Platform, ProjectContext, TestPlatform};
 
 /// Create a test platform and project context for evaluation tests.
-fn test_port_and_context() -> (Arc<dyn Platform>, ProjectContext) {
+fn test_platform_and_context() -> (Arc<dyn Platform>, ProjectContext) {
     (Arc::new(TestPlatform::new()), ProjectContext::new_unsaved())
 }
 
@@ -71,7 +71,7 @@ fn test_evaluation_completes_without_cancellation() {
     let token = CancellationToken::new();
     let mut cache: HashMap<String, NodeOutput> = HashMap::new();
 
-    let (port, ctx) = test_port_and_context();
+    let (port, ctx) = test_platform_and_context();
     let outcome = evaluate_network_cancellable(&library, &token, &mut cache, &port, &ctx);
 
     match outcome {
@@ -94,7 +94,7 @@ fn test_evaluation_cancelled_immediately() {
     // Cancel immediately
     token.cancel();
 
-    let (port, ctx) = test_port_and_context();
+    let (port, ctx) = test_platform_and_context();
     let outcome = evaluate_network_cancellable(&library, &token, &mut cache, &port, &ctx);
 
     match outcome {
@@ -120,7 +120,7 @@ fn test_cache_preserved_after_cancellation() {
         token_clone.cancel();
     });
 
-    let (port, ctx) = test_port_and_context();
+    let (port, ctx) = test_platform_and_context();
     let outcome = evaluate_network_cancellable(&library, &token, &mut cache, &port, &ctx);
 
     // The outcome could be either cancelled or completed depending on timing
@@ -143,7 +143,7 @@ fn test_cache_reused_after_cancellation() {
 
     // First render - complete fully
     let token1 = CancellationToken::new();
-    let (port, ctx) = test_port_and_context();
+    let (port, ctx) = test_platform_and_context();
     let outcome1 = evaluate_network_cancellable(&library, &token1, &mut cache, &port, &ctx);
 
     match outcome1 {
@@ -220,7 +220,7 @@ fn test_multiple_rapid_cancellations() {
             token.cancel();
         }
 
-        let (port, ctx) = test_port_and_context();
+        let (port, ctx) = test_platform_and_context();
     let outcome = evaluate_network_cancellable(&library, &token, &mut cache, &port, &ctx);
 
         // Should not panic or hang regardless of timing
@@ -240,7 +240,7 @@ fn test_empty_network_not_affected_by_cancellation() {
 
     token.cancel(); // Pre-cancel
 
-    let (port, ctx) = test_port_and_context();
+    let (port, ctx) = test_platform_and_context();
     let outcome = evaluate_network_cancellable(&library, &token, &mut cache, &port, &ctx);
 
     // Empty network should complete (nothing to cancel)

--- a/crates/nodebox-desktop/tests/file_tests.rs
+++ b/crates/nodebox-desktop/tests/file_tests.rs
@@ -11,11 +11,11 @@ use nodebox_core::geometry::{Color, Point};
 use nodebox_core::node::{Connection, Node, NodeLibrary, Port};
 use nodebox_desktop::eval::evaluate_network;
 use nodebox_desktop::{populate_default_ports, AppState};
-use nodebox_core::port::{Port as PortTrait, ProjectContext, TestPort};
+use nodebox_core::platform::{Platform, ProjectContext, TestPlatform};
 
-/// Create a test port and project context for evaluation tests.
-fn test_port_and_context() -> (Arc<dyn PortTrait>, ProjectContext) {
-    (Arc::new(TestPort::new()), ProjectContext::new_unsaved())
+/// Create a test platform and project context for evaluation tests.
+fn test_port_and_context() -> (Arc<dyn Platform>, ProjectContext) {
+    (Arc::new(TestPlatform::new()), ProjectContext::new_unsaved())
 }
 
 /// Get the path to the examples directory.

--- a/crates/nodebox-desktop/tests/file_tests.rs
+++ b/crates/nodebox-desktop/tests/file_tests.rs
@@ -14,7 +14,7 @@ use nodebox_desktop::{populate_default_ports, AppState};
 use nodebox_core::platform::{Platform, ProjectContext, TestPlatform};
 
 /// Create a test platform and project context for evaluation tests.
-fn test_port_and_context() -> (Arc<dyn Platform>, ProjectContext) {
+fn test_platform_and_context() -> (Arc<dyn Platform>, ProjectContext) {
     (Arc::new(TestPlatform::new()), ProjectContext::new_unsaved())
 }
 
@@ -167,19 +167,19 @@ fn test_evaluate_primitives() {
     let mut test_library = library.clone();
     test_library.root.rendered_child = Some("rect1".to_string());
 
-    let (port, ctx) = test_port_and_context();
+    let (port, ctx) = test_platform_and_context();
     let (paths, _output, _errors) = evaluate_network(&test_library, &port, &ctx);
     assert_eq!(paths.len(), 1, "rect1 should produce one path");
 
     // Test ellipse
     test_library.root.rendered_child = Some("ellipse1".to_string());
-    let (port, ctx) = test_port_and_context();
+    let (port, ctx) = test_platform_and_context();
     let (paths, _output, _errors) = evaluate_network(&test_library, &port, &ctx);
     assert_eq!(paths.len(), 1, "ellipse1 should produce one path");
 
     // Test polygon
     test_library.root.rendered_child = Some("polygon1".to_string());
-    let (port, ctx) = test_port_and_context();
+    let (port, ctx) = test_platform_and_context();
     let (paths, _output, _errors) = evaluate_network(&test_library, &port, &ctx);
     assert_eq!(paths.len(), 1, "polygon1 should produce one path");
 }
@@ -189,7 +189,7 @@ fn test_evaluate_primitives_full() {
     let library = create_primitives_library();
 
     // The rendered child is "combine1" which uses list.combine
-    let (port, ctx) = test_port_and_context();
+    let (port, ctx) = test_platform_and_context();
     let (paths, _output, _errors) = evaluate_network(&library, &port, &ctx);
 
     // Should have 3 shapes: rect, ellipse, polygon (each colorized)
@@ -209,7 +209,7 @@ fn test_evaluate_colorized_primitives() {
 
     // Test colorized rect (colorize1 <- rect1)
     test_library.root.rendered_child = Some("colorize1".to_string());
-    let (port, ctx) = test_port_and_context();
+    let (port, ctx) = test_platform_and_context();
     let (paths, _output, _errors) = evaluate_network(&test_library, &port, &ctx);
 
     assert_eq!(paths.len(), 1, "colorize1 should produce one path");
@@ -228,7 +228,7 @@ fn test_primitives_shapes_at_different_positions() {
     // Evaluate rect1 alone
     let mut test_library = library.clone();
     test_library.root.rendered_child = Some("rect1".to_string());
-    let (port, ctx) = test_port_and_context();
+    let (port, ctx) = test_platform_and_context();
     let (rect_paths, _output, _errors) = evaluate_network(&test_library, &port, &ctx);
     assert_eq!(rect_paths.len(), 1, "rect1 should produce one path");
     let rect_bounds = rect_paths[0].bounds().unwrap();

--- a/docs/rust-translation-plan.md
+++ b/docs/rust-translation-plan.md
@@ -62,7 +62,7 @@ nodebox/
 │   │   │   │   └── upgrade.rs   # Version migration
 │   │   │   ├── svg/             # SVG renderer (merged from nodebox-svg)
 │   │   │   │   └── mod.rs
-│   │   │   ├── port.rs          # Port definitions (merged from nodebox-port)
+│   │   │   ├── platform.rs      # Platform definitions (merged from nodebox-port)
 │   │   │   └── value.rs         # Runtime value types
 │   │   └── Cargo.toml
 │   │
@@ -1688,7 +1688,7 @@ All three phases have been implemented:
   - `nodebox-core::ops`: 150+ built-in operations (generators, transforms, filters) — merged from `nodebox-ops`
   - `nodebox-core::ndbx`: NDBX file format parser and writer — merged from `nodebox-ndbx`
   - `nodebox-core::svg`: SVG renderer — merged from `nodebox-svg`
-  - `nodebox-core::port`: Port definitions — merged from `nodebox-port`
+  - `nodebox-core::platform`: Platform definitions — merged from `nodebox-port`
 
 ### Phase 2: GUI ✅
 - `nodebox-desktop`: egui-based desktop GUI application (renamed from `nodebox-gui`) with:

--- a/docs/server-api.md
+++ b/docs/server-api.md
@@ -195,15 +195,15 @@ All errors return JSON:
 
 ---
 
-## WebPort Implementation Notes
+## WebPlatform Implementation Notes
 
-The JavaScript WebPort implementation maps Port trait methods to API calls:
+The JavaScript WebPlatform implementation maps Platform trait methods to API calls:
 
 ```javascript
-const webPort = {
+const webPlatform = {
   async read_file(ctx, path) {
     const resp = await fetch(`/api/v1/projects/${ctx.project_id}/assets/${path}`);
-    if (!resp.ok) throw new PortError(resp.status === 404 ? 'NotFound' : 'IoError');
+    if (!resp.ok) throw new PlatformError(resp.status === 404 ? 'NotFound' : 'IoError');
     return new Uint8Array(await resp.arrayBuffer());
   },
 
@@ -213,18 +213,18 @@ const webPort = {
       headers: { 'Content-Type': 'application/octet-stream' },
       body: data
     });
-    if (!resp.ok) throw new PortError('IoError');
+    if (!resp.ok) throw new PlatformError('IoError');
   },
 
   async list_directory(ctx, path) {
     const resp = await fetch(`/api/v1/projects/${ctx.project_id}/assets/${path}`);
-    if (!resp.ok) throw new PortError(resp.status === 404 ? 'NotFound' : 'IoError');
+    if (!resp.ok) throw new PlatformError(resp.status === 404 ? 'NotFound' : 'IoError');
     return (await resp.json()).entries;
   },
 
   async read_project(ctx) {
     const resp = await fetch(`/api/v1/projects/${ctx.project_id}`);
-    if (!resp.ok) throw new PortError(resp.status === 404 ? 'NotFound' : 'IoError');
+    if (!resp.ok) throw new PlatformError(resp.status === 404 ? 'NotFound' : 'IoError');
     return new Uint8Array(await resp.arrayBuffer());
   },
 
@@ -234,18 +234,18 @@ const webPort = {
       headers: { 'Content-Type': 'application/xml' },
       body: data
     });
-    if (!resp.ok) throw new PortError('IoError');
+    if (!resp.ok) throw new PlatformError('IoError');
   },
 
   async load_library(name) {
     const resp = await fetch(`/api/v1/libraries/${name}`);
-    if (!resp.ok) throw new PortError(resp.status === 404 ? 'LibraryNotFound' : 'IoError');
+    if (!resp.ok) throw new PlatformError(resp.status === 404 ? 'LibraryNotFound' : 'IoError');
     return new Uint8Array(await resp.arrayBuffer());
   },
 
   async http_get(url) {
     const resp = await fetch(url);
-    if (!resp.ok) throw new PortError('NetworkError');
+    if (!resp.ok) throw new PlatformError('NetworkError');
     return new Uint8Array(await resp.arrayBuffer());
   },
 
@@ -360,7 +360,7 @@ const webPort = {
         throw e;
       }
     }
-    throw new PortError('Unsupported');
+    throw new PlatformError('Unsupported');
   },
 
   async show_confirm_dialog(title, message) {
@@ -401,7 +401,7 @@ const webPort = {
 
   get_config_dir() {
     // Web has no config directory; return a virtual path
-    throw new PortError('Unsupported');
+    throw new PlatformError('Unsupported');
   },
 
   platform_info() {
@@ -418,10 +418,10 @@ const webPort = {
 
 ### File System Access API
 
-For browsers that support the File System Access API (Chrome, Edge), the WebPort can provide a more native-like experience:
+For browsers that support the File System Access API (Chrome, Edge), the WebPlatform can provide a more native-like experience:
 
 ```javascript
-class FileSystemAccessPort {
+class FileSystemAccessPlatform {
   constructor(directoryHandle) {
     this.root = directoryHandle;
   }


### PR DESCRIPTION
Rename "Port" platform abstraction to "Platform". There is already a NodeBox Port struct, so this avoids confusion. 