### PR TITLE
Render on a conflated background thread for smooth parameter dragging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@
 ## Build, Test, and Development Commands
 - `ant run` builds and launches NodeBox.
 - `ant test` compiles and runs JUnit tests; XML reports land in `reports/`.
+- `ant test-perf` runs the drag-responsiveness measurement harness (needs a display); writes `build/e2e-artifacts/drag-perf.txt`. Pick a scenario with `-Dperf.example=… -Dperf.node=… -Dperf.port=…`.
 - `ant generate-test-reports` renders HTML reports from `reports/TEST-*.xml`.
 - `ant dist-mac` / `ant dist-win` create packaged apps in `dist/`.
 - `ant clean` removes build artifacts.

--- a/build.xml
+++ b/build.xml
@@ -175,6 +175,20 @@
         </junit>
     </target>
 
+    <target name="test-perf" depends="compile-tests" description="Run the drag responsiveness measurement harness">
+        <mkdir dir="${reports}"/>
+        <junit haltonfailure="true" fork="true" showoutput="true">
+            <env key="NODEBOX_E2E" value="1"/>
+            <jvmarg value="-Dnodebox.perf=true"/>
+            <syspropertyset>
+                <propertyref prefix="perf."/>
+            </syspropertyset>
+            <classpath refid="test.classpath"/>
+            <formatter type="plain" usefile="false"/>
+            <test name="nodebox.e2e.DragPerfE2ETest" todir="${reports}"/>
+        </junit>
+    </target>
+
     <target name="generate-test-reports" depends="test">
         <mkdir dir="${reports}"/>
         <junitreport todir="${reports}">

--- a/src/main/java/nodebox/client/NodeBoxDocument.java
+++ b/src/main/java/nodebox/client/NodeBoxDocument.java
@@ -17,6 +17,7 @@ import nodebox.node.*;
 import nodebox.ui.*;
 import nodebox.util.FileUtils;
 import nodebox.util.LoadException;
+import nodebox.util.PerfMonitor;
 import static nodebox.ui.Platform.COMMAND_DOWN_MASK;
 
 import javax.imageio.ImageIO;
@@ -32,9 +33,6 @@ import java.io.StringWriter;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.*;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.google.common.base.Preconditions.*;
 
@@ -60,8 +58,18 @@ public class NodeBoxDocument extends JFrame implements WindowListener, HandleDel
     // State
     private final NodeLibraryController controller;
     // Rendering
-    private final AtomicBoolean isRendering = new AtomicBoolean(false);
-    private final AtomicBoolean shouldRender = new AtomicBoolean(false);
+    // Interactive render loop (see startRenderLoop / requestRender). A single long-lived background
+    // thread renders the most recently requested state, conflating rapid requests such as a parameter
+    // drag. The EDT only publishes a snapshot and wakes the thread; results come back via one
+    // invokeLater. This keeps every render off the EDT (an expensive render can never freeze the UI)
+    // while paying far less per-frame latency than allocating a fresh SwingWorker per change.
+    private final Object renderLock = new Object();
+    private RenderRequest pendingRequest = null;          // guarded by renderLock; newest unrendered request
+    private boolean renderLoopRunning = true;             // guarded by renderLock
+    private int renderGeneration = 0;                     // guarded by renderLock; identifies each request
+    private volatile int canceledGeneration = -1;         // requests with generation <= this are discarded
+    private Thread renderThread;
+    private volatile long activeRenderStartNanos = 0;     // 0 = idle, else nanoTime() the current render began
     // GUI components
     private final NodeBoxMenuBar menuBar;
     private final AnimationBar animationBar;
@@ -88,7 +96,11 @@ public class NodeBoxDocument extends JFrame implements WindowListener, HandleDel
     private boolean invalidateFunctionRepository = false;
     private double frame = 1;
     private Map<String, double[]> networkPanZoomValues = new HashMap<String, double[]>();
-    private SwingWorker<List<?>, Node> currentRender = null;
+    // Polls the active render's elapsed time and shows the progress spinner only for renders that
+    // run long enough to be perceived, so fast interactive renders never flicker it.
+    private javax.swing.Timer progressTimer;
+    private boolean progressShown = false;
+    private static final long SLOW_RENDER_NANOS = 150_000_000L; // 150 ms
     private Iterable<?> lastRenderResult = null;
     // Caches node results across renders so that unchanged parts of the network are not recomputed
     // on every frame change or parameter tweak. Read and reassigned only on the EDT; a running render
@@ -181,6 +193,8 @@ public class NodeBoxDocument extends JFrame implements WindowListener, HandleDel
             devicesDialog = new DevicesDialog(this);
 //            addressBar.setMessage("OSC Port " + getOSCPort());
         }
+
+        startRenderLoop();
     }
 
     public static NodeBoxDocument getCurrentDocument() {
@@ -1192,21 +1206,33 @@ public class NodeBoxDocument extends JFrame implements WindowListener, HandleDel
     //// Rendering ////
 
     /**
-     * Request a renderNetwork operation.
+     * Request a render of the current network.
      * <p/>
-     * This method does a number of checks to see if the renderNetwork goes through.
-     * <p/>
-     * The renderer could already be running.
-     * <p/>
-     * If all checks pass, a renderNetwork request is made.
+     * Snapshots everything the render needs from the (EDT-owned) document state, publishes it to the
+     * background render thread as the latest pending request, and wakes the thread. Rapid successive
+     * calls (e.g. a parameter drag) conflate: the thread always renders the newest snapshot, so no
+     * intermediate frame can block a later one and the final value is always rendered.
      */
     public void requestRender() {
-        // If we're already rendering, request the next renderNetwork.
-        if (isRendering.compareAndSet(false, true)) {
-            // If we're not rendering, start rendering.
-            render();
-        } else {
-            shouldRender.set(true);
+        checkState(SwingUtilities.isEventDispatchThread());
+        PerfMonitor.recordRenderRequest();
+        final NodeLibrary library = getNodeLibrary();
+        final FunctionRepository functions = getFunctionRepository();
+        final String renderNetwork = getRenderedNode();
+        final RenderCache cache = renderCache;
+
+        Map<String, Object> dataMap = new HashMap<String, Object>();
+        dataMap.put("frame", frame);
+        dataMap.put("mouse.position", viewerPane.getViewer().getLastMousePosition());
+        for (DeviceHandler handler : deviceHandlers)
+            handler.addData(dataMap);
+        final ImmutableMap<String, ?> data = ImmutableMap.copyOf(dataMap);
+
+        synchronized (renderLock) {
+            if (pendingRequest != null)
+                PerfMonitor.recordRenderCoalesced();
+            pendingRequest = new RenderRequest(++renderGeneration, library, functions, data, renderNetwork, cache);
+            renderLock.notifyAll();
         }
     }
 
@@ -1238,73 +1264,149 @@ public class NodeBoxDocument extends JFrame implements WindowListener, HandleDel
 
     /**
      * Ask the document to stop the active rendering.
+     * <p/>
+     * Drops any queued render and marks everything requested so far as canceled, so a render that is
+     * already running has its (now unwanted) result discarded when it finishes. The previously shown
+     * output is kept on screen rather than blanked.
      */
-    public synchronized void stopRendering() {
-        if (currentRender != null) {
-            currentRender.cancel(true);
+    public void stopRendering() {
+        Thread t;
+        synchronized (renderLock) {
+            pendingRequest = null;
+            canceledGeneration = renderGeneration;
+            t = renderThread;
+        }
+        if (t != null) t.interrupt();
+    }
+
+    /**
+     * Start the long-lived render thread and the progress-spinner poll timer. Called once from the
+     * constructor.
+     */
+    private void startRenderLoop() {
+        progressTimer = new javax.swing.Timer(100, new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                long start = activeRenderStartNanos;
+                boolean slow = start != 0 && (System.nanoTime() - start) > SLOW_RENDER_NANOS;
+                if (slow != progressShown) {
+                    progressShown = slow;
+                    progressPanel.setInProgress(slow);
+                }
+            }
+        });
+        progressTimer.start();
+
+        renderThread = new Thread("nodebox-render-" + System.identityHashCode(this)) {
+            @Override
+            public void run() {
+                renderLoop();
+            }
+        };
+        renderThread.setDaemon(true);
+        renderThread.start();
+    }
+
+    /**
+     * The body of the render thread: wait for a pending request, render the newest one off the EDT,
+     * and deliver the result back to the EDT. Never touches Swing state directly.
+     */
+    private void renderLoop() {
+        while (true) {
+            RenderRequest request;
+            synchronized (renderLock) {
+                while (renderLoopRunning && pendingRequest == null) {
+                    try {
+                        renderLock.wait();
+                    } catch (InterruptedException e) {
+                        // A stopRendering() interrupt; the loop conditions below are re-checked.
+                    }
+                }
+                if (!renderLoopRunning) return;
+                request = pendingRequest;
+                pendingRequest = null;
+            }
+
+            Thread.interrupted(); // clear any leftover interrupt before computing
+            activeRenderStartNanos = System.nanoTime();
+            List<?> results;
+            Throwable error = null;
+            try {
+                NodeContext context = new NodeContext(request.library, request.functions, request.data,
+                        ImmutableMap.<String, Object>of(), request.cache);
+                results = context.renderNode(request.network);
+                context.renderAlwaysRenderedNodes(request.network);
+            } catch (Throwable t) {
+                results = ImmutableList.of();
+                error = t;
+            }
+            final long renderNanos = System.nanoTime() - activeRenderStartNanos;
+            activeRenderStartNanos = 0;
+
+            final List<?> deliveredResults = results;
+            final Throwable deliveredError = error;
+            final int generation = request.generation;
+            SwingUtilities.invokeLater(new Runnable() {
+                @Override
+                public void run() {
+                    applyRenderResult(generation, deliveredResults, deliveredError, renderNanos);
+                }
+            });
         }
     }
 
-    private void render() {
-        checkState(SwingUtilities.isEventDispatchThread());
-        checkState(currentRender == null);
-        progressPanel.setInProgress(true);
-        final NodeLibrary renderLibrary = getNodeLibrary();
-        final String renderNetwork = getRenderedNode();
+    /** Apply a completed render's result on the EDT, unless it was canceled. */
+    private void applyRenderResult(int generation, List<?> results, Throwable error, long renderNanos) {
+        PerfMonitor.recordRender(renderNanos);
+        if (generation <= canceledGeneration) {
+            // Canceled via the stop button after this render started; keep the previous output.
+            return;
+        }
+        if (error == null) {
+            networkPane.clearError();
+        } else {
+            networkPane.setError(error);
+        }
+        lastRenderResult = results;
+        networkView.checkErrorAndRepaint();
+        if (fullScreenFrame != null)
+            fullScreenFrame.setOutputValues(results);
+        else
+            viewerPane.setOutputValues(results);
+    }
 
-        Map<String, Object> dataMap = new HashMap<String, Object>();
-        dataMap.put("frame", frame);
-        dataMap.put("mouse.position", viewerPane.getViewer().getLastMousePosition());
-        for (DeviceHandler handler : deviceHandlers)
-            handler.addData(dataMap);
-        final ImmutableMap<String, ?> data = ImmutableMap.copyOf(dataMap);
+    /** An immutable snapshot of everything a single render needs, captured on the EDT. */
+    private static final class RenderRequest {
+        final int generation;
+        final NodeLibrary library;
+        final FunctionRepository functions;
+        final ImmutableMap<String, ?> data;
+        final String network;
+        final RenderCache cache;
 
-        final NodeContext context = new NodeContext(renderLibrary, getFunctionRepository(), data, ImmutableMap.<String, Object>of(), renderCache);
-        currentRender = new SwingWorker<List<?>, Node>() {
-            @Override
-            protected List<?> doInBackground() throws Exception {
-                List<?> results = context.renderNode(renderNetwork);
-                context.renderAlwaysRenderedNodes(renderNetwork);
-                return results;
-            }
+        RenderRequest(int generation, NodeLibrary library, FunctionRepository functions,
+                      ImmutableMap<String, ?> data, String network, RenderCache cache) {
+            this.generation = generation;
+            this.library = library;
+            this.functions = functions;
+            this.data = data;
+            this.network = network;
+            this.cache = cache;
+        }
+    }
 
-            @Override
-            protected void done() {
-                networkPane.clearError();
-                isRendering.set(false);
-                currentRender = null;
-                List<?> results;
-                try {
-                    results = get();
-                } catch (CancellationException e) {
-                    results = ImmutableList.of();
-                } catch (InterruptedException e) {
-                    results = ImmutableList.of();
-                } catch (ExecutionException e) {
-                    networkPane.setError(e.getCause());
-                    results = ImmutableList.of();
-                }
-
-                lastRenderResult = results;
-
-                networkView.checkErrorAndRepaint();
-                progressPanel.setInProgress(false);
-                if (fullScreenFrame != null)
-                    fullScreenFrame.setOutputValues(results);
-                else
-                    viewerPane.setOutputValues(results);
-
-                if (shouldRender.getAndSet(false)) {
-                    SwingUtilities.invokeLater(new Runnable() {
-                        @Override
-                        public void run() {
-                            requestRender();
-                        }
-                    });
-                }
-            }
-        };
-        currentRender.execute();
+    @Override
+    public void dispose() {
+        Thread t;
+        synchronized (renderLock) {
+            renderLoopRunning = false;
+            pendingRequest = null;
+            t = renderThread;
+            renderLock.notifyAll();
+        }
+        if (t != null) t.interrupt();
+        if (progressTimer != null) progressTimer.stop();
+        super.dispose();
     }
 
     /**

--- a/src/main/java/nodebox/client/Viewer.java
+++ b/src/main/java/nodebox/client/Viewer.java
@@ -7,6 +7,7 @@ import nodebox.graphics.IGeometry;
 import nodebox.handle.Handle;
 import nodebox.ui.Theme;
 import nodebox.ui.Zoom;
+import nodebox.util.PerfMonitor;
 
 import javax.swing.*;
 import java.awt.*;
@@ -249,6 +250,15 @@ public class Viewer extends ZoomableView implements OutputView, Zoom, MouseListe
 
     @Override
     public void paintComponent(Graphics g) {
+        long paintStart = PerfMonitor.isEnabled() ? System.nanoTime() : 0;
+        try {
+            paintViewer(g);
+        } finally {
+            if (paintStart != 0) PerfMonitor.recordPaint(System.nanoTime() - paintStart);
+        }
+    }
+
+    private void paintViewer(Graphics g) {
         if (!viewPositioned) {
             setViewPosition(getWidth() / 2.0, getHeight() / 2.0);
             viewPositioned = true;

--- a/src/main/java/nodebox/util/PerfMonitor.java
+++ b/src/main/java/nodebox/util/PerfMonitor.java
@@ -1,0 +1,146 @@
+package nodebox.util;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A lightweight, opt-in profiling facility for the interactive render loop.
+ * <p/>
+ * It is disabled by default; when disabled every record* method is a single volatile
+ * read and immediate return, so it adds no measurable overhead to production runs.
+ * Enable it from a test harness (or with {@code -Dnodebox.perf=true}) to characterise
+ * the drag/render/repaint pipeline.
+ * <p/>
+ * All record* methods that increment counters are invoked from the Event Dispatch
+ * Thread (render bookkeeping and painting), so plain fields are sufficient; the
+ * sample lists are synchronized because the reporting thread reads them concurrently.
+ */
+public final class PerfMonitor {
+
+    private static volatile boolean enabled = "true".equalsIgnoreCase(System.getProperty("nodebox.perf"));
+
+    private static final List<Long> renderDurations = Collections.synchronizedList(new ArrayList<Long>());
+    private static final List<Long> paintDurations = Collections.synchronizedList(new ArrayList<Long>());
+
+    private static volatile long renderRequests = 0;
+    private static volatile long rendersCompleted = 0;
+    private static volatile long rendersCoalesced = 0;
+
+    private PerfMonitor() {
+    }
+
+    public static boolean isEnabled() {
+        return enabled;
+    }
+
+    public static void setEnabled(boolean value) {
+        enabled = value;
+    }
+
+    public static synchronized void reset() {
+        renderDurations.clear();
+        paintDurations.clear();
+        renderRequests = 0;
+        rendersCompleted = 0;
+        rendersCoalesced = 0;
+    }
+
+    /** A render was requested (one per value change / drag tick that asks for a redraw). */
+    public static void recordRenderRequest() {
+        if (enabled) renderRequests++;
+    }
+
+    /** A requested render was dropped because another render was already in flight. */
+    public static void recordRenderCoalesced() {
+        if (enabled) rendersCoalesced++;
+    }
+
+    /** A render finished computing; {@code nanos} is the background compute time. */
+    public static void recordRender(long nanos) {
+        if (enabled) {
+            rendersCompleted++;
+            renderDurations.add(nanos);
+        }
+    }
+
+    /** A viewer repaint finished; {@code nanos} is the time spent in paintComponent. */
+    public static void recordPaint(long nanos) {
+        if (enabled) paintDurations.add(nanos);
+    }
+
+    public static synchronized Snapshot snapshot() {
+        return new Snapshot(renderRequests, rendersCompleted, rendersCoalesced,
+                new ArrayList<Long>(renderDurations), new ArrayList<Long>(paintDurations));
+    }
+
+    /** An immutable view of the collected metrics with a few derived statistics. */
+    public static final class Snapshot {
+        public final long renderRequests;
+        public final long rendersCompleted;
+        public final long rendersCoalesced;
+        public final List<Long> renderDurations;
+        public final List<Long> paintDurations;
+
+        Snapshot(long renderRequests, long rendersCompleted, long rendersCoalesced,
+                 List<Long> renderDurations, List<Long> paintDurations) {
+            this.renderRequests = renderRequests;
+            this.rendersCompleted = rendersCompleted;
+            this.rendersCoalesced = rendersCoalesced;
+            this.renderDurations = renderDurations;
+            this.paintDurations = paintDurations;
+        }
+
+        private static double ms(double nanos) {
+            return nanos / 1_000_000.0;
+        }
+
+        public double meanRenderMs() {
+            return ms(mean(renderDurations));
+        }
+
+        public double p95RenderMs() {
+            return ms(percentile(renderDurations, 95));
+        }
+
+        public double meanPaintMs() {
+            return ms(mean(paintDurations));
+        }
+
+        public double p95PaintMs() {
+            return ms(percentile(paintDurations, 95));
+        }
+
+        public int paintCount() {
+            return paintDurations.size();
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append(String.format("render requests : %d%n", renderRequests));
+            sb.append(String.format("renders done    : %d%n", rendersCompleted));
+            sb.append(String.format("renders coalesced: %d%n", rendersCoalesced));
+            sb.append(String.format("render compute  : mean %.2f ms, p95 %.2f ms%n", meanRenderMs(), p95RenderMs()));
+            sb.append(String.format("paints          : %d (mean %.2f ms, p95 %.2f ms)%n", paintCount(), meanPaintMs(), p95PaintMs()));
+            return sb.toString();
+        }
+
+        private static double mean(List<Long> values) {
+            if (values.isEmpty()) return 0;
+            long total = 0;
+            for (long v : values) total += v;
+            return (double) total / values.size();
+        }
+
+        private static double percentile(List<Long> values, double pct) {
+            if (values.isEmpty()) return 0;
+            List<Long> sorted = new ArrayList<Long>(values);
+            Collections.sort(sorted);
+            int index = (int) Math.ceil(pct / 100.0 * sorted.size()) - 1;
+            if (index < 0) index = 0;
+            if (index >= sorted.size()) index = sorted.size() - 1;
+            return sorted.get(index);
+        }
+    }
+}

--- a/src/test/java/nodebox/e2e/DragPerfE2ETest.java
+++ b/src/test/java/nodebox/e2e/DragPerfE2ETest.java
@@ -1,0 +1,340 @@
+package nodebox.e2e;
+
+import nodebox.client.Application;
+import nodebox.client.NodeBoxDocument;
+import nodebox.client.PortView;
+import nodebox.client.port.PortControl;
+import nodebox.util.PerfMonitor;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.swing.SwingUtilities;
+import java.awt.Component;
+import java.awt.GraphicsEnvironment;
+import java.awt.event.MouseEvent;
+import java.io.File;
+import java.io.PrintWriter;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Measures the end-to-end responsiveness of dragging a numeric parameter, the way it actually feels.
+ * <p/>
+ * It synthesizes a real drag by dispatching AWT {@link MouseEvent}s (PRESSED, a stream of DRAGGED,
+ * RELEASED) to the actual {@link nodebox.ui.DraggableNumber}, driving the identical
+ * mouseDragged -> fireStateChanged -> setValue -> requestRender path a user's mouse would. This is
+ * deterministic and independent of screen geometry/focus, unlike a physical {@code Robot} screen
+ * drag. Meanwhile a background probe samples Event Dispatch Thread scheduling latency (the proxy for
+ * perceived jank) and {@link PerfMonitor} captures render/paint throughput.
+ * <p/>
+ * Gated behind {@code NODEBOX_E2E=1} like the other e2e tests. It is a measurement harness, not a
+ * hard gate: it asserts only that the drag drove the pipeline, and writes a full report to the
+ * artifacts directory (and stdout) for before/after comparison.
+ */
+public class DragPerfE2ETest {
+
+    private static final String E2E_ENV = "NODEBOX_E2E";
+    private static final long DEFAULT_TIMEOUT_MS = 20000;
+
+    // The drag: how many mouse-move events, and the delay between them (~100 Hz, like a real mouse).
+    private static final int DRAG_STEPS = 200;
+    private static final int DRAG_STEP_DELAY_MS = 8;
+    // EDT latency probe sampling interval.
+    private static final int PROBE_INTERVAL_MS = 4;
+
+    @BeforeClass
+    public static void requireE2E() throws Exception {
+        Assume.assumeTrue("E2E tests require NODEBOX_E2E=1", "1".equals(System.getenv(E2E_ENV)));
+        Assume.assumeFalse("E2E tests require a graphics environment", GraphicsEnvironment.isHeadless());
+        if (Application.getInstance() == null) {
+            Application.main(new String[]{});
+            waitFor("Application instance", DEFAULT_TIMEOUT_MS, new Supplier<Boolean>() {
+                public Boolean get() {
+                    return Application.getInstance() != null;
+                }
+            });
+        }
+        waitFor("Initial document", DEFAULT_TIMEOUT_MS, new Supplier<Boolean>() {
+            public Boolean get() {
+                Application app = Application.getInstance();
+                return app != null && app.getDocumentCount() > 0 && app.getCurrentDocument() != null;
+            }
+        });
+    }
+
+    @Test
+    public void dragFloatParameter() throws Exception {
+        // Defaults to a reasonably heavy example (dragging copy1.rotate rotates a full spirograph,
+        // forcing an ancestor re-render plus a full antialiased redraw every frame). Override with
+        // -Dperf.example=... -Dperf.node=... -Dperf.port=... to profile other scenarios.
+        final File example = new File(System.getProperty("perf.example",
+                "examples/01 Basics/01 Shape/11 Spirograph/11 Spirograph.ndbx"));
+        final String nodeName = System.getProperty("perf.node", "copy1");
+        final String portName = System.getProperty("perf.port", "rotate");
+
+        report(measureDrag(example, nodeName, portName), example, nodeName, portName);
+    }
+
+    private MeasurementResult measureDrag(final File example, final String nodeName, final String portName) throws Exception {
+        final NodeBoxDocument doc = openExample(example);
+        assertNotNull("Could not open example " + example, doc);
+
+        // Activate the node so its parameter controls are built, then grab its DraggableNumber.
+        SwingUtilities.invokeAndWait(new Runnable() {
+            public void run() {
+                doc.toFront();
+                doc.requestFocus();
+                doc.setActiveNode(nodeName);
+            }
+        });
+        waitFor("Parameter control for " + portName, DEFAULT_TIMEOUT_MS, new Supplier<Boolean>() {
+            public Boolean get() {
+                return draggableComponent(doc, portName) != null;
+            }
+        });
+
+        final Component draggable = draggableComponent(doc, portName);
+        assertNotNull("No DraggableNumber for " + portName, draggable);
+        System.out.println("[perf] dragging " + nodeName + "." + portName + " via " + draggable.getClass().getSimpleName());
+
+        final int cx = draggable.getWidth() / 2;   // centre, clear of the +/- buttons at the edges
+        final int cy = draggable.getHeight() / 2;
+
+        // Warm up: a short drag + settle so the initial cold full render and JIT compilation do not
+        // pollute the steady-state numbers we care about for "feelable" dragging.
+        dispatchMouse(draggable, MouseEvent.MOUSE_PRESSED, cx, cy);
+        for (int i = 0; i < 30; i++) {
+            dispatchMouse(draggable, MouseEvent.MOUSE_DRAGGED, cx + triangle(i, 10), cy);
+            Thread.sleep(DRAG_STEP_DELAY_MS);
+        }
+        dispatchMouse(draggable, MouseEvent.MOUSE_RELEASED, cx, cy);
+        Thread.sleep(1500); // let all queued renders/paints drain
+
+        final List<Long> edtLatencies = Collections.synchronizedList(new ArrayList<Long>());
+        final AtomicBoolean probing = new AtomicBoolean(true);
+        Thread probe = startEdtLatencyProbe(edtLatencies, probing);
+
+        PerfMonitor.setEnabled(true);
+        PerfMonitor.reset();
+
+        // Synthesize a real drag: PRESSED, a stream of DRAGGED at ~100 Hz, then RELEASED, all
+        // dispatched to the actual DraggableNumber on the EDT. This drives the identical
+        // mouseDragged -> fireStateChanged -> setValue -> requestRender path a user's mouse would,
+        // including the same EDT contention, but is deterministic and independent of screen geometry.
+        dispatchMouse(draggable, MouseEvent.MOUSE_PRESSED, cx, cy);
+
+        long dragStart = System.nanoTime();
+        for (int i = 0; i < DRAG_STEPS; i++) {
+            final int x = cx + triangle(i, 40); // oscillate +/- a few px each step
+            dispatchMouse(draggable, MouseEvent.MOUSE_DRAGGED, x, cy);
+            Thread.sleep(DRAG_STEP_DELAY_MS);
+        }
+        dispatchMouse(draggable, MouseEvent.MOUSE_RELEASED, cx, cy);
+        double dragSeconds = (System.nanoTime() - dragStart) / 1_000_000_000.0;
+
+        // Let the final coalesced render settle so it is counted.
+        Thread.sleep(700);
+
+        probing.set(false);
+        probe.join(1000);
+
+        PerfMonitor.Snapshot snapshot = PerfMonitor.snapshot();
+        PerfMonitor.setEnabled(false);
+
+        assertTrue("Drag should have requested renders", snapshot.renderRequests > 0);
+        assertTrue("Drag should have produced paints", snapshot.paintCount() > 0);
+
+        return new MeasurementResult(snapshot, new ArrayList<Long>(edtLatencies), dragSeconds);
+    }
+
+    private Thread startEdtLatencyProbe(final List<Long> samples, final AtomicBoolean running) {
+        Thread t = new Thread("edt-latency-probe") {
+            public void run() {
+                while (running.get()) {
+                    final long t0 = System.nanoTime();
+                    SwingUtilities.invokeLater(new Runnable() {
+                        public void run() {
+                            samples.add(System.nanoTime() - t0);
+                        }
+                    });
+                    try {
+                        Thread.sleep(PROBE_INTERVAL_MS);
+                    } catch (InterruptedException e) {
+                        return;
+                    }
+                }
+            }
+        };
+        t.setDaemon(true);
+        t.start();
+        return t;
+    }
+
+    private void report(MeasurementResult result, File example, String nodeName, String portName) throws Exception {
+        PerfMonitor.Snapshot s = result.snapshot;
+        List<Long> edt = result.edtLatencies;
+
+        double effectiveFps = result.dragSeconds > 0 ? s.paintCount() / result.dragSeconds : 0;
+        double coalesceRatio = s.renderRequests > 0 ? (double) s.rendersCoalesced / s.renderRequests : 0;
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("=== NodeBox drag responsiveness ===\n");
+        sb.append(String.format("example         : %s%n", example.getPath()));
+        sb.append(String.format("node.port       : %s.%s%n", nodeName, portName));
+        sb.append(String.format("drag duration   : %.2f s (%d mouse moves)%n", result.dragSeconds, DRAG_STEPS));
+        sb.append("\n--- pipeline ---\n");
+        sb.append(s.toString());
+        sb.append(String.format("coalesce ratio  : %.0f%% of requests dropped while busy%n", coalesceRatio * 100));
+        sb.append(String.format("effective FPS   : %.1f (viewer paints / drag second)%n", effectiveFps));
+        sb.append("\n--- EDT scheduling latency (perceived jank) ---\n");
+        sb.append(String.format("samples         : %d%n", edt.size()));
+        sb.append(String.format("mean            : %.2f ms%n", ms(mean(edt))));
+        sb.append(String.format("p50             : %.2f ms%n", ms(percentile(edt, 50))));
+        sb.append(String.format("p95             : %.2f ms%n", ms(percentile(edt, 95))));
+        sb.append(String.format("p99             : %.2f ms%n", ms(percentile(edt, 99))));
+        sb.append(String.format("max             : %.2f ms%n", ms(max(edt))));
+        sb.append(String.format("frames > 16.7ms : %.0f%% (each is a likely dropped 60fps frame)%n",
+                fractionAbove(edt, 16_700_000L) * 100));
+
+        String text = sb.toString();
+        System.out.println(text);
+
+        File out = new File(artifactsDir(), "drag-perf.txt");
+        try (PrintWriter w = new PrintWriter(out)) {
+            w.print(text);
+        }
+        System.out.println("Wrote " + out.getAbsolutePath());
+    }
+
+    //// Control discovery (via the document's private PortView -> FloatControl's DraggableNumber) ////
+
+    private static PortControl portControl(NodeBoxDocument doc, String portName) {
+        try {
+            Field f = NodeBoxDocument.class.getDeclaredField("portView");
+            f.setAccessible(true);
+            PortView pv = (PortView) f.get(doc);
+            return pv == null ? null : pv.getControlForPort(portName);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /** The DraggableNumber inside a numeric control, located reflectively, or null. */
+    private static Component draggableComponent(NodeBoxDocument doc, String portName) {
+        PortControl ctrl = portControl(doc, portName);
+        if (ctrl == null) return null;
+        try {
+            Field f = ctrl.getClass().getDeclaredField("draggable");
+            f.setAccessible(true);
+            Object d = f.get(ctrl);
+            return (d instanceof Component && ((Component) d).isShowing()) ? (Component) d : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static void dispatchMouse(final Component target, final int id, final int x, final int y) throws Exception {
+        SwingUtilities.invokeLater(new Runnable() {
+            public void run() {
+                int mods = MouseEvent.BUTTON1_DOWN_MASK;
+                int button = MouseEvent.BUTTON1;
+                MouseEvent e = new MouseEvent(target, id, System.currentTimeMillis(), mods, x, y, 1, false, button);
+                target.dispatchEvent(e);
+            }
+        });
+    }
+
+    //// Bootstrapping helpers ////
+
+    private static NodeBoxDocument openExample(final File example) throws Exception {
+        SwingUtilities.invokeAndWait(new Runnable() {
+            public void run() {
+                Application.getInstance().openExample(example);
+            }
+        });
+        waitFor("Example open", DEFAULT_TIMEOUT_MS, new Supplier<Boolean>() {
+            public Boolean get() {
+                NodeBoxDocument doc = Application.getInstance().getCurrentDocument();
+                return doc != null && doc.getActiveNetwork() != null;
+            }
+        });
+        return Application.getInstance().getCurrentDocument();
+    }
+
+    private static void waitFor(String label, long timeoutMs, Supplier<Boolean> condition) throws Exception {
+        long start = System.currentTimeMillis();
+        while ((System.currentTimeMillis() - start) < timeoutMs) {
+            if (condition.get()) return;
+            Thread.sleep(100);
+        }
+        throw new AssertionError("Timed out waiting for: " + label);
+    }
+
+    private static File artifactsDir() {
+        File dir = new File("build/e2e-artifacts");
+        if (!dir.exists()) dir.mkdirs();
+        return dir;
+    }
+
+    //// Small numeric helpers ////
+
+    /** Triangle wave: rises 0..period then falls back, repeating. */
+    private static int triangle(int i, int period) {
+        int phase = i % (2 * period);
+        return phase <= period ? phase : 2 * period - phase;
+    }
+
+    private static double ms(double nanos) {
+        return nanos / 1_000_000.0;
+    }
+
+    private static double mean(List<Long> values) {
+        if (values.isEmpty()) return 0;
+        long total = 0;
+        for (long v : values) total += v;
+        return (double) total / values.size();
+    }
+
+    private static double max(List<Long> values) {
+        long m = 0;
+        for (long v : values) m = Math.max(m, v);
+        return m;
+    }
+
+    private static double percentile(List<Long> values, double pct) {
+        if (values.isEmpty()) return 0;
+        List<Long> sorted = new ArrayList<Long>(values);
+        Collections.sort(sorted);
+        int index = (int) Math.ceil(pct / 100.0 * sorted.size()) - 1;
+        if (index < 0) index = 0;
+        if (index >= sorted.size()) index = sorted.size() - 1;
+        return sorted.get(index);
+    }
+
+    private static double fractionAbove(List<Long> values, long thresholdNanos) {
+        if (values.isEmpty()) return 0;
+        int count = 0;
+        for (long v : values) if (v > thresholdNanos) count++;
+        return (double) count / values.size();
+    }
+
+    private static final class MeasurementResult {
+        final PerfMonitor.Snapshot snapshot;
+        final List<Long> edtLatencies;
+        final double dragSeconds;
+
+        MeasurementResult(PerfMonitor.Snapshot snapshot, List<Long> edtLatencies, double dragSeconds) {
+            this.snapshot = snapshot;
+            this.edtLatencies = edtLatencies;
+            this.dragSeconds = dragSeconds;
+        }
+    }
+}


### PR DESCRIPTION
## What

Dragging a parameter was **latency-bound, not work-bound**. Render compute is already sub-millisecond thanks to the render cache, but a fresh `SwingWorker` per value change cost three scheduling hops per frame (pool pickup, `done()` marshaling, and an `invokeLater` re-trigger) plus an allocation — capping a light document at ~26fps even with a completely idle EDT.

This replaces the `SwingWorker`-per-render model with a **single long-lived render thread + a latest-wins mailbox**:

- `requestRender()` snapshots an immutable `RenderRequest` on the EDT and wakes the thread.
- The thread renders the newest snapshot off-EDT and delivers the result via one `invokeLater`.
- Rapid drags conflate automatically; the final value is always rendered.
- Every render stays off the EDT, so an expensive render can never freeze the UI — **no render-cost prediction needed**.
- `stopRendering()` discards via a generation marker and keeps the previously shown frame (instead of blanking); `dispose()` cleanly shuts the thread + timer down.
- The progress spinner is now shown only for renders slower than 150ms, so fast interactive frames never flicker it.

## Results

Warm steady-state, measured with the new AWT-drag harness:

| Scenario | Before | After |
|---|---|---|
| Light doc (Primitives, polygon radius) | 26 fps | **101 fps** |
| Heavy doc (Spirograph, copy rotate) | 17 fps | **43 fps** (now paint-bound) |

EDT scheduling-latency (the perceived-jank proxy) on the light doc dropped from a 7ms max to 2.6ms.

Remaining ceiling: heavy documents are now **paint-bound** on `Viewer.paintComponent` (~23ms of antialiased Java2D drawing on the EDT per frame). Pushing past that is a separate, graphics-level effort (dirty-region painting, shape caching, or reduced AA during drag).

## Measurement infrastructure

- `nodebox.util.PerfMonitor` — opt-in (`-Dnodebox.perf=true`), ~zero overhead when disabled; counts render requests/coalescing/duration and paint duration.
- `DragPerfE2ETest` + `ant test-perf` — synthesizes real AWT `MouseEvent`s on the actual `DraggableNumber` (deterministic, unlike a physical `Robot` screen drag), warms up to exclude the cold render, and runs a background EDT-latency probe. Parameterizable via `-Dperf.example/node/port`; writes `build/e2e-artifacts/drag-perf.txt`. It is a measurement harness, not a hard CI gate (wall-clock numbers flake).

## Backward compatibility

Still a background render, still cancelable, errors still routed to `networkPane.setError`. All existing behavior preserved.

## Tests

- `ant test` — 310 pass
- `NODEBOX_E2E=1 ant test-e2e` — 13 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)